### PR TITLE
#24 / feat(settings) : 다국어 기능 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,10 @@
+import createNextIntlPlugin from "next-intl/plugin";
 import type { NextConfig } from "next";
+
+const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
   /* config options here */
 };
 
-export default nextConfig;
+export default withNextIntl(nextConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.1",
+        "next-intl": "^4.13.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
@@ -71,7 +72,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -456,6 +456,36 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.10.tgz",
+      "integrity": "sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.9"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/intl-localematcher": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.8.9.tgz",
+      "integrity": "sha512-GmB0F/gYh4Hdl4rLWjgDsgT+x4pB54fkJeRh8kAZ4XFzKeCK8dGs+SBJWXO42QZtOUni+IDWKNuCw6wiL4lTvw==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.5"
       }
     },
     "node_modules/@humanfs/core": {
@@ -1231,12 +1261,523 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@schummar/icu-type-parser": {
+      "version": "1.21.5",
+      "resolved": "https://registry.npmjs.org/@schummar/icu-type-parser/-/icu-type-parser-1.21.5.tgz",
+      "integrity": "sha512-bXHSaW5jRTmke9Vd0h5P7BtWZG9Znqb8gSDxZnxaGSJnGwPLDPfS+3g0BKzeWqzgZPsIVZkM7m2tbo18cm5HBw==",
+      "license": "MIT"
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.40.tgz",
+      "integrity": "sha512-PaYyclfmQ++77D8ityYvmmVzHv9aG8ROwt2GfG6/ccloy4Hgf80qtOnzb9VYvPsUT7Ty1uhuDRhv3XYpf62qhQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.40.tgz",
+      "integrity": "sha512-HbbPzvfLBUXjIB1Ezks+//lNUjmLjfyd63XSwprJgrZaXYdm70kohXPJUWdqKZozolFxbPaO+xtBaiUp6BoueA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.40.tgz",
+      "integrity": "sha512-SlRZsCjOCPR2LvFs0Ri/Xrx/5o5TCt8vl4gW6mX1hEZOG0a625RxzRHpHdAQNGykmAN/7IeaFAJG+QnNmxlHcA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.40.tgz",
+      "integrity": "sha512-Q8byxJt2fh8CR3EUX6snBpy47AoBVm+In/+Z3rjDHMjC38ZvR9/gtUUNCT0tfrn4EdVsO8/QPi59nxrxvqxvBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.40.tgz",
+      "integrity": "sha512-4z0MgHU+7M0pZDqBN1El7mFXDI1SBwinfcUkAyA4v8QrhOIUOZltySt2aStQLZGrdXVXM4Y4ylfiTC04ED+MoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-ppc64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-ppc64-gnu/-/core-linux-ppc64-gnu-1.15.40.tgz",
+      "integrity": "sha512-fLI4iUgeSZu0eRWUXwe6YzPFx9gHbFiPkl8Rp3mJfP8OpNR3nTQCGPvHdDh9xniW7mVvgMY4ni7A4VzqI1KrpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-s390x-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-s390x-gnu/-/core-linux-s390x-gnu-1.15.40.tgz",
+      "integrity": "sha512-YqeKMAb7d4nQSGMJQ454IlaCENpzcDqhvBE9+CPfdnYpnUXxd+BSrB6Xk0YjW8UyoEhUj4p6quATCxbsp6J3jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.40.tgz",
+      "integrity": "sha512-7HOuS1iGcme/j/TuL1TfmmLGiMQrjv/GmjyZeydl00FKPtpGXEldwqfI56xgd1YzrzoB2svWjxbGGyQ0TEASxg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.40.tgz",
+      "integrity": "sha512-h4kZYHc7dpc9P9u4brRJaS8Pl7tPVHAeiLSzw7T5RfIJgAoSdaCMKzI/2Uay9gFhaw8uyCDl0L5q37r0EpAfIA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.40.tgz",
+      "integrity": "sha512-+mQgKZXSj6mV38Zh05QaxSjUDmGP/R2JWlXZTDLSPkDzHU6p3GxN9eeSf5dfyDVU86946fmCvSzyl/ucImx8+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.40.tgz",
+      "integrity": "sha512-yvwdPLGd25mcj/mNatjNQ0lZujtQD6psH3v9PNmMb+fSzjbNG8KIDxjFWrcV+fsFVLOkyOmdJsFmX7NAFjVyPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.40.tgz",
+      "integrity": "sha512-OXtKsLU1bVtInzzDEAY2sYiF/rl4tvAnLLLpuMp3HzAOQZ5A+i69AKDhA1YLQTaMAqO3vzyYNVAYVRMPtSYD4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
@@ -1245,6 +1786,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@swc/types": {
+      "version": "0.1.26",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.26.tgz",
+      "integrity": "sha512-lyMwd7WGgG79RS7EERZV3T8wMdmPq3xwyg+1nmAM64kIhx5yl+juO2PYIHb7vTiPgPCj8LYjsNV2T5wiQHUEaw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tailwindcss/node": {
@@ -1626,7 +2176,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1686,7 +2235,6 @@
       "integrity": "sha512-3xP4XzzDNQOIqBMWogftkwxhg5oMKApqY0BAflmLZiFYHqyhSOxv/cd/zPQLTcCXr4AkaKb25joocY0BD1WC6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.51.0",
         "@typescript-eslint/types": "8.51.0",
@@ -2186,7 +2734,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2527,7 +3074,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2827,7 +3373,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
@@ -3095,7 +3640,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3281,7 +3825,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3961,6 +4504,21 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/icu-minify": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.13.0.tgz",
+      "integrity": "sha512-SIFMeUHZJjzS5RvIGvybKvWoHjDm9cGVEs2EpJ8PmywOdJLWyblPm7TdPLLoUtkJtwQD7iGhl2WMptZ+N0on+w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4011,6 +4569,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.7.tgz",
+      "integrity": "sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -4175,7 +4743,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4221,7 +4788,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -5019,6 +5585,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next": {
       "version": "16.1.1",
       "resolved": "https://registry.npmjs.org/next/-/next-16.1.1.tgz",
@@ -5072,6 +5647,94 @@
         }
       }
     },
+    "node_modules/next-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.13.0.tgz",
+      "integrity": "sha512-OvNq2v5XLx4EkQOsAhVE9g+6zdb83XHusADCXXtIW4LILYnjEVaeINdr1lkVWKSjzwNUiMSlH5N4K0OQTRiv6A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/intl-localematcher": "^0.8.1",
+        "@parcel/watcher": "^2.4.1",
+        "@swc/core": "^1.15.2",
+        "icu-minify": "^4.13.0",
+        "negotiator": "^1.0.0",
+        "next-intl-swc-plugin-extractor": "^4.13.0",
+        "po-parser": "^2.1.1",
+        "use-intl": "^4.13.0"
+      },
+      "peerDependencies": {
+        "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl-swc-plugin-extractor": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.13.0.tgz",
+      "integrity": "sha512-6S/fJI0KXvLCL8nhBo9P8eGaJPzmwJBTCzX0NaUIj0VyU8U89d//T+vjMLdNIXl5MlLaYH7B9MbAjb8Mvu+tqQ==",
+      "license": "MIT"
+    },
+    "node_modules/next-intl/node_modules/@swc/core": {
+      "version": "1.15.40",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.40.tgz",
+      "integrity": "sha512-2kwzJikRvgtNAG7MwVZY2vEzZjTxKIq5jXOihuSV/8U+Hej8Va22t65aKnJZs3P+NwojZvR8Mf8kyM7O+V8sQg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.26"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.15.40",
+        "@swc/core-darwin-x64": "1.15.40",
+        "@swc/core-linux-arm-gnueabihf": "1.15.40",
+        "@swc/core-linux-arm64-gnu": "1.15.40",
+        "@swc/core-linux-arm64-musl": "1.15.40",
+        "@swc/core-linux-ppc64-gnu": "1.15.40",
+        "@swc/core-linux-s390x-gnu": "1.15.40",
+        "@swc/core-linux-x64-gnu": "1.15.40",
+        "@swc/core-linux-x64-musl": "1.15.40",
+        "@swc/core-win32-arm64-msvc": "1.15.40",
+        "@swc/core-win32-ia32-msvc": "1.15.40",
+        "@swc/core-win32-x64-msvc": "1.15.40"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -5099,6 +5762,12 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
+    },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "license": "MIT"
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -5357,6 +6026,12 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/po-parser": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/po-parser/-/po-parser-2.1.1.tgz",
+      "integrity": "sha512-ECF4zHLbUItpUgE3OTtLKlPjeBN+fKEczj2zYjDfCGOzicNs0GK3Vg2IoAYwx7LH/XYw43fZQP6xnZ4TkNxSLQ==",
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -5412,7 +6087,6 @@
       "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -5550,7 +6224,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5560,7 +6233,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6258,7 +6930,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6421,7 +7092,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6554,6 +7224,27 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-intl": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.13.0.tgz",
+      "integrity": "sha512-fAFDrWaASxlhXOipcOyb5VDD+YONqj6+8O8EcG/J7RBoOUF3A8YahRWLN+mBxYMrlMQB8N6Voqk5X+YC+HSL0A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "^3.1.0",
+        "@schummar/icu-type-parser": "1.21.5",
+        "icu-minify": "^4.13.0",
+        "intl-messageformat": "^11.1.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
       }
     },
     "node_modules/which": {
@@ -6697,7 +7388,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "next": "16.1.1",
+    "next-intl": "^4.13.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,6 @@
 import type { Metadata } from "next";
+import { getInitialLocale } from "@/shared/server/getUserLocale";
+import { IntlProvider } from "@/shared/ui/IntlProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -7,14 +9,20 @@ export const metadata: Metadata = {
     "EasyClip is a clipboard manager that allows you to sync your clipboard across all your devices.",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const locale = await getInitialLocale();
+
   return (
-    <html lang="en">
-      <body className="bg-slate-50 antialiased">{children}</body>
+    <html lang={locale}>
+      <body className="bg-slate-50 antialiased">
+        <IntlProvider initialLocale={locale}>
+          {children}
+        </IntlProvider>
+      </body>
     </html>
   );
 }

--- a/src/features/auth/ui/LoginPage.tsx
+++ b/src/features/auth/ui/LoginPage.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import { HiOutlineClipboardCopy } from "react-icons/hi";
@@ -43,15 +44,16 @@ const GithubIcon = () => (
 );
 
 function SocialButton({ provider, onClick, isLoading }: SocialButtonProps) {
+  const t = useTranslations("login");
   const config = {
     google: {
-      label: "Google로 계속하기",
+      label: t("continueWithGoogle"),
       icon: <GoogleIcon />,
       className:
         "border border-(--border) bg-(--surface) text-(--foreground) hover:bg-(--surface-muted)",
     },
     github: {
-      label: "GitHub로 계속하기",
+      label: t("continueWithGithub"),
       icon: <GithubIcon />,
       className:
         "border border-(--border) bg-(--surface) text-(--foreground) hover:bg-(--surface-muted)",
@@ -74,6 +76,7 @@ function SocialButton({ provider, onClick, isLoading }: SocialButtonProps) {
 }
 
 export function LoginPage() {
+  const t = useTranslations("login");
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
   const [loadingProvider, setLoadingProvider] = useState<
@@ -94,11 +97,9 @@ export function LoginPage() {
           <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-(--primary)">
             <HiOutlineClipboardCopy className="h-6 w-6 text-primary-foreground" />
           </div>
-          <h1 className="text-xl font-semibold text-(--foreground)">
-            EasyClip에 로그인
-          </h1>
+          <h1 className="text-xl font-semibold text-(--foreground)">{t("title")}</h1>
           <p className="mt-2 text-center text-sm text-(--muted)">
-            어디서든 복사하고, 어디서나 붙여넣기
+            {t("subtitle")}
           </p>
         </div>
 
@@ -136,13 +137,13 @@ export function LoginPage() {
                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
               />
             </svg>
-            <span>로그인 중...</span>
+            <span>{t("loading")}</span>
           </div>
         ) : null}
 
         <div className="my-8 flex items-center gap-4">
           <div className="h-px flex-1 bg-(--border)" />
-          <span className="text-xs text-(--muted)">또는</span>
+          <span className="text-xs text-(--muted)">{t("or")}</span>
           <div className="h-px flex-1 bg-(--border)" />
         </div>
 
@@ -150,19 +151,19 @@ export function LoginPage() {
           href="/"
           className="flex w-full items-center justify-center rounded-lg border border-(--border) bg-transparent px-4 py-3 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface-muted) hover:text-(--foreground)"
         >
-          홈으로 돌아가기
+          {t("backHome")}
         </Link>
 
         <p className="mt-8 text-center text-xs text-(--muted)">
-          계속하면{" "}
+          {t("agreementPrefix")}{" "}
           <a href="#" className="underline hover:text-(--foreground)">
-            이용약관
+            {t("terms")}
           </a>{" "}
-          및{" "}
+          {t("agreementMiddle")}{" "}
           <a href="#" className="underline hover:text-(--foreground)">
-            개인정보처리방침
+            {t("privacy")}
           </a>
-          에 동의하게 됩니다.
+          {t("agreementSuffix")}
         </p>
       </div>
     </main>

--- a/src/features/clip/ui/ClipItem.tsx
+++ b/src/features/clip/ui/ClipItem.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Image from "next/image";
+import { useTranslations } from "next-intl";
 import {
   HiOutlineColorSwatch,
   HiOutlineDocumentText,
@@ -23,6 +24,8 @@ export function ClipItem({
   onToggleFavorite,
   onContextMenu,
 }: ClipItemProps) {
+  const t = useTranslations("clips.item");
+
   const getIcon = () => {
     switch (clip.type) {
       case "text":
@@ -84,7 +87,7 @@ export function ClipItem({
         }}
         className="absolute top-3 right-3 z-10 cursor-pointer rounded-full bg-(--favorite-btn-bg) p-1.5 backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-(--favorite-btn-bg-hover)"
         style={{ boxShadow: "var(--favorite-btn-shadow)" }}
-        aria-label="Toggle favorite"
+        aria-label={t("toggleFavorite")}
       >
         {clip.isFavorite ? (
           <HiStar className="h-4 w-4 text-(--warning)" aria-hidden />

--- a/src/features/clip/ui/DeleteAllButton.tsx
+++ b/src/features/clip/ui/DeleteAllButton.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 interface DeleteAllButtonProps {
   disabled?: boolean;
   onClick: () => void;
@@ -9,6 +11,8 @@ export function DeleteAllButton({
   disabled = false,
   onClick,
 }: DeleteAllButtonProps) {
+  const t = useTranslations("clips.actions");
+
   return (
     <button
       type="button"
@@ -16,7 +20,7 @@ export function DeleteAllButton({
       onClick={onClick}
       className="absolute right-6 bottom-6 rounded-full bg-(--danger) px-4 py-2 text-sm font-semibold text-danger-foreground shadow-lg transition hover:bg-(--danger-hover) disabled:cursor-not-allowed disabled:opacity-50"
     >
-      Delete All
+      {t("deleteAll")}
     </button>
   );
 }

--- a/src/features/clip/ui/EmptyState.tsx
+++ b/src/features/clip/ui/EmptyState.tsx
@@ -1,8 +1,11 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { HiOutlineClipboardCopy } from "react-icons/hi";
 
 export function EmptyState() {
+  const t = useTranslations("clips.emptyState");
+
   return (
     <div className="flex flex-1 items-center justify-center px-6 py-10">
       <div className="flex max-w-sm flex-col items-center rounded-3xl border border-dashed border-(--border) bg-(--surface) px-8 py-10 text-center">
@@ -10,10 +13,10 @@ export function EmptyState() {
           <HiOutlineClipboardCopy className="h-7 w-7" aria-hidden />
         </div>
         <p className="text-foreground mt-5 text-base font-semibold">
-          아직 저장된 클립이 없습니다
+          {t("title")}
         </p>
         <p className="text-muted mt-2 text-sm leading-relaxed">
-          새 클립을 복사하거나 폴더에서 붙여넣기를 시작하면 이곳에 표시됩니다.
+          {t("description")}
         </p>
       </div>
     </div>

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -1,11 +1,13 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useFavoriteClipsPage } from "@/features/clip/hooks/useFavoriteClipsPage";
 import { ClipList } from "@/features/clip/ui/ClipList";
 import { EmptyState } from "@/features/clip/ui/EmptyState";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function FavoriteClipsPage() {
+  const t = useTranslations("clips");
   const {
     activeFilter,
     copyToast,
@@ -21,7 +23,7 @@ export function FavoriteClipsPage() {
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}
         showStatus={false}
-        countLabel={`${filteredClips.length} clips`}
+        countLabel={t("count", { count: filteredClips.length })}
       />
       {filteredClips.length ? (
         <ClipList
@@ -38,7 +40,7 @@ export function FavoriteClipsPage() {
           className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
           style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
         >
-          COPY!
+          {t("copyToast")}
         </div>
       ) : null}
     </div>

--- a/src/features/clip/ui/FilterBar.tsx
+++ b/src/features/clip/ui/FilterBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   HiOutlineColorSwatch,
   HiOutlineDocumentText,
@@ -29,21 +30,22 @@ export function FilterBar({
   showStatus = true,
   countLabel,
 }: FilterBarProps) {
+  const t = useTranslations("clips.filter");
   const filters = [
-    { id: "all" as const, label: "All" },
+    { id: "all" as const, label: t("all") },
     {
       id: "text" as const,
-      label: "Text",
+      label: t("text"),
       icon: <HiOutlineDocumentText className="h-4 w-4" aria-hidden />,
     },
     {
       id: "color" as const,
-      label: "Color",
+      label: t("color"),
       icon: <HiOutlineColorSwatch className="h-4 w-4" aria-hidden />,
     },
     {
       id: "image" as const,
-      label: "Image",
+      label: t("image"),
       icon: <HiOutlinePhotograph className="h-4 w-4" aria-hidden />,
     },
   ];
@@ -76,7 +78,7 @@ export function FilterBar({
               }`}
               aria-hidden
             />
-            <span>{isActive ? "Ready to paste" : "Not active"}</span>
+            <span>{isActive ? t("readyToPaste") : t("notActive")}</span>
           </div>
         ) : null}
         {countLabel ? (
@@ -87,7 +89,7 @@ export function FilterBar({
         <div className="relative">
           <input
             type="text"
-            placeholder="Search clips..."
+            placeholder={t("searchPlaceholder")}
             value={searchQuery}
             onChange={(event) => onSearchChange?.(event.target.value)}
             className="text-foreground h-9 w-64 rounded-lg border border-(--border) bg-(--input) pr-4 pl-10 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none"

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useFolderClipsPage } from "@/features/clip/hooks/useFolderClipsPage";
 import { ClipList } from "@/features/clip/ui/ClipList";
 import { DeleteAllButton } from "@/features/clip/ui/DeleteAllButton";
@@ -7,6 +8,7 @@ import { EmptyState } from "@/features/clip/ui/EmptyState";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function FolderClipsPage() {
+  const t = useTranslations("clips");
   const {
     activeFilter,
     clips,
@@ -51,12 +53,12 @@ export function FolderClipsPage() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         isActive={isActive}
-        countLabel={`${filteredClips.length} clips`}
+        countLabel={t("count", { count: filteredClips.length })}
       />
       {!isActive ? (
         <div className="px-6 pt-4">
           <div className="rounded-2xl border border-(--border) bg-(--surface) px-4 py-3 text-center text-xs text-(--muted)">
-            Click anywhere and press Ctrl+V to capture a new clip
+            {t("captureHint")}
           </div>
         </div>
       ) : null}
@@ -92,7 +94,7 @@ export function FolderClipsPage() {
             className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
             data-clip-menu
           >
-            복사
+            {t("actions.copy")}
           </button>
           <button
             type="button"
@@ -105,7 +107,7 @@ export function FolderClipsPage() {
             className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
             data-clip-menu
           >
-            이름 변경
+            {t("actions.rename")}
           </button>
           <button
             type="button"
@@ -113,7 +115,7 @@ export function FolderClipsPage() {
             className="flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--danger) hover:bg-(--surface-muted)"
             data-clip-menu
           >
-            삭제
+            {t("actions.delete")}
           </button>
         </div>
       ) : null}
@@ -123,7 +125,7 @@ export function FolderClipsPage() {
           className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
           style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
         >
-          COPY!
+          {t("copyToast")}
         </div>
       ) : null}
 
@@ -132,10 +134,10 @@ export function FolderClipsPage() {
           <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
             <div className="border-b border-(--border) px-5 py-4">
               <p className="text-foreground text-sm font-semibold">
-                모든 클립 삭제
+                {t("deleteModal.title")}
               </p>
               <p className="text-muted mt-1 text-xs">
-                정말 모든 클립을 삭제하시겠습니까?
+                {t("deleteModal.description")}
               </p>
             </div>
             <div className="flex justify-end gap-2 px-5 py-4">
@@ -144,14 +146,14 @@ export function FolderClipsPage() {
                 onClick={() => setIsDeleteAllOpen(false)}
                 className="hover:text-foreground rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
               >
-                취소
+                {t("actions.cancel")}
               </button>
               <button
                 type="button"
                 onClick={handleDeleteAll}
                 className="rounded-lg bg-(--danger) px-4 py-2 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover)"
               >
-                삭제
+                {t("actions.delete")}
               </button>
             </div>
           </div>
@@ -162,18 +164,20 @@ export function FolderClipsPage() {
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
           <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
             <div className="border-b border-(--border) px-5 py-4">
-              <p className="text-foreground text-sm font-semibold">이름 변경</p>
+              <p className="text-foreground text-sm font-semibold">
+                {t("renameModal.title")}
+              </p>
             </div>
             <div className="px-5 py-4">
               <label className="block text-xs font-semibold text-(--muted)">
-                클립 이름
+                {t("renameModal.label")}
               </label>
               <input
                 ref={renameInputRef}
                 value={renameName}
                 onChange={(event) => setRenameName(event.target.value)}
                 className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder="예: 클립"
+                placeholder={t("renameModal.placeholder")}
               />
             </div>
             <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
@@ -182,14 +186,14 @@ export function FolderClipsPage() {
                 onClick={() => setIsRenameOpen(false)}
                 className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
               >
-                취소
+                {t("actions.cancel")}
               </button>
               <button
                 type="button"
                 onClick={handleRenameClip}
                 className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
               >
-                변경
+                {t("actions.change")}
               </button>
             </div>
           </div>

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import { useRecentClipsPage } from "@/features/clip/hooks/useRecentClipsPage";
 import { ClipList } from "@/features/clip/ui/ClipList";
 import { DeleteAllButton } from "@/features/clip/ui/DeleteAllButton";
@@ -7,6 +8,7 @@ import { EmptyState } from "@/features/clip/ui/EmptyState";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function RecentClipsPage() {
+  const t = useTranslations("clips");
   const {
     activeFilter,
     clearAll,
@@ -27,7 +29,7 @@ export function RecentClipsPage() {
         searchQuery={searchQuery}
         onSearchChange={setSearchQuery}
         showStatus={false}
-        countLabel={`${filteredClips.length} clips`}
+        countLabel={t("count", { count: filteredClips.length })}
       />
       {filteredClips.length ? (
         <ClipList clips={filteredClips} onCopy={handleCopy} />
@@ -41,7 +43,7 @@ export function RecentClipsPage() {
           className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
           style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
         >
-          COPY!
+          {t("copyToast")}
         </div>
       ) : null}
     </div>

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
@@ -24,6 +25,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ onOpenSettings }: SidebarProps) {
+  const t = useTranslations("sidebar");
   const pathname = usePathname();
   const { folders, persistFolders } = useFolders();
   const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
@@ -41,12 +43,12 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
   const topNavs = [
     {
       href: "/favorites",
-      label: "Favorites",
+      label: t("favorites"),
       icon: <HiOutlineStar className="h-5 w-5" aria-hidden />,
     },
     {
       href: "/recent",
-      label: "Recent",
+      label: t("recent"),
       icon: <HiOutlineClock className="h-5 w-5" aria-hidden />,
     },
   ];
@@ -184,7 +186,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
               className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
             >
               <HiOutlinePlus className="h-5 w-5" aria-hidden />
-              Add Folder
+              {t("addFolder")}
             </button>
             <ul className="space-y-1 px-2">
               {folders.map((folder) => (
@@ -219,7 +221,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                       }}
                       onDragEnd={() => setDraggingFolderId(null)}
                       className="text-muted hover:text-foreground cursor-grab rounded p-1"
-                      aria-label="폴더 순서 변경"
+                      aria-label={t("reorderFolder")}
                     >
                       <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
                     </button>
@@ -238,7 +240,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                         )
                       }
                       className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
-                      aria-label="폴더 옵션 열기"
+                      aria-label={t("openFolderOptions")}
                       data-folder-options
                     >
                       <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
@@ -261,7 +263,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                           className="text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-(--surface-muted)"
                         >
                           <HiOutlinePencil className="h-4 w-4" aria-hidden />
-                          이름 변경
+                          {t("rename")}
                         </button>
                         <button
                           type="button"
@@ -277,7 +279,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                           className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-(--danger) hover:bg-(--surface-muted)"
                         >
                           <HiOutlineTrash className="h-4 w-4" aria-hidden />
-                          삭제
+                          {t("delete")}
                         </button>
                       </div>
                     </div>
@@ -305,7 +307,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
               window.location.href = "/login";
             }}
             className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition-colors"
-            aria-label="로그아웃"
+            aria-label={t("logout")}
           >
             <HiOutlineLogout className="h-4 w-4" aria-hidden />
           </button>
@@ -317,7 +319,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
           className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
         >
           <HiOutlineCog className="h-5 w-5" aria-hidden />
-          Settings
+          {t("settings")}
         </button>
       </div>
 
@@ -329,17 +331,17 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                 type="button"
                 onClick={closeCreateModal}
                 className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
-                aria-label="Close create folder"
+                aria-label={t("closeCreateFolder")}
               >
                 <HiX className="h-5 w-5" aria-hidden />
               </button>
               <p className="text-foreground ml-auto text-sm font-semibold">
-                새 폴더 생성
+                {t("createFolder")}
               </p>
             </div>
             <div className="px-5 py-4">
               <label className="text-muted block text-xs font-semibold">
-                폴더 이름
+                {t("folderName")}
               </label>
               <input
                 ref={inputRef}
@@ -353,7 +355,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                   }
                 }}
                 className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder="예: 프로젝트"
+                placeholder={t("folderNamePlaceholder")}
               />
             </div>
             <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
@@ -362,14 +364,14 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                 onClick={closeCreateModal}
                 className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
               >
-                취소
+                {t("cancel")}
               </button>
               <button
                 type="button"
                 onClick={handleCreateFolder}
                 className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
               >
-                생성
+                {t("create")}
               </button>
             </div>
           </div>
@@ -384,17 +386,17 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                 type="button"
                 onClick={closeRenameModal}
                 className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
-                aria-label="Close rename folder"
+                aria-label={t("closeRenameFolder")}
               >
                 <HiX className="h-5 w-5" aria-hidden />
               </button>
               <p className="text-foreground ml-auto text-sm font-semibold">
-                폴더 이름 변경
+                {t("renameFolder")}
               </p>
             </div>
             <div className="px-5 py-4">
               <label className="block text-xs font-semibold text-(--muted)">
-                폴더 이름
+                {t("folderName")}
               </label>
               <input
                 ref={renameInputRef}
@@ -408,7 +410,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                   }
                 }}
                 className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder="예: 프로젝트"
+                placeholder={t("folderNamePlaceholder")}
               />
             </div>
             <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
@@ -417,14 +419,14 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
                 onClick={closeRenameModal}
                 className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
               >
-                취소
+                {t("cancel")}
               </button>
               <button
                 type="button"
                 onClick={handleRenameFolder}
                 className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
               >
-                변경
+                {t("change")}
               </button>
             </div>
           </div>

--- a/src/features/landing/ui/LandingPage.tsx
+++ b/src/features/landing/ui/LandingPage.tsx
@@ -12,31 +12,36 @@ import {
   HiOutlineSun,
 } from "react-icons/hi";
 
-const FEATURES = [
-  {
-    icon: HiOutlineLightningBolt,
-    title: "즉시 동기화",
-    description: "복사하는 순간 모든 기기에 실시간으로 반영됩니다.",
-  },
-  {
-    icon: HiOutlineFolder,
-    title: "폴더 정리",
-    description: "프로젝트별로 클립을 묶어 체계적으로 관리하세요.",
-  },
-  {
-    icon: HiOutlineStar,
-    title: "즐겨찾기",
-    description: "자주 쓰는 문구는 즐겨찾기로 빠르게 접근하세요.",
-  },
-  {
-    icon: HiOutlineSearch,
-    title: "빠른 검색",
-    description: "키워드를 입력하면 즉시 원하는 클립을 찾아냅니다.",
-  },
-];
-
 export function LandingPage() {
   const [isDarkMode, setIsDarkMode] = useState(false);
+  const features = [
+    {
+      key: "sync",
+      title: "즉시 동기화",
+      description: "복사하는 순간 모든 기기에 실시간으로 반영됩니다.",
+      icon: HiOutlineLightningBolt,
+    },
+    {
+      key: "folder",
+      title: "폴더 정리",
+      description: "프로젝트별로 클립을 묶어 체계적으로 관리하세요.",
+      icon: HiOutlineFolder,
+    },
+    {
+      key: "favorite",
+      title: "즐겨찾기",
+      description: "자주 쓰는 문구는 즐겨찾기로 빠르게 접근하세요.",
+      icon: HiOutlineStar,
+    },
+    {
+      key: "search",
+      title: "빠른 검색",
+      description: "키워드를 입력하면 즉시 원하는 클립을 찾아냅니다.",
+      icon: HiOutlineSearch,
+    },
+  ] as const;
+  const demoItems = ["디자인 가이드라인", "API 엔드포인트", "회의 노트"];
+  const mobileDemoItems = ["디자인 가이드", "API 엔드포인트"];
 
   return (
     <main
@@ -153,20 +158,18 @@ export function LandingPage() {
 
               <div className="flex-1 p-4">
                 <div className="space-y-3">
-                  {["디자인 가이드라인", "API 엔드포인트", "회의 노트"].map(
-                    (item, index) => (
-                      <div
-                        key={item}
-                        className={`flex items-center gap-3 rounded-xl p-3 ${
-                          isDarkMode ? "bg-white/5" : "bg-white"
-                        }`}
-                        style={{ animationDelay: `${index * 100}ms` }}
-                      >
-                        <div className="h-2 w-2 rounded-full bg-[#3b82f6]" />
-                        <span className="text-sm font-medium">{item}</span>
-                      </div>
-                    ),
-                  )}
+                  {demoItems.map((item, index) => (
+                    <div
+                      key={item}
+                      className={`flex items-center gap-3 rounded-xl p-3 ${
+                        isDarkMode ? "bg-white/5" : "bg-white"
+                      }`}
+                      style={{ animationDelay: `${index * 100}ms` }}
+                    >
+                      <div className="h-2 w-2 rounded-full bg-[#3b82f6]" />
+                      <span className="text-sm font-medium">{item}</span>
+                    </div>
+                  ))}
                 </div>
               </div>
             </div>
@@ -218,7 +221,7 @@ export function LandingPage() {
 
               <div className="flex-1 p-3">
                 <div className="space-y-2">
-                  {["디자인 가이드", "API 엔드포인트"].map((item) => (
+                  {mobileDemoItems.map((item) => (
                     <div
                       key={item}
                       className={`flex items-center gap-2 rounded-lg p-2 ${
@@ -256,12 +259,12 @@ export function LandingPage() {
           </div>
 
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-            {FEATURES.map((feature) => {
+            {features.map((feature) => {
               const Icon = feature.icon;
 
               return (
                 <div
-                  key={feature.title}
+                  key={feature.key}
                   className={`rounded-2xl border p-6 transition-transform hover:-translate-y-1 ${
                     isDarkMode
                       ? "border-white/10 bg-white/5"

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,14 @@
+import { getRequestConfig } from "next-intl/server";
+import { DEFAULT_TIME_ZONE } from "@/shared/config/locale";
+import { getInitialLocale } from "@/shared/server/getUserLocale";
+
+export default getRequestConfig(async () => {
+  const locale = await getInitialLocale();
+  const messages = (await import(`../messages/${locale}.json`)).default;
+
+  return {
+    locale,
+    messages,
+    timeZone: DEFAULT_TIME_ZONE,
+  };
+});

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "themeToggle": "Toggle dark mode",
+    "start": "Get Started",
+    "heroTitleLine1": "Copy anywhere.",
+    "heroTitleLine2": "Paste everywhere.",
+    "heroDescription": "Keep your clipboard perfectly synced across every device. Built for fast-moving developers, designers, and creative teams.",
+    "startFree": "Start for free",
+    "viewDemo": "View demo",
+    "demoWindowTitle": "Easy Clip - Clipboard Manager",
+    "demoDeviceTitle": "Easy Clip",
+    "demoItem1": "Design guidelines",
+    "demoItem2": "API endpoints",
+    "demoItem3": "Meeting notes",
+    "demoMobileItem1": "Design guide",
+    "demoMobileItem2": "API endpoints",
+    "sectionTitle": "A clipboard that keeps your flow moving",
+    "sectionDescription": "Manage copying, organizing, and reusing in one place.",
+    "features": {
+      "sync": {
+        "title": "Instant sync",
+        "description": "Everything you copy is reflected across your devices in real time."
+      },
+      "folder": {
+        "title": "Folder organization",
+        "description": "Group clips by project and keep your workspace structured."
+      },
+      "favorite": {
+        "title": "Favorites",
+        "description": "Pin your most-used snippets for quick access."
+      },
+      "search": {
+        "title": "Fast search",
+        "description": "Find the clip you need the moment you type a keyword."
+      }
+    }
+  },
+  "login": {
+    "title": "Sign in to EasyClip",
+    "subtitle": "Copy anywhere, paste everywhere",
+    "continueWithGoogle": "Continue with Google",
+    "continueWithGithub": "Continue with GitHub",
+    "loading": "Signing in...",
+    "or": "or",
+    "backHome": "Back to home",
+    "agreementPrefix": "By continuing, you agree to the",
+    "agreementMiddle": "and",
+    "terms": "Terms of Service",
+    "privacy": "Privacy Policy",
+    "agreementSuffix": "."
+  },
+  "sidebar": {
+    "favorites": "Favorites",
+    "recent": "Recent",
+    "addFolder": "Add Folder",
+    "reorderFolder": "Reorder folder",
+    "openFolderOptions": "Open folder options",
+    "rename": "Rename",
+    "delete": "Delete",
+    "logout": "Log out",
+    "settings": "Settings",
+    "closeCreateFolder": "Close create folder",
+    "createFolder": "Create folder",
+    "folderName": "Folder name",
+    "folderNamePlaceholder": "e.g. Project",
+    "cancel": "Cancel",
+    "create": "Create",
+    "closeRenameFolder": "Close rename folder",
+    "renameFolder": "Rename folder",
+    "change": "Save"
+  },
+  "settings": {
+    "title": "Settings",
+    "close": "Close settings",
+    "appearance": "Appearance",
+    "darkMode": "Dark Mode",
+    "darkModeDescription": "Switch between light and dark themes.",
+    "toggleDarkMode": "Toggle dark mode",
+    "general": "General",
+    "language": "Language",
+    "languageDescription": "Select your preferred language.",
+    "about": "About",
+    "aboutTitle": "Clipboard Studio v1.0.0",
+    "aboutDescription": "A modern clipboard manager for designers and developers",
+    "closeButton": "Close"
+  },
+  "clips": {
+    "count": "{count, plural, =0 {0 clips} one {# clip} other {# clips}}",
+    "copyToast": "Copied!",
+    "captureHint": "Click anywhere and press Ctrl+V to capture a new clip.",
+    "filter": {
+      "all": "All",
+      "text": "Text",
+      "color": "Color",
+      "image": "Image",
+      "readyToPaste": "Ready to paste",
+      "notActive": "Not active",
+      "searchPlaceholder": "Search clips..."
+    },
+    "emptyState": {
+      "title": "No saved clips yet",
+      "description": "Copied clips or new pasted items from a folder will appear here."
+    },
+    "item": {
+      "toggleFavorite": "Toggle favorite"
+    },
+    "actions": {
+      "copy": "Copy",
+      "rename": "Rename",
+      "delete": "Delete",
+      "deleteAll": "Delete All",
+      "cancel": "Cancel",
+      "change": "Save"
+    },
+    "deleteModal": {
+      "title": "Delete all clips",
+      "description": "Are you sure you want to delete every clip?"
+    },
+    "renameModal": {
+      "title": "Rename",
+      "label": "Clip name",
+      "placeholder": "e.g. Clip"
+    }
+  }
+}

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "themeToggle": "ダークモードを切り替え",
+    "start": "はじめる",
+    "heroTitleLine1": "どこでもコピー。",
+    "heroTitleLine2": "どこでも貼り付け。",
+    "heroDescription": "すべてのデバイスでクリップボードを完全に同期します。素早く動く開発者、デザイナー、クリエイティブチームのために設計されています。",
+    "startFree": "無料で始める",
+    "viewDemo": "デモを見る",
+    "demoWindowTitle": "Easy Clip - クリップボード管理",
+    "demoDeviceTitle": "Easy Clip",
+    "demoItem1": "デザインガイドライン",
+    "demoItem2": "API エンドポイント",
+    "demoItem3": "会議メモ",
+    "demoMobileItem1": "デザインガイド",
+    "demoMobileItem2": "API エンドポイント",
+    "sectionTitle": "作業の流れを止めないクリップボード",
+    "sectionDescription": "コピー、整理、再利用までを一か所で管理します。",
+    "features": {
+      "sync": {
+        "title": "即時同期",
+        "description": "コピーした内容がすぐにすべてのデバイスへリアルタイムで反映されます。"
+      },
+      "folder": {
+        "title": "フォルダ整理",
+        "description": "プロジェクトごとにクリップをまとめて、すっきり管理できます。"
+      },
+      "favorite": {
+        "title": "お気に入り",
+        "description": "よく使う文言はお気に入りにしてすぐにアクセスできます。"
+      },
+      "search": {
+        "title": "高速検索",
+        "description": "キーワードを入力すると必要なクリップをすぐに見つけられます。"
+      }
+    }
+  },
+  "login": {
+    "title": "EasyClip にログイン",
+    "subtitle": "どこでもコピーして、どこでも貼り付け",
+    "continueWithGoogle": "Google で続行",
+    "continueWithGithub": "GitHub で続行",
+    "loading": "ログイン中...",
+    "or": "または",
+    "backHome": "ホームに戻る",
+    "agreementPrefix": "続行すると、",
+    "agreementMiddle": "および",
+    "terms": "利用規約",
+    "privacy": "プライバシーポリシー",
+    "agreementSuffix": "に同意したものとみなされます。"
+  },
+  "sidebar": {
+    "favorites": "お気に入り",
+    "recent": "最近",
+    "addFolder": "フォルダ追加",
+    "reorderFolder": "フォルダの並び替え",
+    "openFolderOptions": "フォルダオプションを開く",
+    "rename": "名前を変更",
+    "delete": "削除",
+    "logout": "ログアウト",
+    "settings": "設定",
+    "closeCreateFolder": "フォルダ作成を閉じる",
+    "createFolder": "新しいフォルダを作成",
+    "folderName": "フォルダ名",
+    "folderNamePlaceholder": "例: プロジェクト",
+    "cancel": "キャンセル",
+    "create": "作成",
+    "closeRenameFolder": "フォルダ名変更を閉じる",
+    "renameFolder": "フォルダ名を変更",
+    "change": "変更"
+  },
+  "settings": {
+    "title": "設定",
+    "close": "設定を閉じる",
+    "appearance": "表示",
+    "darkMode": "ダークモード",
+    "darkModeDescription": "ライトモードとダークモードを切り替えます。",
+    "toggleDarkMode": "ダークモードを切り替え",
+    "general": "一般",
+    "language": "言語",
+    "languageDescription": "希望する言語を選択してください。",
+    "about": "情報",
+    "aboutTitle": "Clipboard Studio v1.0.0",
+    "aboutDescription": "デザイナーと開発者のためのモダンなクリップボードマネージャー",
+    "closeButton": "閉じる"
+  },
+  "clips": {
+    "count": "{count, plural, =0 {0 件のクリップ} other {# 件のクリップ}}",
+    "copyToast": "コピーしました！",
+    "captureHint": "どこかをクリックしてから Ctrl+V を押すと新しいクリップを保存できます。",
+    "filter": {
+      "all": "すべて",
+      "text": "テキスト",
+      "color": "カラー",
+      "image": "画像",
+      "readyToPaste": "貼り付け準備完了",
+      "notActive": "非アクティブ",
+      "searchPlaceholder": "クリップを検索..."
+    },
+    "emptyState": {
+      "title": "保存されたクリップはまだありません",
+      "description": "新しいクリップをコピーするか、フォルダで貼り付けを始めるとここに表示されます。"
+    },
+    "item": {
+      "toggleFavorite": "お気に入りを切り替え"
+    },
+    "actions": {
+      "copy": "コピー",
+      "rename": "名前を変更",
+      "delete": "削除",
+      "deleteAll": "すべて削除",
+      "cancel": "キャンセル",
+      "change": "変更"
+    },
+    "deleteModal": {
+      "title": "すべてのクリップを削除",
+      "description": "本当にすべてのクリップを削除しますか？"
+    },
+    "renameModal": {
+      "title": "名前を変更",
+      "label": "クリップ名",
+      "placeholder": "例: クリップ"
+    }
+  }
+}

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "themeToggle": "다크 모드 전환",
+    "start": "시작하기",
+    "heroTitleLine1": "어디서든 복사하고.",
+    "heroTitleLine2": "어디서나 붙여넣기.",
+    "heroDescription": "모든 기기에서 클립보드를 완벽하게 동기화하세요. 빠르게 움직이는 개발자, 디자이너, 크리에이티브 팀을 위해 설계되었습니다.",
+    "startFree": "무료로 시작하기",
+    "viewDemo": "데모 보기",
+    "demoWindowTitle": "Easy Clip - 클립보드 관리",
+    "demoDeviceTitle": "Easy Clip",
+    "demoItem1": "디자인 가이드라인",
+    "demoItem2": "API 엔드포인트",
+    "demoItem3": "회의 노트",
+    "demoMobileItem1": "디자인 가이드",
+    "demoMobileItem2": "API 엔드포인트",
+    "sectionTitle": "일의 흐름을 끊지 않는 클립보드",
+    "sectionDescription": "복사, 정리, 재사용까지 한 번에 관리하세요.",
+    "features": {
+      "sync": {
+        "title": "즉시 동기화",
+        "description": "복사하는 순간 모든 기기에 실시간으로 반영됩니다."
+      },
+      "folder": {
+        "title": "폴더 정리",
+        "description": "프로젝트별로 클립을 묶어 체계적으로 관리하세요."
+      },
+      "favorite": {
+        "title": "즐겨찾기",
+        "description": "자주 쓰는 문구는 즐겨찾기로 빠르게 접근하세요."
+      },
+      "search": {
+        "title": "빠른 검색",
+        "description": "키워드를 입력하면 즉시 원하는 클립을 찾아냅니다."
+      }
+    }
+  },
+  "login": {
+    "title": "EasyClip에 로그인",
+    "subtitle": "어디서든 복사하고, 어디서나 붙여넣기",
+    "continueWithGoogle": "Google로 계속하기",
+    "continueWithGithub": "GitHub로 계속하기",
+    "loading": "로그인 중...",
+    "or": "또는",
+    "backHome": "홈으로 돌아가기",
+    "agreementPrefix": "계속하면",
+    "agreementMiddle": "및",
+    "terms": "이용약관",
+    "privacy": "개인정보처리방침",
+    "agreementSuffix": "에 동의하게 됩니다."
+  },
+  "sidebar": {
+    "favorites": "즐겨찾기",
+    "recent": "최근 항목",
+    "addFolder": "폴더 추가",
+    "reorderFolder": "폴더 순서 변경",
+    "openFolderOptions": "폴더 옵션 열기",
+    "rename": "이름 변경",
+    "delete": "삭제",
+    "logout": "로그아웃",
+    "settings": "설정",
+    "closeCreateFolder": "폴더 생성 닫기",
+    "createFolder": "새 폴더 생성",
+    "folderName": "폴더 이름",
+    "folderNamePlaceholder": "예: 프로젝트",
+    "cancel": "취소",
+    "create": "생성",
+    "closeRenameFolder": "폴더 이름 변경 닫기",
+    "renameFolder": "폴더 이름 변경",
+    "change": "변경"
+  },
+  "settings": {
+    "title": "설정",
+    "close": "설정 닫기",
+    "appearance": "화면 설정",
+    "darkMode": "다크 모드",
+    "darkModeDescription": "라이트 모드와 다크 모드를 전환합니다.",
+    "toggleDarkMode": "다크 모드 전환",
+    "general": "일반",
+    "language": "언어",
+    "languageDescription": "선호하는 언어를 선택하세요.",
+    "about": "정보",
+    "aboutTitle": "Clipboard Studio v1.0.0",
+    "aboutDescription": "디자이너와 개발자를 위한 현대적인 클립보드 매니저",
+    "closeButton": "닫기"
+  },
+  "clips": {
+    "count": "{count, plural, =0 {0개 클립} other {#개 클립}}",
+    "copyToast": "복사됨!",
+    "captureHint": "아무 곳이나 클릭한 뒤 Ctrl+V를 눌러 새 클립을 저장하세요.",
+    "filter": {
+      "all": "전체",
+      "text": "텍스트",
+      "color": "색상",
+      "image": "이미지",
+      "readyToPaste": "붙여넣기 준비됨",
+      "notActive": "비활성 상태",
+      "searchPlaceholder": "클립 검색..."
+    },
+    "emptyState": {
+      "title": "아직 저장된 클립이 없습니다",
+      "description": "새 클립을 복사하거나 폴더에서 붙여넣기를 시작하면 이곳에 표시됩니다."
+    },
+    "item": {
+      "toggleFavorite": "즐겨찾기 전환"
+    },
+    "actions": {
+      "copy": "복사",
+      "rename": "이름 변경",
+      "delete": "삭제",
+      "deleteAll": "전체 삭제",
+      "cancel": "취소",
+      "change": "변경"
+    },
+    "deleteModal": {
+      "title": "모든 클립 삭제",
+      "description": "정말 모든 클립을 삭제하시겠습니까?"
+    },
+    "renameModal": {
+      "title": "이름 변경",
+      "label": "클립 이름",
+      "placeholder": "예: 클립"
+    }
+  }
+}

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -1,0 +1,125 @@
+{
+  "landing": {
+    "themeToggle": "切换深色模式",
+    "start": "开始使用",
+    "heroTitleLine1": "随处复制。",
+    "heroTitleLine2": "随处粘贴。",
+    "heroDescription": "在所有设备上保持剪贴板完美同步。为高效率的开发者、设计师和创意团队而打造。",
+    "startFree": "免费开始",
+    "viewDemo": "查看演示",
+    "demoWindowTitle": "Easy Clip - 剪贴板管理",
+    "demoDeviceTitle": "Easy Clip",
+    "demoItem1": "设计规范",
+    "demoItem2": "API 接口",
+    "demoItem3": "会议记录",
+    "demoMobileItem1": "设计指南",
+    "demoMobileItem2": "API 接口",
+    "sectionTitle": "不中断工作流的剪贴板",
+    "sectionDescription": "把复制、整理和复用集中到一个地方管理。",
+    "features": {
+      "sync": {
+        "title": "即时同步",
+        "description": "复制的内容会立即实时同步到所有设备。"
+      },
+      "folder": {
+        "title": "文件夹整理",
+        "description": "按项目归类剪贴内容，让工作区更有条理。"
+      },
+      "favorite": {
+        "title": "收藏",
+        "description": "把常用内容加入收藏，随时快速访问。"
+      },
+      "search": {
+        "title": "快速搜索",
+        "description": "输入关键词即可立即找到需要的剪贴内容。"
+      }
+    }
+  },
+  "login": {
+    "title": "登录 EasyClip",
+    "subtitle": "随处复制，随处粘贴",
+    "continueWithGoogle": "使用 Google 继续",
+    "continueWithGithub": "使用 GitHub 继续",
+    "loading": "登录中...",
+    "or": "或",
+    "backHome": "返回首页",
+    "agreementPrefix": "继续即表示你同意",
+    "agreementMiddle": "以及",
+    "terms": "服务条款",
+    "privacy": "隐私政策",
+    "agreementSuffix": "。"
+  },
+  "sidebar": {
+    "favorites": "收藏",
+    "recent": "最近",
+    "addFolder": "添加文件夹",
+    "reorderFolder": "调整文件夹顺序",
+    "openFolderOptions": "打开文件夹选项",
+    "rename": "重命名",
+    "delete": "删除",
+    "logout": "退出登录",
+    "settings": "设置",
+    "closeCreateFolder": "关闭新建文件夹",
+    "createFolder": "新建文件夹",
+    "folderName": "文件夹名称",
+    "folderNamePlaceholder": "例如：项目",
+    "cancel": "取消",
+    "create": "创建",
+    "closeRenameFolder": "关闭重命名文件夹",
+    "renameFolder": "重命名文件夹",
+    "change": "保存"
+  },
+  "settings": {
+    "title": "设置",
+    "close": "关闭设置",
+    "appearance": "外观",
+    "darkMode": "深色模式",
+    "darkModeDescription": "在浅色和深色主题之间切换。",
+    "toggleDarkMode": "切换深色模式",
+    "general": "通用",
+    "language": "语言",
+    "languageDescription": "选择你偏好的语言。",
+    "about": "关于",
+    "aboutTitle": "Clipboard Studio v1.0.0",
+    "aboutDescription": "面向设计师和开发者的现代剪贴板管理器",
+    "closeButton": "关闭"
+  },
+  "clips": {
+    "count": "{count, plural, =0 {0 个剪贴项} other {# 个剪贴项}}",
+    "copyToast": "已复制！",
+    "captureHint": "点击任意位置后按 Ctrl+V，即可保存新的剪贴内容。",
+    "filter": {
+      "all": "全部",
+      "text": "文本",
+      "color": "颜色",
+      "image": "图片",
+      "readyToPaste": "可粘贴",
+      "notActive": "未激活",
+      "searchPlaceholder": "搜索剪贴内容..."
+    },
+    "emptyState": {
+      "title": "还没有保存的剪贴内容",
+      "description": "复制新的内容，或在文件夹中开始粘贴后，这里就会显示内容。"
+    },
+    "item": {
+      "toggleFavorite": "切换收藏"
+    },
+    "actions": {
+      "copy": "复制",
+      "rename": "重命名",
+      "delete": "删除",
+      "deleteAll": "全部删除",
+      "cancel": "取消",
+      "change": "保存"
+    },
+    "deleteModal": {
+      "title": "删除所有剪贴内容",
+      "description": "确定要删除全部剪贴内容吗？"
+    },
+    "renameModal": {
+      "title": "重命名",
+      "label": "剪贴名称",
+      "placeholder": "例如：剪贴"
+    }
+  }
+}

--- a/src/shared/config/locale.ts
+++ b/src/shared/config/locale.ts
@@ -1,0 +1,16 @@
+export const APP_LOCALES = ["ko", "en", "ja", "zh"] as const;
+
+export type AppLocale = (typeof APP_LOCALES)[number];
+
+export const DEFAULT_LOCALE: AppLocale = "ko";
+export const DEFAULT_TIME_ZONE = "Asia/Seoul";
+
+export const LOCALE_LABELS: Record<AppLocale, string> = {
+  ko: "한국어",
+  en: "English",
+  ja: "日本語",
+  zh: "中文",
+};
+
+export const isAppLocale = (value: string): value is AppLocale =>
+  APP_LOCALES.includes(value as AppLocale);

--- a/src/shared/server/getUserLocale.ts
+++ b/src/shared/server/getUserLocale.ts
@@ -1,0 +1,11 @@
+import { DEFAULT_LOCALE, type AppLocale } from "@/shared/config/locale";
+
+export async function getUserLocaleSetting(): Promise<AppLocale | null> {
+  return null;
+}
+
+export async function getInitialLocale(): Promise<AppLocale> {
+  const locale = await getUserLocaleSetting();
+
+  return locale ?? DEFAULT_LOCALE;
+}

--- a/src/shared/store/settingsStore.ts
+++ b/src/shared/store/settingsStore.ts
@@ -1,10 +1,15 @@
 "use client";
 
 import { create } from "zustand";
-import { createJSONStorage, persist } from "zustand/middleware";
+import {
+  createJSONStorage,
+  persist,
+  type StateStorage,
+} from "zustand/middleware";
+import { DEFAULT_LOCALE, type AppLocale } from "@/shared/config/locale";
 
 export type ThemeMode = "light" | "dark";
-export type LanguageCode = "en" | "ko";
+export type LanguageCode = AppLocale;
 
 interface SettingsState {
   theme: ThemeMode;
@@ -12,21 +17,31 @@ interface SettingsState {
   setTheme: (theme: ThemeMode) => void;
   toggleTheme: () => void;
   setLanguage: (language: LanguageCode) => void;
+  syncLanguage: (language: LanguageCode) => void;
 }
+
+const noopStorage: StateStorage = {
+  getItem: () => null,
+  setItem: () => undefined,
+  removeItem: () => undefined,
+};
 
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
       theme: "dark",
-      language: "en",
+      language: DEFAULT_LOCALE,
       setTheme: (theme) => set({ theme }),
       toggleTheme: () =>
         set({ theme: get().theme === "dark" ? "light" : "dark" }),
       setLanguage: (language) => set({ language }),
+      syncLanguage: (language) => set({ language }),
     }),
     {
       name: "easy-clip-settings",
-      storage: createJSONStorage(() => localStorage),
+      storage: createJSONStorage(() =>
+        typeof window === "undefined" ? noopStorage : localStorage,
+      ),
     },
   ),
 );

--- a/src/shared/ui/AppShell.tsx
+++ b/src/shared/ui/AppShell.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Sidebar } from "@/features/folder/ui/Sidebar";
-import { applySettings, useSettingsStore } from "@/shared/store/settingsStore";
 import { SettingsModal } from "@/shared/ui/SettingsModal";
 
 interface AppShellProps {
@@ -11,11 +10,6 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
-  const { language, theme } = useSettingsStore();
-
-  useEffect(() => {
-    applySettings(theme, language);
-  }, [language, theme]);
 
   return (
     <div className="bg-background text-foreground flex h-screen flex-col overflow-hidden">

--- a/src/shared/ui/IntlProvider.tsx
+++ b/src/shared/ui/IntlProvider.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import { NextIntlClientProvider } from "next-intl";
+import enMessages from "@/messages/en.json";
+import jaMessages from "@/messages/ja.json";
+import koMessages from "@/messages/ko.json";
+import zhMessages from "@/messages/zh.json";
+import {
+  DEFAULT_TIME_ZONE,
+  type AppLocale,
+} from "@/shared/config/locale";
+import { applySettings, useSettingsStore } from "@/shared/store/settingsStore";
+
+interface IntlProviderProps {
+  children: React.ReactNode;
+  initialLocale: AppLocale;
+}
+
+const messagesByLocale = {
+  ko: koMessages,
+  en: enMessages,
+  ja: jaMessages,
+  zh: zhMessages,
+} as const;
+
+export function IntlProvider({
+  children,
+  initialLocale,
+}: IntlProviderProps) {
+  const theme = useSettingsStore((state) => state.theme);
+  const language = useSettingsStore((state) => state.language);
+  const syncLanguage = useSettingsStore((state) => state.syncLanguage);
+
+  useEffect(() => {
+    syncLanguage(initialLocale);
+  }, [initialLocale, syncLanguage]);
+
+  useEffect(() => {
+    applySettings(theme, language);
+  }, [language, theme]);
+
+  return (
+    <NextIntlClientProvider
+      locale={language}
+      messages={messagesByLocale[language]}
+      timeZone={DEFAULT_TIME_ZONE}
+    >
+      {children}
+    </NextIntlClientProvider>
+  );
+}

--- a/src/shared/ui/SettingsModal.tsx
+++ b/src/shared/ui/SettingsModal.tsx
@@ -1,18 +1,21 @@
 "use client";
 
+import { useTranslations } from "next-intl";
 import {
   HiOutlineCog,
   HiOutlineMoon,
   HiOutlineTranslate,
   HiOutlineX,
 } from "react-icons/hi";
-import { applySettings, useSettingsStore } from "@/shared/store/settingsStore";
+import { LOCALE_LABELS, type AppLocale } from "@/shared/config/locale";
+import { useSettingsStore } from "@/shared/store/settingsStore";
 
 interface SettingsModalProps {
   onClose: () => void;
 }
 
 export function SettingsModal({ onClose }: SettingsModalProps) {
+  const t = useTranslations("settings");
   const { theme, language, setLanguage, toggleTheme } = useSettingsStore();
   const isDark = theme === "dark";
 
@@ -33,13 +36,13 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
             <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-(--modal-icon-bg) text-(--modal-icon-fg)">
               <HiOutlineCog className="h-5 w-5" aria-hidden />
             </span>
-            Settings
+            {t("title")}
           </div>
           <button
             type="button"
             onClick={onClose}
             className="flex h-9 w-9 cursor-pointer items-center justify-center rounded-full transition hover:bg-(--surface-muted)"
-            aria-label="Close settings"
+            aria-label={t("close")}
           >
             <HiOutlineX className="h-5 w-5 text-(--muted)" aria-hidden />
           </button>
@@ -47,29 +50,28 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
 
         <div className="space-y-6 px-6 py-6">
           <div>
-            <p className="text-sm font-semibold text-(--muted)">Appearance</p>
+            <p className="text-sm font-semibold text-(--muted)">
+              {t("appearance")}
+            </p>
             <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
               <div className="flex items-center gap-3">
                 <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
                   <HiOutlineMoon className="h-5 w-5" aria-hidden />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">Dark Mode</p>
+                  <p className="text-sm font-semibold">{t("darkMode")}</p>
                   <p className="text-xs text-(--muted)">
-                    Switch between light and dark theme
+                    {t("darkModeDescription")}
                   </p>
                 </div>
               </div>
               <button
                 type="button"
-                onClick={() => {
-                  toggleTheme();
-                  applySettings(theme === "dark" ? "light" : "dark", language);
-                }}
+                onClick={toggleTheme}
                 className={`relative h-7 w-12 cursor-pointer rounded-full transition ${
                   isDark ? "bg-(--primary)" : "bg-(--border)"
                 }`}
-                aria-label="Toggle dark mode"
+                aria-label={t("toggleDarkMode")}
               >
                 <span
                   className={`absolute top-0.5 h-6 w-6 rounded-full bg-white shadow transition ${
@@ -81,42 +83,44 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
           </div>
 
           <div>
-            <p className="text-sm font-semibold text-(--muted)">General</p>
+            <p className="text-sm font-semibold text-(--muted)">
+              {t("general")}
+            </p>
             <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
               <div className="flex items-center gap-3">
                 <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
                   <HiOutlineTranslate className="h-5 w-5" aria-hidden />
                 </div>
                 <div>
-                  <p className="text-sm font-semibold">Language</p>
+                  <p className="text-sm font-semibold">{t("language")}</p>
                   <p className="text-xs text-(--muted)">
-                    Select your preferred language
+                    {t("languageDescription")}
                   </p>
                 </div>
               </div>
               <select
                 value={language}
                 onChange={(event) => {
-                  const nextLanguage =
-                    event.target.value === "ko" ? "ko" : "en";
-                  setLanguage(nextLanguage);
-                  applySettings(theme, nextLanguage);
+                  setLanguage(event.target.value as AppLocale);
                 }}
                 className="cursor-pointer rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm text-(--foreground) focus:border-(--focus-ring) focus:outline-none"
               >
-                <option value="en">English</option>
-                <option value="ko">한국어</option>
+                {Object.entries(LOCALE_LABELS).map(([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ))}
               </select>
             </div>
           </div>
 
           <div>
-            <p className="text-sm font-semibold text-(--muted)">About</p>
+            <p className="text-sm font-semibold text-(--muted)">
+              {t("about")}
+            </p>
             <div className="mt-3 rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
-              <p className="text-sm font-semibold">Clipboard Studio v1.0.0</p>
-              <p className="text-xs text-(--muted)">
-                A modern clipboard manager for designers and developers
-              </p>
+              <p className="text-sm font-semibold">{t("aboutTitle")}</p>
+              <p className="text-xs text-(--muted)">{t("aboutDescription")}</p>
             </div>
           </div>
         </div>
@@ -127,7 +131,7 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
             onClick={onClose}
             className="cursor-pointer rounded-lg bg-(--primary) px-5 py-2 text-sm font-semibold text-primary-foreground transition hover:bg-(--primary-hover)"
           >
-            Close
+            {t("closeButton")}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## 📌 PR 요약

- 서버 설정 기반 다국어 초기화 구조를 추가하고 주요 앱 화면에 `next-intl`을 적용했습니다.

## 🔍 변경 내용 상세

### 변경 사항

- 서버 사용자 언어 설정을 읽는 스텁 함수와 기본값 `ko` fallback 구조를 추가했습니다.
- `zustand` 전역 언어 상태와 `next-intl` provider를 연결했습니다.
- 설정, 로그인, 사이드바, 클립 관련 화면에 `ko/en/ja/zh` 메시지 리소스를 연결했습니다.
- 랜딩 페이지는 요청에 맞춰 다국어 대상에서 제외하고 고정 한국어로 유지했습니다.

### 변경 이유

- 추후 서버에서 내려주는 사용자 언어 설정을 그대로 붙일 수 있는 초기화 구조가 필요했습니다.
- 언어 상태를 `shared`에서 공통 관리해 여러 화면에서 일관되게 다국어를 적용하려는 목적입니다.

_(스크린샷 또는 영상 첨부)_

## 🗂 관련 이슈

- Closes #24

## 📚 기타 참고사항

- 검증: `npm run lint`, `npm run build`
- `npm run start`는 미실행했습니다.
- `npm run package` 스크립트는 현재 저장소에 없습니다.
