### PR TITLE
#28 / refactor(clips) : 메인 클립 화면 모바일 반응형 UI 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -45,6 +45,9 @@
   --favorite-btn-bg-hover: rgba(255, 255, 255, 1);
   --favorite-btn-shadow: 0 8px 18px rgba(15, 23, 42, 0.14);
   --favorite-icon-muted: #94a3b8;
+  --clip-scrollbar-track: rgba(226, 232, 240, 0.72);
+  --clip-scrollbar-thumb: rgba(100, 116, 139, 0.52);
+  --clip-scrollbar-thumb-hover: rgba(51, 65, 85, 0.72);
   --modal-section-bg: #f8fafc;
   --modal-icon-bg: #e5e7eb;
   --modal-icon-fg: #4b5563;
@@ -116,6 +119,9 @@
   --favorite-btn-bg-hover: rgba(42, 42, 43, 0.96);
   --favorite-btn-shadow: 0 8px 18px rgba(0, 0, 0, 0.32);
   --favorite-icon-muted: #cbd5e1;
+  --clip-scrollbar-track: rgba(255, 255, 255, 0.06);
+  --clip-scrollbar-thumb: rgba(148, 163, 184, 0.4);
+  --clip-scrollbar-thumb-hover: rgba(203, 213, 225, 0.58);
   --modal-section-bg: rgba(255, 255, 255, 0.05);
   --modal-icon-bg: rgba(255, 255, 255, 0.1);
   --modal-icon-fg: #e5e7eb;
@@ -221,4 +227,32 @@ a {
   to {
     transform: translateX(calc(-50% - (var(--marquee-gap, 0px) / 2)));
   }
+}
+
+.clip-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: var(--clip-scrollbar-thumb) var(--clip-scrollbar-track);
+}
+
+.clip-scrollbar::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+
+.clip-scrollbar::-webkit-scrollbar-track {
+  background: var(--clip-scrollbar-track);
+  border-radius: 999px;
+}
+
+.clip-scrollbar::-webkit-scrollbar-thumb {
+  background: var(--clip-scrollbar-thumb);
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background-clip: padding-box;
+}
+
+.clip-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: var(--clip-scrollbar-thumb-hover);
+  border: 2px solid transparent;
+  background-clip: padding-box;
 }

--- a/src/features/clip/ui/ClipList.tsx
+++ b/src/features/clip/ui/ClipList.tsx
@@ -22,7 +22,7 @@ export function ClipList({
 
   return (
     <div className="clip-scrollbar flex-1 overflow-auto px-4 py-4 md:px-6">
-      <div className="grid grid-cols-1 gap-4 min-[401px]:grid-cols-2 min-[1200px]:grid-cols-5 md:grid-cols-3 lg:grid-cols-4">
+      <div className="grid grid-cols-1 gap-4 min-[800px]:grid-cols-2 min-[1200px]:grid-cols-3 min-[1440px]:grid-cols-4">
         {clips.map((clip) => (
           <ClipItem
             key={clip.id}

--- a/src/features/clip/ui/ClipList.tsx
+++ b/src/features/clip/ui/ClipList.tsx
@@ -21,7 +21,7 @@ export function ClipList({
   }
 
   return (
-    <div className="flex-1 overflow-auto px-6 py-4">
+    <div className="clip-scrollbar flex-1 overflow-auto px-4 py-4 md:px-6">
       <div className="grid grid-cols-1 gap-4 min-[401px]:grid-cols-2 min-[1200px]:grid-cols-5 md:grid-cols-3 lg:grid-cols-4">
         {clips.map((clip) => (
           <ClipItem

--- a/src/features/clip/ui/DeleteAllButton.tsx
+++ b/src/features/clip/ui/DeleteAllButton.tsx
@@ -16,7 +16,7 @@ export function DeleteAllButton({
       type="button"
       disabled={disabled}
       onClick={onClick}
-      className="absolute right-6 bottom-6 rounded-full bg-(--danger) px-4 py-2 text-sm font-semibold text-danger-foreground shadow-lg transition hover:bg-(--danger-hover) disabled:cursor-not-allowed disabled:opacity-50"
+      className="absolute right-4 bottom-4 rounded-full bg-(--danger) px-4 py-2 text-sm font-semibold text-danger-foreground shadow-lg transition hover:bg-(--danger-hover) disabled:cursor-not-allowed disabled:opacity-50 md:right-6 md:bottom-6"
     >
       {t("deleteAll")}
     </button>

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -18,7 +18,7 @@ export function FavoriteClipsPage() {
   } = useFavoriteClipsPage();
 
   return (
-    <div className="bg-background flex h-full flex-col">
+    <div className="bg-background relative flex h-full flex-col">
       <FilterBar
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}

--- a/src/features/clip/ui/FilterBar.tsx
+++ b/src/features/clip/ui/FilterBar.tsx
@@ -58,7 +58,7 @@ export function FilterBar({
         placeholder={t("searchPlaceholder")}
         value={searchQuery}
         onChange={(event) => onSearchChange?.(event.target.value)}
-        className="text-foreground h-11 w-full rounded-xl border border-(--border) bg-(--input) pr-4 pl-10 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none md:h-9 md:w-64 md:rounded-lg"
+        className="text-foreground h-11 w-full rounded-xl border border-(--border) bg-(--input) pr-4 pl-10 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none min-[1200px]:h-9 min-[1200px]:w-64 min-[1200px]:rounded-lg"
       />
       <HiOutlineSearch
         className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-(--muted)"
@@ -68,7 +68,7 @@ export function FilterBar({
   );
 
   const statusGroup = (
-    <div className="flex w-full flex-wrap items-center justify-end gap-3 md:w-auto">
+    <div className="flex w-full flex-wrap items-center justify-end gap-3 min-[1200px]:w-auto">
       {showStatus ? (
         <div className="flex items-center gap-2 text-xs text-(--muted)">
           <span
@@ -89,9 +89,9 @@ export function FilterBar({
   );
 
   return (
-    <div className="border-b border-(--border) px-4 py-4 md:px-6">
-      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
-        <div className="md:hidden">
+    <div className="border-b border-(--border) px-4 py-4 min-[1200px]:px-6">
+      <div className="flex flex-col gap-3 min-[1200px]:flex-row min-[1200px]:items-center min-[1200px]:justify-between">
+        <div className="min-[1200px]:hidden">
           <StyledSelect
             value={activeFilter}
             onChange={(value) => onFilterChange(value as FilterType)}
@@ -102,7 +102,7 @@ export function FilterBar({
           />
         </div>
 
-        <div className="hidden gap-2 md:flex">
+        <div className="hidden gap-2 min-[1200px]:flex">
           {filters.map((filter) => (
             <button
               key={filter.id}
@@ -120,11 +120,11 @@ export function FilterBar({
           ))}
         </div>
 
-        <div className="order-2 md:hidden">{searchField}</div>
+        <div className="order-2 min-[1200px]:hidden">{searchField}</div>
 
-        <div className="order-3 md:hidden">{statusGroup}</div>
+        <div className="order-3 min-[1200px]:hidden">{statusGroup}</div>
 
-        <div className="hidden items-center gap-3 md:flex">
+        <div className="hidden items-center gap-3 min-[1200px]:flex">
           {statusGroup}
           {searchField}
         </div>

--- a/src/features/clip/ui/FilterBar.tsx
+++ b/src/features/clip/ui/FilterBar.tsx
@@ -8,6 +8,7 @@ import {
   HiOutlineSearch,
 } from "react-icons/hi";
 import { ClipType } from "@/features/clip/model/clip";
+import { StyledSelect } from "@/shared/ui/StyledSelect";
 
 export type FilterType = ClipType | "all";
 
@@ -91,17 +92,14 @@ export function FilterBar({
     <div className="border-b border-(--border) px-4 py-4 md:px-6">
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="md:hidden">
-          <select
+          <StyledSelect
             value={activeFilter}
-            onChange={(event) => onFilterChange(event.target.value as FilterType)}
-            className="h-11 w-full rounded-xl border border-(--border) bg-(--surface) px-4 text-sm font-medium text-(--foreground) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none"
-          >
-            {filters.map((filter) => (
-              <option key={filter.id} value={filter.id}>
-                {filter.label}
-              </option>
-            ))}
-          </select>
+            onChange={(value) => onFilterChange(value as FilterType)}
+            options={filters.map((filter) => ({
+              value: filter.id,
+              label: filter.label,
+            }))}
+          />
         </div>
 
         <div className="hidden gap-2 md:flex">

--- a/src/features/clip/ui/FilterBar.tsx
+++ b/src/features/clip/ui/FilterBar.tsx
@@ -50,54 +50,85 @@ export function FilterBar({
     },
   ];
 
-  return (
-    <div className="flex items-center justify-between border-b border-(--border) px-6 py-4">
-      <div className="flex gap-2">
-        {filters.map((filter) => (
-          <button
-            key={filter.id}
-            type="button"
-            onClick={() => onFilterChange(filter.id)}
-            className={`flex cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
-              activeFilter === filter.id
-                ? "bg-(--icon-chip) text-(--icon-chip-text)"
-                : "bg-(--surface) text-(--muted) hover:bg-(--surface-muted)"
+  const searchField = (
+    <div className="relative">
+      <input
+        type="text"
+        placeholder={t("searchPlaceholder")}
+        value={searchQuery}
+        onChange={(event) => onSearchChange?.(event.target.value)}
+        className="text-foreground h-11 w-full rounded-xl border border-(--border) bg-(--input) pr-4 pl-10 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none md:h-9 md:w-64 md:rounded-lg"
+      />
+      <HiOutlineSearch
+        className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-(--muted)"
+        aria-hidden
+      />
+    </div>
+  );
+
+  const statusGroup = (
+    <div className="flex w-full flex-wrap items-center justify-end gap-3 md:w-auto">
+      {showStatus ? (
+        <div className="flex items-center gap-2 text-xs text-(--muted)">
+          <span
+            className={`h-2 w-2 rounded-full ${
+              isActive ? "bg-(--success)" : "bg-(--danger)"
             }`}
-          >
-            {filter.icon}
-            {filter.label}
-          </button>
-        ))}
-      </div>
-      <div className="flex items-center gap-3">
-        {showStatus ? (
-          <div className="flex items-center gap-2 text-xs text-(--muted)">
-            <span
-              className={`h-2 w-2 rounded-full ${
-                isActive ? "bg-(--success)" : "bg-(--danger)"
-              }`}
-              aria-hidden
-            />
-            <span>{isActive ? t("readyToPaste") : t("notActive")}</span>
-          </div>
-        ) : null}
-        {countLabel ? (
-          <span className="rounded-full bg-(--icon-chip) px-2.5 py-1 text-xs font-semibold text-(--icon-chip-text)">
-            {countLabel}
-          </span>
-        ) : null}
-        <div className="relative">
-          <input
-            type="text"
-            placeholder={t("searchPlaceholder")}
-            value={searchQuery}
-            onChange={(event) => onSearchChange?.(event.target.value)}
-            className="text-foreground h-9 w-64 rounded-lg border border-(--border) bg-(--input) pr-4 pl-10 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none"
-          />
-          <HiOutlineSearch
-            className="absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2 text-(--muted)"
             aria-hidden
           />
+          <span>{isActive ? t("readyToPaste") : t("notActive")}</span>
+        </div>
+      ) : null}
+      {countLabel ? (
+        <span className="rounded-full bg-(--icon-chip) px-2.5 py-1 text-xs font-semibold text-(--icon-chip-text)">
+          {countLabel}
+        </span>
+      ) : null}
+    </div>
+  );
+
+  return (
+    <div className="border-b border-(--border) px-4 py-4 md:px-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div className="md:hidden">
+          <select
+            value={activeFilter}
+            onChange={(event) => onFilterChange(event.target.value as FilterType)}
+            className="h-11 w-full rounded-xl border border-(--border) bg-(--surface) px-4 text-sm font-medium text-(--foreground) focus:border-(--focus-ring) focus:ring-1 focus:ring-(--focus-ring) focus:outline-none"
+          >
+            {filters.map((filter) => (
+              <option key={filter.id} value={filter.id}>
+                {filter.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="hidden gap-2 md:flex">
+          {filters.map((filter) => (
+            <button
+              key={filter.id}
+              type="button"
+              onClick={() => onFilterChange(filter.id)}
+              className={`flex cursor-pointer items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+                activeFilter === filter.id
+                  ? "bg-(--icon-chip) text-(--icon-chip-text)"
+                  : "bg-(--surface) text-(--muted) hover:bg-(--surface-muted)"
+              }`}
+            >
+              {filter.icon}
+              {filter.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="order-2 md:hidden">{searchField}</div>
+
+        <div className="order-3 md:hidden">{statusGroup}</div>
+
+        <div className="hidden items-center gap-3 md:flex">
+          {statusGroup}
+          {searchField}
         </div>
       </div>
     </div>

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -56,7 +56,7 @@ export function FolderClipsPage() {
         countLabel={t("count", { count: filteredClips.length })}
       />
       {!isActive ? (
-        <div className="px-6 pt-4">
+        <div className="px-4 pt-4 md:px-6">
           <div className="rounded-2xl border border-(--border) bg-(--surface) px-4 py-3 text-center text-xs text-(--muted)">
             {t("captureHint")}
           </div>

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -22,7 +22,7 @@ export function RecentClipsPage() {
   } = useRecentClipsPage();
 
   return (
-    <div className="bg-background flex h-full flex-col">
+    <div className="bg-background relative flex h-full flex-col">
       <FilterBar
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -368,116 +368,117 @@ export function Sidebar({
           </button>
         </div>
 
-        {isCreateFolderModalOpen ? (
-          <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
-            <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-              <div className="flex items-center border-b border-(--border) px-5 py-4">
-                <button
-                  type="button"
-                  onClick={closeCreateModal}
-                  className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
-                  aria-label={t("closeCreateFolder")}
-                >
-                  <HiX className="h-5 w-5" aria-hidden />
-                </button>
-                <p className="text-foreground ml-auto text-sm font-semibold">
-                  {t("createFolder")}
-                </p>
-              </div>
-              <div className="px-5 py-4">
-                <label className="text-muted block text-xs font-semibold">
-                  {t("folderName")}
-                </label>
-                <input
-                  ref={inputRef}
-                  value={newFolderName}
-                  onChange={(event) => setNewFolderName(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      handleCreateFolder();
-                    } else if (event.key === "Escape") {
-                      closeCreateModal();
-                    }
-                  }}
-                  className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                  placeholder={t("folderNamePlaceholder")}
-                />
-              </div>
-              <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-                <button
-                  type="button"
-                  onClick={closeCreateModal}
-                  className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-                >
-                  {t("cancel")}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleCreateFolder}
-                  className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
-                >
-                  {t("create")}
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : null}
-
-        {isRenameFolderModalOpen ? (
-          <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
-            <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-              <div className="flex items-center border-b border-(--border) px-5 py-4">
-                <button
-                  type="button"
-                  onClick={closeRenameModal}
-                  className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
-                  aria-label={t("closeRenameFolder")}
-                >
-                  <HiX className="h-5 w-5" aria-hidden />
-                </button>
-                <p className="text-foreground ml-auto text-sm font-semibold">
-                  {t("renameFolder")}
-                </p>
-              </div>
-              <div className="px-5 py-4">
-                <label className="block text-xs font-semibold text-(--muted)">
-                  {t("folderName")}
-                </label>
-                <input
-                  ref={renameInputRef}
-                  value={renameFolderName}
-                  onChange={(event) => setRenameFolderName(event.target.value)}
-                  onKeyDown={(event) => {
-                    if (event.key === "Enter") {
-                      handleRenameFolder();
-                    } else if (event.key === "Escape") {
-                      closeRenameModal();
-                    }
-                  }}
-                  className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                  placeholder={t("folderNamePlaceholder")}
-                />
-              </div>
-              <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-                <button
-                  type="button"
-                  onClick={closeRenameModal}
-                  className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-                >
-                  {t("cancel")}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleRenameFolder}
-                  className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
-                >
-                  {t("change")}
-                </button>
-              </div>
-            </div>
-          </div>
-        ) : null}
       </aside>
+
+      {isCreateFolderModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
+          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+            <div className="flex items-center border-b border-(--border) px-5 py-4">
+              <button
+                type="button"
+                onClick={closeCreateModal}
+                className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
+                aria-label={t("closeCreateFolder")}
+              >
+                <HiX className="h-5 w-5" aria-hidden />
+              </button>
+              <p className="text-foreground ml-auto text-sm font-semibold">
+                {t("createFolder")}
+              </p>
+            </div>
+            <div className="px-5 py-4">
+              <label className="text-muted block text-xs font-semibold">
+                {t("folderName")}
+              </label>
+              <input
+                ref={inputRef}
+                value={newFolderName}
+                onChange={(event) => setNewFolderName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    handleCreateFolder();
+                  } else if (event.key === "Escape") {
+                    closeCreateModal();
+                  }
+                }}
+                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+                placeholder={t("folderNamePlaceholder")}
+              />
+            </div>
+            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+              <button
+                type="button"
+                onClick={closeCreateModal}
+                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+              >
+                {t("cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleCreateFolder}
+                className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
+              >
+                {t("create")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      {isRenameFolderModalOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
+          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+            <div className="flex items-center border-b border-(--border) px-5 py-4">
+              <button
+                type="button"
+                onClick={closeRenameModal}
+                className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
+                aria-label={t("closeRenameFolder")}
+              >
+                <HiX className="h-5 w-5" aria-hidden />
+              </button>
+              <p className="text-foreground ml-auto text-sm font-semibold">
+                {t("renameFolder")}
+              </p>
+            </div>
+            <div className="px-5 py-4">
+              <label className="block text-xs font-semibold text-(--muted)">
+                {t("folderName")}
+              </label>
+              <input
+                ref={renameInputRef}
+                value={renameFolderName}
+                onChange={(event) => setRenameFolderName(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === "Enter") {
+                    handleRenameFolder();
+                  } else if (event.key === "Escape") {
+                    closeRenameModal();
+                  }
+                }}
+                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+                placeholder={t("folderNamePlaceholder")}
+              />
+            </div>
+            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+              <button
+                type="button"
+                onClick={closeRenameModal}
+                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+              >
+                {t("cancel")}
+              </button>
+              <button
+                type="button"
+                onClick={handleRenameFolder}
+                className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
+              >
+                {t("change")}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </>
   );
 }

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -281,7 +281,10 @@ export function Sidebar({
                         aria-label={t("openFolderOptions")}
                         data-folder-options
                       >
-                        <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
+                        <HiOutlineDotsVertical
+                          className="h-4 w-4"
+                          aria-hidden
+                        />
                       </button>
                     </div>
                     {openOptionsFolderId === folder.id ? (
@@ -365,115 +368,115 @@ export function Sidebar({
           </button>
         </div>
 
-      {isCreateFolderModalOpen ? (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="flex items-center border-b border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeCreateModal}
-                className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
-                aria-label={t("closeCreateFolder")}
-              >
-                <HiX className="h-5 w-5" aria-hidden />
-              </button>
-              <p className="text-foreground ml-auto text-sm font-semibold">
-                {t("createFolder")}
-              </p>
-            </div>
-            <div className="px-5 py-4">
-              <label className="text-muted block text-xs font-semibold">
-                {t("folderName")}
-              </label>
-              <input
-                ref={inputRef}
-                value={newFolderName}
-                onChange={(event) => setNewFolderName(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    handleCreateFolder();
-                  } else if (event.key === "Escape") {
-                    closeCreateModal();
-                  }
-                }}
-                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder={t("folderNamePlaceholder")}
-              />
-            </div>
-            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeCreateModal}
-                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleCreateFolder}
-                className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
-              >
-                {t("create")}
-              </button>
+        {isCreateFolderModalOpen ? (
+          <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
+            <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+              <div className="flex items-center border-b border-(--border) px-5 py-4">
+                <button
+                  type="button"
+                  onClick={closeCreateModal}
+                  className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
+                  aria-label={t("closeCreateFolder")}
+                >
+                  <HiX className="h-5 w-5" aria-hidden />
+                </button>
+                <p className="text-foreground ml-auto text-sm font-semibold">
+                  {t("createFolder")}
+                </p>
+              </div>
+              <div className="px-5 py-4">
+                <label className="text-muted block text-xs font-semibold">
+                  {t("folderName")}
+                </label>
+                <input
+                  ref={inputRef}
+                  value={newFolderName}
+                  onChange={(event) => setNewFolderName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleCreateFolder();
+                    } else if (event.key === "Escape") {
+                      closeCreateModal();
+                    }
+                  }}
+                  className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+                  placeholder={t("folderNamePlaceholder")}
+                />
+              </div>
+              <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+                <button
+                  type="button"
+                  onClick={closeCreateModal}
+                  className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+                >
+                  {t("cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCreateFolder}
+                  className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
+                >
+                  {t("create")}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
+        ) : null}
 
-      {isRenameFolderModalOpen ? (
-        <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="flex items-center border-b border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeRenameModal}
-                className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
-                aria-label={t("closeRenameFolder")}
-              >
-                <HiX className="h-5 w-5" aria-hidden />
-              </button>
-              <p className="text-foreground ml-auto text-sm font-semibold">
-                {t("renameFolder")}
-              </p>
-            </div>
-            <div className="px-5 py-4">
-              <label className="block text-xs font-semibold text-(--muted)">
-                {t("folderName")}
-              </label>
-              <input
-                ref={renameInputRef}
-                value={renameFolderName}
-                onChange={(event) => setRenameFolderName(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    handleRenameFolder();
-                  } else if (event.key === "Escape") {
-                    closeRenameModal();
-                  }
-                }}
-                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder={t("folderNamePlaceholder")}
-              />
-            </div>
-            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeRenameModal}
-                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleRenameFolder}
-                className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
-              >
-                {t("change")}
-              </button>
+        {isRenameFolderModalOpen ? (
+          <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
+            <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+              <div className="flex items-center border-b border-(--border) px-5 py-4">
+                <button
+                  type="button"
+                  onClick={closeRenameModal}
+                  className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
+                  aria-label={t("closeRenameFolder")}
+                >
+                  <HiX className="h-5 w-5" aria-hidden />
+                </button>
+                <p className="text-foreground ml-auto text-sm font-semibold">
+                  {t("renameFolder")}
+                </p>
+              </div>
+              <div className="px-5 py-4">
+                <label className="block text-xs font-semibold text-(--muted)">
+                  {t("folderName")}
+                </label>
+                <input
+                  ref={renameInputRef}
+                  value={renameFolderName}
+                  onChange={(event) => setRenameFolderName(event.target.value)}
+                  onKeyDown={(event) => {
+                    if (event.key === "Enter") {
+                      handleRenameFolder();
+                    } else if (event.key === "Escape") {
+                      closeRenameModal();
+                    }
+                  }}
+                  className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+                  placeholder={t("folderNamePlaceholder")}
+                />
+              </div>
+              <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+                <button
+                  type="button"
+                  onClick={closeRenameModal}
+                  className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+                >
+                  {t("cancel")}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleRenameFolder}
+                  className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
+                >
+                  {t("change")}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      ) : null}
+        ) : null}
       </aside>
     </>
   );

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -22,9 +22,15 @@ import { useFolders } from "@/features/folder/hooks/useFolders";
 
 interface SidebarProps {
   onOpenSettings: () => void;
+  isMobileOpen?: boolean;
+  onCloseMobile?: () => void;
 }
 
-export function Sidebar({ onOpenSettings }: SidebarProps) {
+export function Sidebar({
+  onOpenSettings,
+  isMobileOpen = false,
+  onCloseMobile,
+}: SidebarProps) {
   const t = useTranslations("sidebar");
   const pathname = usePathname();
   const { folders, persistFolders } = useFolders();
@@ -82,6 +88,10 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
     window.addEventListener("pointerdown", handlePointerDown);
     return () => window.removeEventListener("pointerdown", handlePointerDown);
   }, [openOptionsFolderId]);
+
+  useEffect(() => {
+    onCloseMobile?.();
+  }, [onCloseMobile, pathname]);
 
   const reorderFolders = useCallback(
     (sourceId: string, targetId: string) => {
@@ -148,180 +158,212 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
   }, [folders, persistFolders, renameFolderId, renameFolderName]);
 
   return (
-    <aside className="flex h-screen w-64 flex-col border-r border-(--border) bg-(--surface-muted)">
-      <div className="border-b border-(--border) px-4 py-5">
-        <div className="flex items-center gap-2">
-          <HiOutlinePaperClip className="h-5 w-5" aria-hidden />
-          <h1 className="text-foreground text-xl font-semibold">Easy Clip</h1>
-        </div>
-      </div>
+    <>
+      {isMobileOpen ? (
+        <button
+          type="button"
+          onClick={onCloseMobile}
+          className="fixed inset-0 z-30 bg-(--overlay) md:hidden"
+          aria-label="사이드바 닫기"
+        />
+      ) : null}
 
-      <nav className="flex-1 py-4">
-        <div className="space-y-6">
-          <ul className="space-y-2 px-2">
-            {topNavs.map((nav) => (
-              <li key={nav.href}>
-                <Link
-                  href={nav.href}
-                  className={`flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
-                    pathname === nav.href
-                      ? "text-foreground bg-(--surface)"
-                      : "text-muted hover:text-foreground hover:bg-(--surface)"
-                  }`}
-                >
-                  {nav.icon}
-                  {nav.label}
-                </Link>
-              </li>
-            ))}
-          </ul>
-
-          <div className="space-y-2 border-t border-(--border) pt-4">
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex h-screen w-72 max-w-[86vw] flex-col border-r border-(--border) bg-(--surface-muted) transition-transform duration-300 md:static md:z-auto md:w-64 md:max-w-none ${
+          isMobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        }`}
+      >
+        <div className="border-b border-(--border) px-4 py-5">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <HiOutlinePaperClip className="h-5 w-5" aria-hidden />
+              <h1 className="text-foreground text-xl font-semibold">
+                Easy Clip
+              </h1>
+            </div>
             <button
               type="button"
-              onClick={() => {
-                setNewFolderName("");
-                setIsCreateFolderModalOpen(true);
-              }}
-              className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
+              onClick={onCloseMobile}
+              className="flex h-9 w-9 items-center justify-center rounded-full text-(--muted) transition hover:bg-(--surface) hover:text-(--foreground) md:hidden"
+              aria-label="사이드바 닫기"
             >
-              <HiOutlinePlus className="h-5 w-5" aria-hidden />
-              {t("addFolder")}
+              <HiX className="h-5 w-5" aria-hidden />
             </button>
-            <ul className="space-y-1 px-2">
-              {folders.map((folder) => (
-                <li
-                  key={folder.id}
-                  onDragOver={(event) => {
-                    event.preventDefault();
-                    event.dataTransfer.dropEffect = "move";
-                    if (!draggingFolderId || draggingFolderId === folder.id) {
-                      return;
-                    }
-                    reorderFolders(draggingFolderId, folder.id);
-                  }}
-                  className={`relative rounded-lg ${
-                    draggingFolderId === folder.id ? "opacity-50" : ""
-                  }`}
-                >
-                  <div
-                    className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
-                      pathname === `/${folder.id}`
+          </div>
+        </div>
+
+        <nav className="flex-1 py-4">
+          <div className="space-y-6">
+            <ul className="space-y-2 px-2">
+              {topNavs.map((nav) => (
+                <li key={nav.href}>
+                  <Link
+                    href={nav.href}
+                    onClick={onCloseMobile}
+                    className={`flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
+                      pathname === nav.href
                         ? "text-foreground bg-(--surface)"
                         : "text-muted hover:text-foreground hover:bg-(--surface)"
                     }`}
                   >
-                    <button
-                      type="button"
-                      draggable
-                      onDragStart={(event) => {
-                        setDraggingFolderId(folder.id);
-                        event.dataTransfer.effectAllowed = "move";
-                        event.dataTransfer.setData("text/plain", folder.id);
-                      }}
-                      onDragEnd={() => setDraggingFolderId(null)}
-                      className="text-muted hover:text-foreground cursor-grab rounded p-1"
-                      aria-label={t("reorderFolder")}
-                    >
-                      <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
-                    </button>
-                    <Link
-                      href={`/${folder.id}`}
-                      className="flex flex-1 items-center gap-2 truncate"
-                    >
-                      <HiOutlineFolder className="h-5 w-5" aria-hidden />
-                      <span className="truncate">{folder.name}</span>
-                    </Link>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        setOpenOptionsFolderId((previous) =>
-                          previous === folder.id ? null : folder.id,
-                        )
-                      }
-                      className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
-                      aria-label={t("openFolderOptions")}
-                      data-folder-options
-                    >
-                      <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
-                    </button>
-                  </div>
-                  {openOptionsFolderId === folder.id ? (
-                    <div className="relative">
-                      <div
-                        className="absolute right-0 z-20 w-32 overflow-hidden rounded-lg border border-(--border) bg-(--surface) shadow-lg"
-                        data-folder-options
-                      >
-                        <button
-                          type="button"
-                          onClick={() => {
-                            setOpenOptionsFolderId(null);
-                            setRenameFolderId(folder.id);
-                            setRenameFolderName(folder.name);
-                            setIsRenameFolderModalOpen(true);
-                          }}
-                          className="text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-(--surface-muted)"
-                        >
-                          <HiOutlinePencil className="h-4 w-4" aria-hidden />
-                          {t("rename")}
-                        </button>
-                        <button
-                          type="button"
-                          onClick={() => {
-                            persistFolders(
-                              folders.filter(
-                                (currentFolder) =>
-                                  currentFolder.id !== folder.id,
-                              ),
-                            );
-                            setOpenOptionsFolderId(null);
-                          }}
-                          className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-(--danger) hover:bg-(--surface-muted)"
-                        >
-                          <HiOutlineTrash className="h-4 w-4" aria-hidden />
-                          {t("delete")}
-                        </button>
-                      </div>
-                    </div>
-                  ) : null}
+                    {nav.icon}
+                    {nav.label}
+                  </Link>
                 </li>
               ))}
             </ul>
-          </div>
-        </div>
-      </nav>
 
-      <div className="border-t border-(--border) px-4 py-4">
-        <div className="mb-3 flex items-center justify-between rounded-lg bg-(--surface) px-3 py-2">
-          <div className="flex items-center gap-2 truncate">
-            <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--icon-chip) text-[10px] font-semibold text-(--icon-chip-text)">
-              EC
+            <div className="space-y-2 border-t border-(--border) pt-4">
+              <button
+                type="button"
+                onClick={() => {
+                  setNewFolderName("");
+                  setIsCreateFolderModalOpen(true);
+                }}
+                className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
+              >
+                <HiOutlinePlus className="h-5 w-5" aria-hidden />
+                {t("addFolder")}
+              </button>
+              <ul className="space-y-1 px-2">
+                {folders.map((folder) => (
+                  <li
+                    key={folder.id}
+                    onDragOver={(event) => {
+                      event.preventDefault();
+                      event.dataTransfer.dropEffect = "move";
+                      if (!draggingFolderId || draggingFolderId === folder.id) {
+                        return;
+                      }
+                      reorderFolders(draggingFolderId, folder.id);
+                    }}
+                    className={`relative rounded-lg ${
+                      draggingFolderId === folder.id ? "opacity-50" : ""
+                    }`}
+                  >
+                    <div
+                      className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
+                        pathname === `/${folder.id}`
+                          ? "text-foreground bg-(--surface)"
+                          : "text-muted hover:text-foreground hover:bg-(--surface)"
+                      }`}
+                    >
+                      <button
+                        type="button"
+                        draggable
+                        onDragStart={(event) => {
+                          setDraggingFolderId(folder.id);
+                          event.dataTransfer.effectAllowed = "move";
+                          event.dataTransfer.setData("text/plain", folder.id);
+                        }}
+                        onDragEnd={() => setDraggingFolderId(null)}
+                        className="text-muted hover:text-foreground cursor-grab rounded p-1"
+                        aria-label={t("reorderFolder")}
+                      >
+                        <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
+                      </button>
+                      <Link
+                        href={`/${folder.id}`}
+                        onClick={onCloseMobile}
+                        className="flex flex-1 items-center gap-2 truncate"
+                      >
+                        <HiOutlineFolder className="h-5 w-5" aria-hidden />
+                        <span className="truncate">{folder.name}</span>
+                      </Link>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setOpenOptionsFolderId((previous) =>
+                            previous === folder.id ? null : folder.id,
+                          )
+                        }
+                        className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
+                        aria-label={t("openFolderOptions")}
+                        data-folder-options
+                      >
+                        <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
+                      </button>
+                    </div>
+                    {openOptionsFolderId === folder.id ? (
+                      <div className="relative">
+                        <div
+                          className="absolute right-0 z-20 w-32 overflow-hidden rounded-lg border border-(--border) bg-(--surface) shadow-lg"
+                          data-folder-options
+                        >
+                          <button
+                            type="button"
+                            onClick={() => {
+                              setOpenOptionsFolderId(null);
+                              setRenameFolderId(folder.id);
+                              setRenameFolderName(folder.name);
+                              setIsRenameFolderModalOpen(true);
+                            }}
+                            className="text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-(--surface-muted)"
+                          >
+                            <HiOutlinePencil className="h-4 w-4" aria-hidden />
+                            {t("rename")}
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              persistFolders(
+                                folders.filter(
+                                  (currentFolder) =>
+                                    currentFolder.id !== folder.id,
+                                ),
+                              );
+                              setOpenOptionsFolderId(null);
+                            }}
+                            className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-(--danger) hover:bg-(--surface-muted)"
+                          >
+                            <HiOutlineTrash className="h-4 w-4" aria-hidden />
+                            {t("delete")}
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
             </div>
-            <span className="text-foreground truncate text-sm font-medium">
-              user@example.com
-            </span>
           </div>
+        </nav>
+
+        <div className="border-t border-(--border) px-4 py-4">
+          <div className="mb-3 flex items-center justify-between rounded-lg bg-(--surface) px-3 py-2">
+            <div className="flex items-center gap-2 truncate">
+              <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--icon-chip) text-[10px] font-semibold text-(--icon-chip-text)">
+                EC
+              </div>
+              <span className="text-foreground truncate text-sm font-medium">
+                user@example.com
+              </span>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                onCloseMobile?.();
+                window.location.href = "/login";
+              }}
+              className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition-colors"
+              aria-label={t("logout")}
+            >
+              <HiOutlineLogout className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+
           <button
             type="button"
             onClick={() => {
-              window.location.href = "/login";
+              onCloseMobile?.();
+              onOpenSettings();
             }}
-            className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition-colors"
-            aria-label={t("logout")}
+            className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
           >
-            <HiOutlineLogout className="h-4 w-4" aria-hidden />
+            <HiOutlineCog className="h-5 w-5" aria-hidden />
+            {t("settings")}
           </button>
         </div>
-
-        <button
-          type="button"
-          onClick={onOpenSettings}
-          className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
-        >
-          <HiOutlineCog className="h-5 w-5" aria-hidden />
-          {t("settings")}
-        </button>
-      </div>
 
       {isCreateFolderModalOpen ? (
         <div className="fixed inset-0 z-40 flex items-center justify-center bg-(--overlay) px-4">
@@ -432,6 +474,7 @@ export function Sidebar({ onOpenSettings }: SidebarProps) {
           </div>
         </div>
       ) : null}
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/src/shared/ui/AppShell.tsx
+++ b/src/shared/ui/AppShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useState } from "react";
+import { HiOutlineMenuAlt4, HiOutlinePaperClip } from "react-icons/hi";
 import { Sidebar } from "@/features/folder/ui/Sidebar";
 import { SettingsModal } from "@/shared/ui/SettingsModal";
 
@@ -10,15 +11,46 @@ interface AppShellProps {
 
 export function AppShell({ children }: AppShellProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const openSidebar = useCallback(() => setIsSidebarOpen(true), []);
+  const closeSidebar = useCallback(() => setIsSidebarOpen(false), []);
+  const openSettings = useCallback(() => setIsSettingsOpen(true), []);
+  const closeSettings = useCallback(() => setIsSettingsOpen(false), []);
 
   return (
     <div className="bg-background text-foreground flex h-screen flex-col overflow-hidden">
+      <header className="bg-background border-b border-(--border) md:hidden">
+        <div className="flex items-center justify-between px-4 py-3">
+          <button
+            type="button"
+            onClick={openSidebar}
+            className="flex h-10 w-10 items-center justify-center rounded-full text-(--muted) transition hover:bg-(--surface-muted) hover:text-(--foreground)"
+            aria-label="사이드바 열기"
+          >
+            <HiOutlineMenuAlt4 className="h-5 w-5" aria-hidden />
+          </button>
+
+          <div className="flex items-center gap-2">
+            <HiOutlinePaperClip className="h-5 w-5" aria-hidden />
+            <span className="text-sm font-semibold">Easy Clip</span>
+          </div>
+
+          <div className="h-10 w-10" aria-hidden />
+        </div>
+      </header>
+
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar onOpenSettings={() => setIsSettingsOpen(true)} />
-        <main className="bg-background flex-1 overflow-hidden">{children}</main>
+        <Sidebar
+          onOpenSettings={openSettings}
+          isMobileOpen={isSidebarOpen}
+          onCloseMobile={closeSidebar}
+        />
+        <main className="bg-background min-w-0 flex-1 overflow-hidden">
+          {children}
+        </main>
       </div>
       {isSettingsOpen ? (
-        <SettingsModal onClose={() => setIsSettingsOpen(false)} />
+        <SettingsModal onClose={closeSettings} />
       ) : null}
     </div>
   );

--- a/src/shared/ui/SettingsModal.tsx
+++ b/src/shared/ui/SettingsModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-icons/hi";
 import { LOCALE_LABELS, type AppLocale } from "@/shared/config/locale";
 import { useSettingsStore } from "@/shared/store/settingsStore";
+import { StyledSelect } from "@/shared/ui/StyledSelect";
 
 interface SettingsModalProps {
   onClose: () => void;
@@ -98,19 +99,17 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
                   </p>
                 </div>
               </div>
-              <select
+              <StyledSelect
                 value={language}
-                onChange={(event) => {
-                  setLanguage(event.target.value as AppLocale);
+                onChange={(value) => {
+                  setLanguage(value as AppLocale);
                 }}
-                className="cursor-pointer rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm text-(--foreground) focus:border-(--focus-ring) focus:outline-none"
-              >
-                {Object.entries(LOCALE_LABELS).map(([value, label]) => (
-                  <option key={value} value={value}>
-                    {label}
-                  </option>
-                ))}
-              </select>
+                options={Object.entries(LOCALE_LABELS).map(([value, label]) => ({
+                  value,
+                  label,
+                }))}
+                className="min-w-36"
+              />
             </div>
           </div>
 

--- a/src/shared/ui/StyledSelect.tsx
+++ b/src/shared/ui/StyledSelect.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { HiCheck, HiChevronDown } from "react-icons/hi";
+
+interface StyledSelectOption {
+  value: string;
+  label: string;
+}
+
+interface StyledSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  options: readonly StyledSelectOption[];
+  className?: string;
+}
+
+export function StyledSelect({
+  value,
+  onChange,
+  options,
+  className = "",
+}: StyledSelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const selectedOption =
+    options.find((option) => option.value === value) ?? options[0];
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const handlePointerDown = (event: MouseEvent) => {
+      const target = event.target as Node | null;
+      if (!target || rootRef.current?.contains(target)) {
+        return;
+      }
+
+      setIsOpen(false);
+    };
+
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("pointerdown", handlePointerDown);
+    window.addEventListener("keydown", handleEscape);
+    return () => {
+      window.removeEventListener("pointerdown", handlePointerDown);
+      window.removeEventListener("keydown", handleEscape);
+    };
+  }, [isOpen]);
+
+  return (
+    <div ref={rootRef} className={`relative ${className}`}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((previous) => !previous)}
+        className="text-foreground flex h-11 w-full items-center justify-between rounded-xl border border-(--border) bg-(--surface) px-4 text-sm font-medium transition-colors hover:bg-(--surface-muted)"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        <span className="truncate">{selectedOption?.label}</span>
+        <HiChevronDown
+          className={`h-4 w-4 shrink-0 text-(--muted) transition-transform ${
+            isOpen ? "rotate-180" : ""
+          }`}
+          aria-hidden
+        />
+      </button>
+
+      {isOpen ? (
+        <div className="absolute top-[calc(100%+0.5rem)] left-0 z-50 w-full overflow-hidden rounded-2xl border border-(--border) bg-(--surface-elevated) shadow-[0_18px_40px_rgba(15,23,42,0.16)]">
+          <ul className="py-2" role="listbox">
+            {options.map((option) => {
+              const isSelected = option.value === value;
+
+              return (
+                <li key={option.value}>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onChange(option.value);
+                      setIsOpen(false);
+                    }}
+                    className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors ${
+                      isSelected
+                        ? "bg-(--surface-muted) text-(--foreground)"
+                        : "text-(--muted) hover:bg-(--surface-muted) hover:text-(--foreground)"
+                    }`}
+                    role="option"
+                    aria-selected={isSelected}
+                  >
+                    <span className="truncate font-medium">{option.label}</span>
+                    <span
+                      className={`flex h-5 w-5 items-center justify-center rounded-full ${
+                        isSelected
+                          ? "bg-(--icon-chip) text-(--icon-chip-text)"
+                          : "text-transparent"
+                      }`}
+                    >
+                      <HiCheck className="h-3.5 w-3.5" aria-hidden />
+                    </span>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
## PR 요약

- 메인 클립 화면의 모바일 반응형 UI를 중심으로 레이아웃과 필터/사이드바 사용성을 개선합니다.

## 변경 내용 상세

### 변경 사항

- 모바일에서 좌측 사이드바를 슬라이드 패널 방식으로 전환하고 상단 헤더에서 열 수 있도록 정리했습니다.
- 필터바를 모바일/데스크톱 기준으로 재구성하고, 모바일에서는 드롭다운 + 검색창 + 상태 영역 순서로 정리했습니다.
- 클립 그리드 개수와 여백을 반응형 기준에 맞게 조정하고, 폴더 추가 모달이 화면 중앙에 뜨도록 수정했습니다.

### 변경 이유

- 로그인 이후 핵심 사용 화면이 모바일에서도 자연스럽게 동작하도록 반응형 사용성을 먼저 확보하기 위해서입니다.

## 관련 이슈

- Closes #28

## 기타 참고사항

- `npm run lint`: 통과
- `npm run build`: 통과