### PR TITLE
#2 / feat(favorites) : 즐겨찾기 탭 UI 정리

### DIFF
--- a/src/app/(app)/favorites/page.tsx
+++ b/src/app/(app)/favorites/page.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ClipList } from "../../../components/clips/ClipList";
-import { DeleteAllButton } from "../../../components/clips/DeleteAllButton";
 import { EmptyState } from "../../../components/clips/EmptyState";
 import { FilterBar, FilterType } from "../../../components/clips/FilterBar";
 import { Clip } from "../../../types/clip";
@@ -129,7 +128,11 @@ export default function FavoritesPage() {
 
   return (
     <div className="flex h-full flex-col bg-white">
-      <FilterBar activeFilter={activeFilter} onFilterChange={setActiveFilter} />
+      <FilterBar
+        activeFilter={activeFilter}
+        onFilterChange={setActiveFilter}
+        showStatus={false}
+      />
       {filteredClips.length ? (
         <ClipList
           clips={filteredClips}
@@ -139,7 +142,6 @@ export default function FavoritesPage() {
       ) : (
         <EmptyState />
       )}
-      <DeleteAllButton disabled />
 
       {copyToast ? (
         <div

--- a/src/components/clips/FilterBar.tsx
+++ b/src/components/clips/FilterBar.tsx
@@ -22,6 +22,7 @@ interface FilterBarProps {
   searchQuery?: string;
   onSearchChange?: (value: string) => void;
   isActive?: boolean;
+  showStatus?: boolean;
 }
 
 export function FilterBar({
@@ -30,6 +31,7 @@ export function FilterBar({
   searchQuery = "",
   onSearchChange,
   isActive = false,
+  showStatus = true,
 }: FilterBarProps) {
   const filters: FilterOption[] = [
     { id: "all", label: "All" },
@@ -70,15 +72,17 @@ export function FilterBar({
         ))}
       </div>
       <div className="flex items-center gap-3">
-        <div className="flex items-center gap-2 text-xs text-gray-500">
-          <span
-            className={`h-2 w-2 rounded-full ${
-              isActive ? "bg-green-500" : "bg-red-500"
-            }`}
-            aria-hidden
-          />
-          <span>{isActive ? "Ready to paste" : "Not active"}</span>
-        </div>
+        {showStatus ? (
+          <div className="flex items-center gap-2 text-xs text-gray-500">
+            <span
+              className={`h-2 w-2 rounded-full ${
+                isActive ? "bg-green-500" : "bg-red-500"
+              }`}
+              aria-hidden
+            />
+            <span>{isActive ? "Ready to paste" : "Not active"}</span>
+          </div>
+        ) : null}
         <div className="relative">
           <input
             type="text"


### PR DESCRIPTION
## 📌 PR 요약

- 즐겨찾기 탭에서 상태 인디케이터와 삭제 버튼을 제거했습니다.

## 🔍 변경 내용 상세

### 변경 사항

- 즐겨찾기 탭에서 활성 상태 UI 숨김
- 즐겨찾기 탭 하단 Delete All 버튼 제거

### 변경 이유

- 이슈 #2 요구사항(조회/복사 중심 UI)에 맞추기 위해서입니다.

---

## 📸 UI 변경 (해당 시)

### Before

_(스크린샷 또는 영상 첨부)_

<img width="1658" height="916" alt="image" src="https://github.com/user-attachments/assets/0a26485f-27de-4c9f-9f5a-e55a128b2e8a" />


_(스크린샷 또는 영상 첨부)_

---

## 🗂 관련 이슈

- Closes #2

---

## 📚 기타 참고사항

- 즐겨찾기 탭은 조회/복사 위주로 간결하게 유지됩니다.
