### PR TITLE
#31 / refactor(clips) : 도메인 페이지 UI 조립 구조 정리

### DIFF
--- a/src/features/auth/ui/LoginAgreementNotice.tsx
+++ b/src/features/auth/ui/LoginAgreementNotice.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+interface LoginAgreementNoticeProps {
+  prefix: string;
+  middle: string;
+  suffix: string;
+  termsLabel: string;
+  privacyLabel: string;
+}
+
+export function LoginAgreementNotice({
+  prefix,
+  middle,
+  suffix,
+  termsLabel,
+  privacyLabel,
+}: LoginAgreementNoticeProps) {
+  return (
+    <p className="mt-8 text-center text-xs text-(--muted)">
+      {prefix}{" "}
+      <a href="#" className="underline hover:text-(--foreground)">
+        {termsLabel}
+      </a>{" "}
+      {middle}{" "}
+      <a href="#" className="underline hover:text-(--foreground)">
+        {privacyLabel}
+      </a>
+      {suffix}
+    </p>
+  );
+}

--- a/src/features/auth/ui/LoginBrandPanel.tsx
+++ b/src/features/auth/ui/LoginBrandPanel.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { HiOutlineClipboardCopy } from "react-icons/hi";
+
+interface LoginBrandPanelProps {
+  title: string;
+  subtitle: string;
+}
+
+export function LoginBrandPanel({
+  title,
+  subtitle,
+}: LoginBrandPanelProps) {
+  return (
+    <div className="mb-8 flex flex-col items-center">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-(--primary)">
+        <HiOutlineClipboardCopy className="h-6 w-6 text-primary-foreground" />
+      </div>
+      <h1 className="text-xl font-semibold text-(--foreground)">{title}</h1>
+      <p className="mt-2 text-center text-sm text-(--muted)">{subtitle}</p>
+    </div>
+  );
+}

--- a/src/features/auth/ui/LoginLoadingState.tsx
+++ b/src/features/auth/ui/LoginLoadingState.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+interface LoginLoadingStateProps {
+  label: string;
+  isVisible: boolean;
+}
+
+export function LoginLoadingState({
+  label,
+  isVisible,
+}: LoginLoadingStateProps) {
+  if (!isVisible) {
+    return null;
+  }
+
+  return (
+    <div className="mt-6 flex items-center justify-center gap-2 text-sm text-(--muted)">
+      <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+        <circle
+          className="opacity-25"
+          cx="12"
+          cy="12"
+          r="10"
+          stroke="currentColor"
+          strokeWidth="4"
+        />
+        <path
+          className="opacity-75"
+          fill="currentColor"
+          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+        />
+      </svg>
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/src/features/auth/ui/LoginPage.tsx
+++ b/src/features/auth/ui/LoginPage.tsx
@@ -4,76 +4,10 @@ import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
-import { HiOutlineClipboardCopy } from "react-icons/hi";
-
-interface SocialButtonProps {
-  provider: "google" | "github";
-  onClick: () => void;
-  isLoading: boolean;
-}
-
-const GoogleIcon = () => (
-  <svg className="h-5 w-5" viewBox="0 0 24 24">
-    <path
-      fill="#4285F4"
-      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-    />
-    <path
-      fill="#34A853"
-      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-    />
-    <path
-      fill="#FBBC05"
-      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-    />
-    <path
-      fill="#EA4335"
-      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-    />
-  </svg>
-);
-
-const GithubIcon = () => (
-  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-    />
-  </svg>
-);
-
-function SocialButton({ provider, onClick, isLoading }: SocialButtonProps) {
-  const t = useTranslations("login");
-  const config = {
-    google: {
-      label: t("continueWithGoogle"),
-      icon: <GoogleIcon />,
-      className:
-        "border border-(--border) bg-(--surface) text-(--foreground) hover:bg-(--surface-muted)",
-    },
-    github: {
-      label: t("continueWithGithub"),
-      icon: <GithubIcon />,
-      className:
-        "border border-(--border) bg-(--surface) text-(--foreground) hover:bg-(--surface-muted)",
-    },
-  };
-
-  const { className, icon, label } = config[provider];
-
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={isLoading}
-      className={`flex w-full items-center justify-center gap-3 rounded-lg border px-4 py-3 text-sm font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
-    >
-      {icon}
-      <span>{label}</span>
-    </button>
-  );
-}
+import { LoginAgreementNotice } from "@/features/auth/ui/LoginAgreementNotice";
+import { LoginBrandPanel } from "@/features/auth/ui/LoginBrandPanel";
+import { LoginLoadingState } from "@/features/auth/ui/LoginLoadingState";
+import { LoginSocialActions } from "@/features/auth/ui/LoginSocialActions";
 
 export function LoginPage() {
   const t = useTranslations("login");
@@ -93,53 +27,15 @@ export function LoginPage() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center bg-(--background) px-4">
       <div className="w-full max-w-sm">
-        <div className="mb-8 flex flex-col items-center">
-          <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-(--primary)">
-            <HiOutlineClipboardCopy className="h-6 w-6 text-primary-foreground" />
-          </div>
-          <h1 className="text-xl font-semibold text-(--foreground)">{t("title")}</h1>
-          <p className="mt-2 text-center text-sm text-(--muted)">
-            {t("subtitle")}
-          </p>
-        </div>
+        <LoginBrandPanel title={t("title")} subtitle={t("subtitle")} />
 
-        <div className="space-y-3">
-          <SocialButton
-            provider="google"
-            onClick={() => handleLogin("google")}
-            isLoading={isLoading && loadingProvider === "google"}
-          />
-          <SocialButton
-            provider="github"
-            onClick={() => handleLogin("github")}
-            isLoading={isLoading && loadingProvider === "github"}
-          />
-        </div>
+        <LoginSocialActions
+          isLoading={isLoading}
+          loadingProvider={loadingProvider}
+          onLogin={handleLogin}
+        />
 
-        {isLoading ? (
-          <div className="mt-6 flex items-center justify-center gap-2 text-sm text-(--muted)">
-            <svg
-              className="h-4 w-4 animate-spin"
-              fill="none"
-              viewBox="0 0 24 24"
-            >
-              <circle
-                className="opacity-25"
-                cx="12"
-                cy="12"
-                r="10"
-                stroke="currentColor"
-                strokeWidth="4"
-              />
-              <path
-                className="opacity-75"
-                fill="currentColor"
-                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-              />
-            </svg>
-            <span>{t("loading")}</span>
-          </div>
-        ) : null}
+        <LoginLoadingState label={t("loading")} isVisible={isLoading} />
 
         <div className="my-8 flex items-center gap-4">
           <div className="h-px flex-1 bg-(--border)" />
@@ -154,17 +50,13 @@ export function LoginPage() {
           {t("backHome")}
         </Link>
 
-        <p className="mt-8 text-center text-xs text-(--muted)">
-          {t("agreementPrefix")}{" "}
-          <a href="#" className="underline hover:text-(--foreground)">
-            {t("terms")}
-          </a>{" "}
-          {t("agreementMiddle")}{" "}
-          <a href="#" className="underline hover:text-(--foreground)">
-            {t("privacy")}
-          </a>
-          {t("agreementSuffix")}
-        </p>
+        <LoginAgreementNotice
+          prefix={t("agreementPrefix")}
+          middle={t("agreementMiddle")}
+          suffix={t("agreementSuffix")}
+          termsLabel={t("terms")}
+          privacyLabel={t("privacy")}
+        />
       </div>
     </main>
   );

--- a/src/features/auth/ui/LoginSocialActions.tsx
+++ b/src/features/auth/ui/LoginSocialActions.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { SocialLoginButton } from "@/features/auth/ui/SocialLoginButton";
+
+interface LoginSocialActionsProps {
+  isLoading: boolean;
+  loadingProvider: "google" | "github" | null;
+  onLogin: (provider: "google" | "github") => void;
+}
+
+const GoogleIcon = () => (
+  <svg className="h-5 w-5" viewBox="0 0 24 24">
+    <path
+      fill="#4285F4"
+      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
+    />
+    <path
+      fill="#34A853"
+      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+    />
+  </svg>
+);
+
+const GithubIcon = () => (
+  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
+    />
+  </svg>
+);
+
+export function LoginSocialActions({
+  isLoading,
+  loadingProvider,
+  onLogin,
+}: LoginSocialActionsProps) {
+  const t = useTranslations("login");
+
+  return (
+    <div className="space-y-3">
+      <SocialLoginButton
+        label={t("continueWithGoogle")}
+        icon={<GoogleIcon />}
+        onClick={() => onLogin("google")}
+        isLoading={isLoading && loadingProvider === "google"}
+      />
+      <SocialLoginButton
+        label={t("continueWithGithub")}
+        icon={<GithubIcon />}
+        onClick={() => onLogin("github")}
+        isLoading={isLoading && loadingProvider === "github"}
+      />
+    </div>
+  );
+}

--- a/src/features/auth/ui/SocialLoginButton.tsx
+++ b/src/features/auth/ui/SocialLoginButton.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+interface SocialLoginButtonProps {
+  label: string;
+  icon: React.ReactNode;
+  onClick: () => void;
+  isLoading: boolean;
+}
+
+export function SocialLoginButton({
+  label,
+  icon,
+  onClick,
+  isLoading,
+}: SocialLoginButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={isLoading}
+      className="flex w-full items-center justify-center gap-3 rounded-lg border border-(--border) bg-(--surface) px-4 py-3 text-sm font-medium text-(--foreground) transition-colors hover:bg-(--surface-muted) disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}

--- a/src/features/clip/ui/ClipContextMenu.tsx
+++ b/src/features/clip/ui/ClipContextMenu.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Clip } from "@/features/clip/model/clip";
+
+interface ClipContextMenuProps {
+  clips: Clip[];
+  contextMenu: {
+    id: string;
+    x: number;
+    y: number;
+  } | null;
+  copyLabel: string;
+  renameLabel: string;
+  deleteLabel: string;
+  onCopy: (clip: Clip) => void;
+  onRename: (clip: Clip) => void;
+  onDelete: (clipId: string) => void;
+}
+
+export function ClipContextMenu({
+  clips,
+  contextMenu,
+  copyLabel,
+  renameLabel,
+  deleteLabel,
+  onCopy,
+  onRename,
+  onDelete,
+}: ClipContextMenuProps) {
+  if (!contextMenu) {
+    return null;
+  }
+
+  const targetClip = clips.find((clip) => clip.id === contextMenu.id);
+  if (!targetClip) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed z-50 w-36 rounded-lg border border-(--border) bg-(--surface) p-1 text-xs text-(--muted) shadow-lg"
+      style={{ left: contextMenu.x, top: contextMenu.y }}
+      data-clip-menu
+    >
+      <button
+        type="button"
+        onClick={() => onCopy(targetClip)}
+        className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
+        data-clip-menu
+      >
+        {copyLabel}
+      </button>
+      <button
+        type="button"
+        onClick={() => onRename(targetClip)}
+        className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
+        data-clip-menu
+      >
+        {renameLabel}
+      </button>
+      <button
+        type="button"
+        onClick={() => onDelete(targetClip.id)}
+        className="flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--danger) hover:bg-(--surface-muted)"
+        data-clip-menu
+      >
+        {deleteLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/features/clip/ui/ClipCopyToast.tsx
+++ b/src/features/clip/ui/ClipCopyToast.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+interface ClipCopyToastProps {
+  label: string;
+  position: {
+    x: number;
+    y: number;
+  } | null;
+}
+
+export function ClipCopyToast({ label, position }: ClipCopyToastProps) {
+  if (!position) {
+    return null;
+  }
+
+  return (
+    <div
+      className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
+      style={{ left: position.x + 12, top: position.y + 12 }}
+    >
+      {label}
+    </div>
+  );
+}

--- a/src/features/clip/ui/ClipResultsSection.tsx
+++ b/src/features/clip/ui/ClipResultsSection.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { Clip } from "@/features/clip/model/clip";
+import { ClipList } from "@/features/clip/ui/ClipList";
+import { EmptyState } from "@/features/clip/ui/EmptyState";
+
+interface ClipResultsSectionProps {
+  clips: Clip[];
+  onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
+  onToggleFavorite?: (clip: Clip) => void;
+  onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
+}
+
+export function ClipResultsSection({
+  clips,
+  onCopy,
+  onToggleFavorite,
+  onContextMenu,
+}: ClipResultsSectionProps) {
+  if (!clips.length) {
+    return <EmptyState />;
+  }
+
+  return (
+    <ClipList
+      clips={clips}
+      onCopy={onCopy}
+      onToggleFavorite={onToggleFavorite}
+      onContextMenu={onContextMenu}
+    />
+  );
+}

--- a/src/features/clip/ui/DeleteAllClipsModal.tsx
+++ b/src/features/clip/ui/DeleteAllClipsModal.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+interface DeleteAllClipsModalProps {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  cancelLabel: string;
+  confirmLabel: string;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function DeleteAllClipsModal({
+  isOpen,
+  title,
+  description,
+  cancelLabel,
+  confirmLabel,
+  onCancel,
+  onConfirm,
+}: DeleteAllClipsModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
+      <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+        <div className="border-b border-(--border) px-5 py-4">
+          <p className="text-foreground text-sm font-semibold">{title}</p>
+          <p className="text-muted mt-1 text-xs">{description}</p>
+        </div>
+        <div className="flex justify-end gap-2 px-5 py-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="hover:text-foreground rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="rounded-lg bg-(--danger) px-4 py-2 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover)"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -1,9 +1,9 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
+import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { useFavoriteClipsPage } from "@/features/clip/hooks/useFavoriteClipsPage";
-import { ClipList } from "@/features/clip/ui/ClipList";
-import { EmptyState } from "@/features/clip/ui/EmptyState";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function FavoriteClipsPage() {
@@ -25,24 +25,12 @@ export function FavoriteClipsPage() {
         showStatus={false}
         countLabel={t("count", { count: filteredClips.length })}
       />
-      {filteredClips.length ? (
-        <ClipList
-          clips={filteredClips}
-          onCopy={handleCopy}
-          onToggleFavorite={handleToggleFavorite}
-        />
-      ) : (
-        <EmptyState />
-      )}
-
-      {copyToast ? (
-        <div
-          className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
-          style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
-        >
-          {t("copyToast")}
-        </div>
-      ) : null}
+      <ClipResultsSection
+        clips={filteredClips}
+        onCopy={handleCopy}
+        onToggleFavorite={handleToggleFavorite}
+      />
+      <ClipCopyToast label={t("copyToast")} position={copyToast} />
     </div>
   );
 }

--- a/src/features/clip/ui/FolderClipCaptureHint.tsx
+++ b/src/features/clip/ui/FolderClipCaptureHint.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+interface FolderClipCaptureHintProps {
+  message: string;
+}
+
+export function FolderClipCaptureHint({
+  message,
+}: FolderClipCaptureHintProps) {
+  return (
+    <div className="px-4 pt-4 md:px-6">
+      <div className="rounded-2xl border border-(--border) bg-(--surface) px-4 py-3 text-center text-xs text-(--muted)">
+        {message}
+      </div>
+    </div>
+  );
+}

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -2,10 +2,14 @@
 
 import { useTranslations } from "next-intl";
 import { useFolderClipsPage } from "@/features/clip/hooks/useFolderClipsPage";
-import { ClipList } from "@/features/clip/ui/ClipList";
+import { ClipContextMenu } from "@/features/clip/ui/ClipContextMenu";
+import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
+import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { DeleteAllButton } from "@/features/clip/ui/DeleteAllButton";
-import { EmptyState } from "@/features/clip/ui/EmptyState";
+import { DeleteAllClipsModal } from "@/features/clip/ui/DeleteAllClipsModal";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
+import { FolderClipCaptureHint } from "@/features/clip/ui/FolderClipCaptureHint";
+import { RenameClipModal } from "@/features/clip/ui/RenameClipModal";
 
 export function FolderClipsPage() {
   const t = useTranslations("clips");
@@ -56,149 +60,52 @@ export function FolderClipsPage() {
         countLabel={t("count", { count: filteredClips.length })}
       />
       {!isActive ? (
-        <div className="px-4 pt-4 md:px-6">
-          <div className="rounded-2xl border border-(--border) bg-(--surface) px-4 py-3 text-center text-xs text-(--muted)">
-            {t("captureHint")}
-          </div>
-        </div>
+        <FolderClipCaptureHint message={t("captureHint")} />
       ) : null}
-      {filteredClips.length ? (
-        <ClipList
-          clips={filteredClips}
-          onCopy={handleCopy}
-          onToggleFavorite={handleToggleFavorite}
-          onContextMenu={handleOpenContextMenu}
-        />
-      ) : (
-        <EmptyState />
-      )}
+      <ClipResultsSection
+        clips={filteredClips}
+        onCopy={handleCopy}
+        onToggleFavorite={handleToggleFavorite}
+        onContextMenu={handleOpenContextMenu}
+      />
       <DeleteAllButton
         disabled={!hasClips}
         onClick={() => setIsDeleteAllOpen(true)}
       />
 
-      {contextMenu ? (
-        <div
-          className="fixed z-50 w-36 rounded-lg border border-(--border) bg-(--surface) p-1 text-xs text-(--muted) shadow-lg"
-          style={{ left: contextMenu.x, top: contextMenu.y }}
-          data-clip-menu
-        >
-          <button
-            type="button"
-            onClick={() => {
-              const target = clips.find((clip) => clip.id === contextMenu.id);
-              if (target) {
-                handleCopyFromMenu(target);
-              }
-            }}
-            className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
-            data-clip-menu
-          >
-            {t("actions.copy")}
-          </button>
-          <button
-            type="button"
-            onClick={() => {
-              const target = clips.find((clip) => clip.id === contextMenu.id);
-              if (target) {
-                handleOpenRename(target.id, target.name);
-              }
-            }}
-            className="hover:text-foreground flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--muted) hover:bg-(--surface-muted)"
-            data-clip-menu
-          >
-            {t("actions.rename")}
-          </button>
-          <button
-            type="button"
-            onClick={() => handleDeleteClip(contextMenu.id)}
-            className="flex w-full items-center justify-start rounded px-2 py-1.5 text-left text-(--danger) hover:bg-(--surface-muted)"
-            data-clip-menu
-          >
-            {t("actions.delete")}
-          </button>
-        </div>
-      ) : null}
-
-      {copyToast ? (
-        <div
-          className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
-          style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
-        >
-          {t("copyToast")}
-        </div>
-      ) : null}
-
-      {isDeleteAllOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="border-b border-(--border) px-5 py-4">
-              <p className="text-foreground text-sm font-semibold">
-                {t("deleteModal.title")}
-              </p>
-              <p className="text-muted mt-1 text-xs">
-                {t("deleteModal.description")}
-              </p>
-            </div>
-            <div className="flex justify-end gap-2 px-5 py-4">
-              <button
-                type="button"
-                onClick={() => setIsDeleteAllOpen(false)}
-                className="hover:text-foreground rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("actions.cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleDeleteAll}
-                className="rounded-lg bg-(--danger) px-4 py-2 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover)"
-              >
-                {t("actions.delete")}
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
-
-      {isRenameOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="border-b border-(--border) px-5 py-4">
-              <p className="text-foreground text-sm font-semibold">
-                {t("renameModal.title")}
-              </p>
-            </div>
-            <div className="px-5 py-4">
-              <label className="block text-xs font-semibold text-(--muted)">
-                {t("renameModal.label")}
-              </label>
-              <input
-                ref={renameInputRef}
-                value={renameName}
-                onChange={(event) => setRenameName(event.target.value)}
-                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder={t("renameModal.placeholder")}
-              />
-            </div>
-            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={() => setIsRenameOpen(false)}
-                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("actions.cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleRenameClip}
-                className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
-              >
-                {t("actions.change")}
-              </button>
-            </div>
-          </div>
-        </div>
-      ) : null}
+      <ClipContextMenu
+        clips={clips}
+        contextMenu={contextMenu}
+        copyLabel={t("actions.copy")}
+        renameLabel={t("actions.rename")}
+        deleteLabel={t("actions.delete")}
+        onCopy={handleCopyFromMenu}
+        onRename={(clip) => handleOpenRename(clip.id, clip.name)}
+        onDelete={handleDeleteClip}
+      />
+      <ClipCopyToast label={t("copyToast")} position={copyToast} />
+      <DeleteAllClipsModal
+        isOpen={isDeleteAllOpen}
+        title={t("deleteModal.title")}
+        description={t("deleteModal.description")}
+        cancelLabel={t("actions.cancel")}
+        confirmLabel={t("actions.delete")}
+        onCancel={() => setIsDeleteAllOpen(false)}
+        onConfirm={handleDeleteAll}
+      />
+      <RenameClipModal
+        isOpen={isRenameOpen}
+        title={t("renameModal.title")}
+        label={t("renameModal.label")}
+        placeholder={t("renameModal.placeholder")}
+        cancelLabel={t("actions.cancel")}
+        confirmLabel={t("actions.change")}
+        inputRef={renameInputRef}
+        value={renameName}
+        onChange={setRenameName}
+        onCancel={() => setIsRenameOpen(false)}
+        onConfirm={handleRenameClip}
+      />
     </div>
   );
 }

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
+import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { useRecentClipsPage } from "@/features/clip/hooks/useRecentClipsPage";
-import { ClipList } from "@/features/clip/ui/ClipList";
 import { DeleteAllButton } from "@/features/clip/ui/DeleteAllButton";
-import { EmptyState } from "@/features/clip/ui/EmptyState";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function RecentClipsPage() {
@@ -31,21 +31,9 @@ export function RecentClipsPage() {
         showStatus={false}
         countLabel={t("count", { count: filteredClips.length })}
       />
-      {filteredClips.length ? (
-        <ClipList clips={filteredClips} onCopy={handleCopy} />
-      ) : (
-        <EmptyState />
-      )}
+      <ClipResultsSection clips={filteredClips} onCopy={handleCopy} />
       <DeleteAllButton disabled={!hasClips} onClick={clearAll} />
-
-      {copyToast ? (
-        <div
-          className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
-          style={{ left: copyToast.x + 12, top: copyToast.y + 12 }}
-        >
-          {t("copyToast")}
-        </div>
-      ) : null}
+      <ClipCopyToast label={t("copyToast")} position={copyToast} />
     </div>
   );
 }

--- a/src/features/clip/ui/RenameClipModal.tsx
+++ b/src/features/clip/ui/RenameClipModal.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+interface RenameClipModalProps {
+  isOpen: boolean;
+  title: string;
+  label: string;
+  placeholder: string;
+  cancelLabel: string;
+  confirmLabel: string;
+  inputRef: React.RefObject<HTMLInputElement | null>;
+  value: string;
+  onChange: (value: string) => void;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function RenameClipModal({
+  isOpen,
+  title,
+  label,
+  placeholder,
+  cancelLabel,
+  confirmLabel,
+  inputRef,
+  value,
+  onChange,
+  onCancel,
+  onConfirm,
+}: RenameClipModalProps) {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
+      <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+        <div className="border-b border-(--border) px-5 py-4">
+          <p className="text-foreground text-sm font-semibold">{title}</p>
+        </div>
+        <div className="px-5 py-4">
+          <label className="block text-xs font-semibold text-(--muted)">
+            {label}
+          </label>
+          <input
+            ref={inputRef}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+            placeholder={placeholder}
+          />
+        </div>
+        <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+          <button
+            type="button"
+            onClick={onCancel}
+            className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium text-primary-foreground transition hover:bg-(--primary-hover)"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/folder/ui/FolderNameModal.tsx
+++ b/src/features/folder/ui/FolderNameModal.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import { HiX } from "react-icons/hi";
+
+interface FolderNameModalProps {
+  title: string;
+  closeLabel: string;
+  fieldLabel: string;
+  placeholder: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  value: string;
+  inputRef?: React.RefObject<HTMLInputElement | null>;
+  onChange: (value: string) => void;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+export function FolderNameModal({
+  title,
+  closeLabel,
+  fieldLabel,
+  placeholder,
+  confirmLabel,
+  cancelLabel,
+  value,
+  inputRef,
+  onChange,
+  onClose,
+  onConfirm,
+}: FolderNameModalProps) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
+      <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
+        <div className="flex items-center border-b border-(--border) px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
+            aria-label={closeLabel}
+          >
+            <HiX className="h-5 w-5" aria-hidden />
+          </button>
+          <p className="text-foreground ml-auto text-sm font-semibold">
+            {title}
+          </p>
+        </div>
+
+        <div className="px-5 py-4">
+          <label className="text-muted block text-xs font-semibold">
+            {fieldLabel}
+          </label>
+          <input
+            ref={inputRef}
+            value={value}
+            onChange={(event) => onChange(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === "Enter") {
+                onConfirm();
+              } else if (event.key === "Escape") {
+                onClose();
+              }
+            }}
+            className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
+            placeholder={placeholder}
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
+          >
+            {confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/folder/ui/FolderOptionsMenu.tsx
+++ b/src/features/folder/ui/FolderOptionsMenu.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { HiOutlinePencil, HiOutlineTrash } from "react-icons/hi";
+
+interface FolderOptionsMenuProps {
+  renameLabel: string;
+  deleteLabel: string;
+  onRename: () => void;
+  onDelete: () => void;
+}
+
+export function FolderOptionsMenu({
+  renameLabel,
+  deleteLabel,
+  onRename,
+  onDelete,
+}: FolderOptionsMenuProps) {
+  return (
+    <div className="relative">
+      <div
+        className="absolute right-0 z-20 w-32 overflow-hidden rounded-lg border border-(--border) bg-(--surface) shadow-lg"
+        data-folder-options
+      >
+        <button
+          type="button"
+          onClick={onRename}
+          className="text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-(--surface-muted)"
+        >
+          <HiOutlinePencil className="h-4 w-4" aria-hidden />
+          {renameLabel}
+        </button>
+        <button
+          type="button"
+          onClick={onDelete}
+          className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-(--danger) hover:bg-(--surface-muted)"
+        >
+          <HiOutlineTrash className="h-4 w-4" aria-hidden />
+          {deleteLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/folder/ui/FolderSidebarFooter.tsx
+++ b/src/features/folder/ui/FolderSidebarFooter.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { HiOutlineCog, HiOutlineLogout } from "react-icons/hi";
+
+interface FolderSidebarFooterProps {
+  email: string;
+  settingsLabel: string;
+  logoutLabel: string;
+  onOpenSettings: () => void;
+  onLogout: () => void;
+}
+
+export function FolderSidebarFooter({
+  email,
+  settingsLabel,
+  logoutLabel,
+  onOpenSettings,
+  onLogout,
+}: FolderSidebarFooterProps) {
+  return (
+    <div className="border-t border-(--border) px-4 py-4">
+      <div className="mb-3 flex items-center justify-between rounded-lg bg-(--surface) px-3 py-2">
+        <div className="flex items-center gap-2 truncate">
+          <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--icon-chip) text-[10px] font-semibold text-(--icon-chip-text)">
+            EC
+          </div>
+          <span className="text-foreground truncate text-sm font-medium">
+            {email}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onLogout}
+          className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition-colors"
+          aria-label={logoutLabel}
+        >
+          <HiOutlineLogout className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+
+      <button
+        type="button"
+        onClick={onOpenSettings}
+        className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
+      >
+        <HiOutlineCog className="h-5 w-5" aria-hidden />
+        {settingsLabel}
+      </button>
+    </div>
+  );
+}

--- a/src/features/folder/ui/FolderSidebarHeader.tsx
+++ b/src/features/folder/ui/FolderSidebarHeader.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { HiOutlinePaperClip, HiX } from "react-icons/hi";
+
+interface FolderSidebarHeaderProps {
+  onCloseMobile?: () => void;
+}
+
+export function FolderSidebarHeader({
+  onCloseMobile,
+}: FolderSidebarHeaderProps) {
+  return (
+    <div className="border-b border-(--border) px-4 py-5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <HiOutlinePaperClip className="h-5 w-5" aria-hidden />
+          <h1 className="text-foreground text-xl font-semibold">Easy Clip</h1>
+        </div>
+        <button
+          type="button"
+          onClick={onCloseMobile}
+          className="flex h-9 w-9 items-center justify-center rounded-full text-(--muted) transition hover:bg-(--surface) hover:text-(--foreground) md:hidden"
+          aria-label="사이드바 닫기"
+        >
+          <HiX className="h-5 w-5" aria-hidden />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/features/folder/ui/FolderSidebarSection.tsx
+++ b/src/features/folder/ui/FolderSidebarSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import Link from "next/link";
+import { FolderItem } from "@/features/folder/model/folder";
+import {
+  HiOutlineDotsVertical,
+  HiOutlineFolder,
+  HiOutlineMenuAlt4,
+  HiOutlinePlus,
+} from "react-icons/hi";
+import { FolderOptionsMenu } from "@/features/folder/ui/FolderOptionsMenu";
+
+interface FolderSidebarSectionProps {
+  folders: FolderItem[];
+  pathname: string;
+  addFolderLabel: string;
+  reorderFolderLabel: string;
+  openFolderOptionsLabel: string;
+  renameLabel: string;
+  deleteLabel: string;
+  openOptionsFolderId: string | null;
+  draggingFolderId: string | null;
+  onAddFolder: () => void;
+  onNavigate?: () => void;
+  onDragStart: (folderId: string, event: React.DragEvent<HTMLButtonElement>) => void;
+  onDragEnd: () => void;
+  onDragOver: (folderId: string, event: React.DragEvent<HTMLLIElement>) => void;
+  onToggleOptions: (folderId: string) => void;
+  onRenameFolder: (folderId: string) => void;
+  onDeleteFolder: (folderId: string) => void;
+}
+
+export function FolderSidebarSection({
+  folders,
+  pathname,
+  addFolderLabel,
+  reorderFolderLabel,
+  openFolderOptionsLabel,
+  renameLabel,
+  deleteLabel,
+  openOptionsFolderId,
+  draggingFolderId,
+  onAddFolder,
+  onNavigate,
+  onDragStart,
+  onDragEnd,
+  onDragOver,
+  onToggleOptions,
+  onRenameFolder,
+  onDeleteFolder,
+}: FolderSidebarSectionProps) {
+  return (
+    <div className="space-y-2 border-t border-(--border) pt-4">
+      <button
+        type="button"
+        onClick={onAddFolder}
+        className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
+      >
+        <HiOutlinePlus className="h-5 w-5" aria-hidden />
+        {addFolderLabel}
+      </button>
+
+      <ul className="space-y-1 px-2">
+        {folders.map((folder) => (
+          <li
+            key={folder.id}
+            onDragOver={(event) => onDragOver(folder.id, event)}
+            className={`relative rounded-lg ${
+              draggingFolderId === folder.id ? "opacity-50" : ""
+            }`}
+          >
+            <div
+              className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
+                pathname === `/${folder.id}`
+                  ? "text-foreground bg-(--surface)"
+                  : "text-muted hover:text-foreground hover:bg-(--surface)"
+              }`}
+            >
+              <button
+                type="button"
+                draggable
+                onDragStart={(event) => onDragStart(folder.id, event)}
+                onDragEnd={onDragEnd}
+                className="text-muted hover:text-foreground cursor-grab rounded p-1"
+                aria-label={reorderFolderLabel}
+              >
+                <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
+              </button>
+
+              <Link
+                href={`/${folder.id}`}
+                onClick={onNavigate}
+                className="flex flex-1 items-center gap-2 truncate"
+              >
+                <HiOutlineFolder className="h-5 w-5" aria-hidden />
+                <span className="truncate">{folder.name}</span>
+              </Link>
+
+              <button
+                type="button"
+                onClick={() => onToggleOptions(folder.id)}
+                className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
+                aria-label={openFolderOptionsLabel}
+                data-folder-options
+              >
+                <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+
+            {openOptionsFolderId === folder.id ? (
+              <FolderOptionsMenu
+                renameLabel={renameLabel}
+                deleteLabel={deleteLabel}
+                onRename={() => onRenameFolder(folder.id)}
+                onDelete={() => onDeleteFolder(folder.id)}
+              />
+            ) : null}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -1,24 +1,18 @@
 "use client";
 
-import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   HiOutlineClock,
-  HiOutlineCog,
-  HiOutlineDotsVertical,
-  HiOutlineFolder,
-  HiOutlineLogout,
-  HiOutlineMenuAlt4,
-  HiOutlinePaperClip,
-  HiOutlinePencil,
-  HiOutlinePlus,
   HiOutlineStar,
-  HiOutlineTrash,
-  HiX,
 } from "react-icons/hi";
 import { useFolders } from "@/features/folder/hooks/useFolders";
+import { FolderNameModal } from "@/features/folder/ui/FolderNameModal";
+import { FolderSidebarFooter } from "@/features/folder/ui/FolderSidebarFooter";
+import { FolderSidebarHeader } from "@/features/folder/ui/FolderSidebarHeader";
+import { FolderSidebarSection } from "@/features/folder/ui/FolderSidebarSection";
+import { SidebarPrimaryNav } from "@/features/folder/ui/SidebarPrimaryNav";
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -173,311 +167,117 @@ export function Sidebar({
           isMobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
         }`}
       >
-        <div className="border-b border-(--border) px-4 py-5">
-          <div className="flex items-center justify-between gap-2">
-            <div className="flex items-center gap-2">
-              <HiOutlinePaperClip className="h-5 w-5" aria-hidden />
-              <h1 className="text-foreground text-xl font-semibold">
-                Easy Clip
-              </h1>
-            </div>
-            <button
-              type="button"
-              onClick={onCloseMobile}
-              className="flex h-9 w-9 items-center justify-center rounded-full text-(--muted) transition hover:bg-(--surface) hover:text-(--foreground) md:hidden"
-              aria-label="사이드바 닫기"
-            >
-              <HiX className="h-5 w-5" aria-hidden />
-            </button>
-          </div>
-        </div>
+        <FolderSidebarHeader onCloseMobile={onCloseMobile} />
 
         <nav className="flex-1 py-4">
           <div className="space-y-6">
-            <ul className="space-y-2 px-2">
-              {topNavs.map((nav) => (
-                <li key={nav.href}>
-                  <Link
-                    href={nav.href}
-                    onClick={onCloseMobile}
-                    className={`flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
-                      pathname === nav.href
-                        ? "text-foreground bg-(--surface)"
-                        : "text-muted hover:text-foreground hover:bg-(--surface)"
-                    }`}
-                  >
-                    {nav.icon}
-                    {nav.label}
-                  </Link>
-                </li>
-              ))}
-            </ul>
+            <SidebarPrimaryNav
+              items={topNavs}
+              pathname={pathname}
+              onNavigate={onCloseMobile}
+            />
 
-            <div className="space-y-2 border-t border-(--border) pt-4">
-              <button
-                type="button"
-                onClick={() => {
-                  setNewFolderName("");
-                  setIsCreateFolderModalOpen(true);
-                }}
-                className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-4 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
-              >
-                <HiOutlinePlus className="h-5 w-5" aria-hidden />
-                {t("addFolder")}
-              </button>
-              <ul className="space-y-1 px-2">
-                {folders.map((folder) => (
-                  <li
-                    key={folder.id}
-                    onDragOver={(event) => {
-                      event.preventDefault();
-                      event.dataTransfer.dropEffect = "move";
-                      if (!draggingFolderId || draggingFolderId === folder.id) {
-                        return;
-                      }
-                      reorderFolders(draggingFolderId, folder.id);
-                    }}
-                    className={`relative rounded-lg ${
-                      draggingFolderId === folder.id ? "opacity-50" : ""
-                    }`}
-                  >
-                    <div
-                      className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
-                        pathname === `/${folder.id}`
-                          ? "text-foreground bg-(--surface)"
-                          : "text-muted hover:text-foreground hover:bg-(--surface)"
-                      }`}
-                    >
-                      <button
-                        type="button"
-                        draggable
-                        onDragStart={(event) => {
-                          setDraggingFolderId(folder.id);
-                          event.dataTransfer.effectAllowed = "move";
-                          event.dataTransfer.setData("text/plain", folder.id);
-                        }}
-                        onDragEnd={() => setDraggingFolderId(null)}
-                        className="text-muted hover:text-foreground cursor-grab rounded p-1"
-                        aria-label={t("reorderFolder")}
-                      >
-                        <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
-                      </button>
-                      <Link
-                        href={`/${folder.id}`}
-                        onClick={onCloseMobile}
-                        className="flex flex-1 items-center gap-2 truncate"
-                      >
-                        <HiOutlineFolder className="h-5 w-5" aria-hidden />
-                        <span className="truncate">{folder.name}</span>
-                      </Link>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setOpenOptionsFolderId((previous) =>
-                            previous === folder.id ? null : folder.id,
-                          )
-                        }
-                        className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
-                        aria-label={t("openFolderOptions")}
-                        data-folder-options
-                      >
-                        <HiOutlineDotsVertical
-                          className="h-4 w-4"
-                          aria-hidden
-                        />
-                      </button>
-                    </div>
-                    {openOptionsFolderId === folder.id ? (
-                      <div className="relative">
-                        <div
-                          className="absolute right-0 z-20 w-32 overflow-hidden rounded-lg border border-(--border) bg-(--surface) shadow-lg"
-                          data-folder-options
-                        >
-                          <button
-                            type="button"
-                            onClick={() => {
-                              setOpenOptionsFolderId(null);
-                              setRenameFolderId(folder.id);
-                              setRenameFolderName(folder.name);
-                              setIsRenameFolderModalOpen(true);
-                            }}
-                            className="text-foreground flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm hover:bg-(--surface-muted)"
-                          >
-                            <HiOutlinePencil className="h-4 w-4" aria-hidden />
-                            {t("rename")}
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              persistFolders(
-                                folders.filter(
-                                  (currentFolder) =>
-                                    currentFolder.id !== folder.id,
-                                ),
-                              );
-                              setOpenOptionsFolderId(null);
-                            }}
-                            className="flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-sm text-(--danger) hover:bg-(--surface-muted)"
-                          >
-                            <HiOutlineTrash className="h-4 w-4" aria-hidden />
-                            {t("delete")}
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-            </div>
+            <FolderSidebarSection
+              folders={folders}
+              pathname={pathname}
+              addFolderLabel={t("addFolder")}
+              reorderFolderLabel={t("reorderFolder")}
+              openFolderOptionsLabel={t("openFolderOptions")}
+              renameLabel={t("rename")}
+              deleteLabel={t("delete")}
+              openOptionsFolderId={openOptionsFolderId}
+              draggingFolderId={draggingFolderId}
+              onAddFolder={() => {
+                setNewFolderName("");
+                setIsCreateFolderModalOpen(true);
+              }}
+              onNavigate={onCloseMobile}
+              onDragStart={(folderId, event) => {
+                setDraggingFolderId(folderId);
+                event.dataTransfer.effectAllowed = "move";
+                event.dataTransfer.setData("text/plain", folderId);
+              }}
+              onDragEnd={() => setDraggingFolderId(null)}
+              onDragOver={(folderId, event) => {
+                event.preventDefault();
+                event.dataTransfer.dropEffect = "move";
+                if (!draggingFolderId || draggingFolderId === folderId) {
+                  return;
+                }
+
+                reorderFolders(draggingFolderId, folderId);
+              }}
+              onToggleOptions={(folderId) =>
+                setOpenOptionsFolderId((previous) =>
+                  previous === folderId ? null : folderId,
+                )
+              }
+              onRenameFolder={(folderId) => {
+                const targetFolder = folders.find((folder) => folder.id === folderId);
+                if (!targetFolder) {
+                  return;
+                }
+
+                setOpenOptionsFolderId(null);
+                setRenameFolderId(folderId);
+                setRenameFolderName(targetFolder.name);
+                setIsRenameFolderModalOpen(true);
+              }}
+              onDeleteFolder={(folderId) => {
+                persistFolders(
+                  folders.filter((currentFolder) => currentFolder.id !== folderId),
+                );
+                setOpenOptionsFolderId(null);
+              }}
+            />
           </div>
         </nav>
 
-        <div className="border-t border-(--border) px-4 py-4">
-          <div className="mb-3 flex items-center justify-between rounded-lg bg-(--surface) px-3 py-2">
-            <div className="flex items-center gap-2 truncate">
-              <div className="flex h-6 w-6 items-center justify-center rounded-full bg-(--icon-chip) text-[10px] font-semibold text-(--icon-chip-text)">
-                EC
-              </div>
-              <span className="text-foreground truncate text-sm font-medium">
-                user@example.com
-              </span>
-            </div>
-            <button
-              type="button"
-              onClick={() => {
-                onCloseMobile?.();
-                window.location.href = "/login";
-              }}
-              className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition-colors"
-              aria-label={t("logout")}
-            >
-              <HiOutlineLogout className="h-4 w-4" aria-hidden />
-            </button>
-          </div>
-
-          <button
-            type="button"
-            onClick={() => {
-              onCloseMobile?.();
-              onOpenSettings();
-            }}
-            className="hover:text-foreground flex w-full cursor-pointer items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium text-(--muted) transition-colors hover:bg-(--surface)"
-          >
-            <HiOutlineCog className="h-5 w-5" aria-hidden />
-            {t("settings")}
-          </button>
-        </div>
-
+        <FolderSidebarFooter
+          email="user@example.com"
+          settingsLabel={t("settings")}
+          logoutLabel={t("logout")}
+          onOpenSettings={() => {
+            onCloseMobile?.();
+            onOpenSettings();
+          }}
+          onLogout={() => {
+            onCloseMobile?.();
+            window.location.href = "/login";
+          }}
+        />
       </aside>
 
       {isCreateFolderModalOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="flex items-center border-b border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeCreateModal}
-                className="text-muted hover:text-foreground cursor-pointer rounded-full p-1 transition"
-                aria-label={t("closeCreateFolder")}
-              >
-                <HiX className="h-5 w-5" aria-hidden />
-              </button>
-              <p className="text-foreground ml-auto text-sm font-semibold">
-                {t("createFolder")}
-              </p>
-            </div>
-            <div className="px-5 py-4">
-              <label className="text-muted block text-xs font-semibold">
-                {t("folderName")}
-              </label>
-              <input
-                ref={inputRef}
-                value={newFolderName}
-                onChange={(event) => setNewFolderName(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    handleCreateFolder();
-                  } else if (event.key === "Escape") {
-                    closeCreateModal();
-                  }
-                }}
-                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder={t("folderNamePlaceholder")}
-              />
-            </div>
-            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeCreateModal}
-                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleCreateFolder}
-                className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
-              >
-                {t("create")}
-              </button>
-            </div>
-          </div>
-        </div>
+        <FolderNameModal
+          title={t("createFolder")}
+          closeLabel={t("closeCreateFolder")}
+          fieldLabel={t("folderName")}
+          placeholder={t("folderNamePlaceholder")}
+          confirmLabel={t("create")}
+          cancelLabel={t("cancel")}
+          value={newFolderName}
+          inputRef={inputRef}
+          onChange={setNewFolderName}
+          onClose={closeCreateModal}
+          onConfirm={handleCreateFolder}
+        />
       ) : null}
 
       {isRenameFolderModalOpen ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-(--overlay) px-4">
-          <div className="w-full max-w-sm rounded-xl bg-(--surface-elevated) shadow-xl">
-            <div className="flex items-center border-b border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeRenameModal}
-                className="hover:text-foreground cursor-pointer rounded-full p-1 text-(--muted) transition"
-                aria-label={t("closeRenameFolder")}
-              >
-                <HiX className="h-5 w-5" aria-hidden />
-              </button>
-              <p className="text-foreground ml-auto text-sm font-semibold">
-                {t("renameFolder")}
-              </p>
-            </div>
-            <div className="px-5 py-4">
-              <label className="block text-xs font-semibold text-(--muted)">
-                {t("folderName")}
-              </label>
-              <input
-                ref={renameInputRef}
-                value={renameFolderName}
-                onChange={(event) => setRenameFolderName(event.target.value)}
-                onKeyDown={(event) => {
-                  if (event.key === "Enter") {
-                    handleRenameFolder();
-                  } else if (event.key === "Escape") {
-                    closeRenameModal();
-                  }
-                }}
-                className="text-foreground mt-2 w-full rounded-lg border border-(--border) bg-(--input) px-3 py-2 text-sm placeholder:text-(--muted) focus:border-(--focus-ring) focus:outline-none"
-                placeholder={t("folderNamePlaceholder")}
-              />
-            </div>
-            <div className="flex justify-end gap-2 border-t border-(--border) px-5 py-4">
-              <button
-                type="button"
-                onClick={closeRenameModal}
-                className="hover:text-foreground cursor-pointer rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
-              >
-                {t("cancel")}
-              </button>
-              <button
-                type="button"
-                onClick={handleRenameFolder}
-                className="text-primary-foreground cursor-pointer rounded-lg bg-(--primary) px-4 py-2 text-sm font-medium transition hover:bg-(--primary-hover)"
-              >
-                {t("change")}
-              </button>
-            </div>
-          </div>
-        </div>
+        <FolderNameModal
+          title={t("renameFolder")}
+          closeLabel={t("closeRenameFolder")}
+          fieldLabel={t("folderName")}
+          placeholder={t("folderNamePlaceholder")}
+          confirmLabel={t("change")}
+          cancelLabel={t("cancel")}
+          value={renameFolderName}
+          inputRef={renameInputRef}
+          onChange={setRenameFolderName}
+          onClose={closeRenameModal}
+          onConfirm={handleRenameFolder}
+        />
       ) : null}
     </>
   );

--- a/src/features/folder/ui/SidebarPrimaryNav.tsx
+++ b/src/features/folder/ui/SidebarPrimaryNav.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import Link from "next/link";
+
+interface SidebarNavItem {
+  href: string;
+  label: string;
+  icon: React.ReactNode;
+}
+
+interface SidebarPrimaryNavProps {
+  items: SidebarNavItem[];
+  pathname: string;
+  onNavigate?: () => void;
+}
+
+export function SidebarPrimaryNav({
+  items,
+  pathname,
+  onNavigate,
+}: SidebarPrimaryNavProps) {
+  return (
+    <ul className="space-y-2 px-2">
+      {items.map((item) => (
+        <li key={item.href}>
+          <Link
+            href={item.href}
+            onClick={onNavigate}
+            className={`flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
+              pathname === item.href
+                ? "text-foreground bg-(--surface)"
+                : "text-muted hover:text-foreground hover:bg-(--surface)"
+            }`}
+          >
+            {item.icon}
+            {item.label}
+          </Link>
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
## PR 요약

- clip/auth/folder 도메인의 핵심 UI를 페이지 조립 레이어 중심 구조로 정리합니다.

## 변경 내용 상세

### 변경 사항

- `clip` 도메인에서 `FolderClipsPage`, `RecentClipsPage`, `FavoriteClipsPage`의 세부 UI를 의미 있는 하위 컴포넌트로 분리했습니다.
- `auth` 도메인에서 `LoginPage`를 브랜드 영역, 소셜 로그인 액션, 로딩 상태, 약관 안내 단위로 분리했습니다.
- `folder` 도메인에서 `Sidebar`를 헤더, 기본 네비게이션, 폴더 목록 섹션, 하단 사용자 액션, 폴더 이름 모달 단위로 분리했습니다.
- 페이지/핵심 UI 컴포넌트만 읽어도 도메인 화면 구조를 파악할 수 있도록 조립 레이어 역할을 명확히 했습니다.

### 변경 이유

- `features/*/ui`의 핵심 페이지가 화면 책임을 과도하게 가지지 않도록 정리하고, 도메인 파악이 가능한 구조를 만들기 위해서입니다.

## 관련 이슈

- Closes #31

## 기타 참고사항

- `npm run lint`: 통과
- `npm run build`: 통과