### PR TITLE
#37 / feat(clips) : 휴지통 페이지 및 리스트 UI 구현

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,7 +4,14 @@ import type { NextConfig } from "next";
 const withNextIntl = createNextIntlPlugin("./src/i18n/request.ts");
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "cdn.easy-clip.app",
+      },
+    ],
+  },
 };
 
 export default withNextIntl(nextConfig);

--- a/src/app/(app)/trash/page.tsx
+++ b/src/app/(app)/trash/page.tsx
@@ -1,0 +1,5 @@
+import { TrashPage } from "@/features/trash/ui/TrashPage";
+
+export default function Trash() {
+  return <TrashPage />;
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -229,6 +229,26 @@ a {
   }
 }
 
+@keyframes shimmer-x {
+  from {
+    background-position: 200% 0;
+  }
+  to {
+    background-position: -200% 0;
+  }
+}
+
+.trash-skeleton {
+  background-image: linear-gradient(
+    90deg,
+    var(--surface-muted) 0%,
+    var(--surface-elevated) 50%,
+    var(--surface-muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: shimmer-x 1.15s ease-in-out infinite;
+}
+
 .clip-scrollbar {
   scrollbar-width: thin;
   scrollbar-color: var(--clip-scrollbar-thumb) var(--clip-scrollbar-track);

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -1,7 +1,7 @@
 import { AuthProvider } from "@/features/auth/model/auth";
 import {
-  AuthSignInResponseDto,
   LogoutResponseDto,
+  RefreshAccessTokenResponseDto,
   UserProfileResponseDto,
 } from "@/features/auth/model/auth.dto";
 import { apiRequest } from "@/shared/lib/apiClient";
@@ -18,16 +18,23 @@ export const logout = async (accessToken: string) =>
   apiRequest<LogoutResponseDto>("/auth/logout", {
     method: "POST",
     accessToken,
+    credentials: "include",
   });
 
-// 테스트용
-export const testAdminLogin = async () =>
-  apiRequest<AuthSignInResponseDto>("/auth/test/admin-login", {
+export const refreshAccessToken = async () =>
+  apiRequest<RefreshAccessTokenResponseDto>("/auth/refresh", {
     method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-    },
-    body: JSON.stringify({
-      platform: "WEB",
-    }),
+    credentials: "include",
   });
+
+// 테스트 어드민 로그인 API는 실제 OAuth 연동 전 임시 우회용으로 사용했습니다.
+// export const testAdminLogin = async () =>
+//   apiRequest<AuthSignInResponseDto>("/auth/test/admin-login", {
+//     method: "POST",
+//     headers: {
+//       "Content-Type": "application/json",
+//     },
+//     body: JSON.stringify({
+//       platform: "WEB",
+//     }),
+//   });

--- a/src/features/auth/model/auth.dto.ts
+++ b/src/features/auth/model/auth.dto.ts
@@ -16,6 +16,10 @@ export interface AuthSignInResponseDto {
   user: AuthUserResponseDto;
 }
 
+export interface RefreshAccessTokenResponseDto {
+  access_token: string;
+}
+
 export interface UserProfileResponseDto {
   id: string;
   displayName: string;

--- a/src/features/auth/model/auth.ts
+++ b/src/features/auth/model/auth.ts
@@ -11,6 +11,6 @@ export interface AuthSessionUser {
 
 export interface AuthSession {
   accessToken: string;
-  refreshToken: string;
+  refreshToken?: string | null;
   user: AuthSessionUser | null;
 }

--- a/src/features/auth/service/authService.ts
+++ b/src/features/auth/service/authService.ts
@@ -1,4 +1,7 @@
-import { fetchMyProfile } from "@/features/auth/api/authApi";
+import {
+  fetchMyProfile,
+  refreshAccessToken,
+} from "@/features/auth/api/authApi";
 import { AuthSession } from "@/features/auth/model/auth";
 import {
   clearAuthSession,
@@ -14,6 +17,17 @@ export const syncSessionProfile = async (session: AuthSession) => {
 
   persistAuthSession(nextSession);
   return nextSession;
+};
+
+export const restoreSessionFromRefreshCookie = async () => {
+  const token = await refreshAccessToken();
+  const session = await syncSessionProfile({
+    accessToken: token.access_token,
+    refreshToken: null,
+    user: null,
+  });
+
+  return session;
 };
 
 export const clearSessionOnUnauthorized = () => {

--- a/src/features/auth/ui/AuthBootstrap.tsx
+++ b/src/features/auth/ui/AuthBootstrap.tsx
@@ -6,16 +6,25 @@ import { syncUserSettings } from "@/features/settings/service/settingsService";
 import { ApiError } from "@/shared/lib/apiClient";
 import {
   clearSessionOnUnauthorized,
+  restoreSessionFromRefreshCookie,
   syncSessionProfile,
 } from "@/features/auth/service/authService";
 
 export function AuthBootstrap() {
   const session = useAuthSession();
   const lastTokenRef = useRef<string | null>(null);
+  const hasTriedCookieRestoreRef = useRef(false);
 
   useEffect(() => {
     if (!session?.accessToken) {
       lastTokenRef.current = null;
+      if (!hasTriedCookieRestoreRef.current) {
+        hasTriedCookieRestoreRef.current = true;
+
+        void restoreSessionFromRefreshCookie().catch(() => {
+          // No refresh cookie means the user is simply logged out.
+        });
+      }
       return;
     }
 
@@ -29,9 +38,7 @@ export function AuthBootstrap() {
     lastTokenRef.current = accessToken;
 
     void Promise.all([
-      currentSession.user
-        ? Promise.resolve(currentSession)
-        : syncSessionProfile(currentSession),
+      syncSessionProfile(currentSession),
       syncUserSettings(accessToken),
     ]).catch((error: unknown) => {
       if (error instanceof ApiError && error.status === 401) {

--- a/src/features/auth/ui/LoginBrandPanel.tsx
+++ b/src/features/auth/ui/LoginBrandPanel.tsx
@@ -1,21 +1,13 @@
 "use client";
 
-import { HiOutlineClipboardCopy } from "react-icons/hi";
-
 interface LoginBrandPanelProps {
   title: string;
   subtitle: string;
 }
 
-export function LoginBrandPanel({
-  title,
-  subtitle,
-}: LoginBrandPanelProps) {
+export function LoginBrandPanel({ title, subtitle }: LoginBrandPanelProps) {
   return (
     <div className="mb-8 flex flex-col items-center">
-      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-(--primary)">
-        <HiOutlineClipboardCopy className="h-6 w-6 text-primary-foreground" />
-      </div>
       <h1 className="text-xl font-semibold text-(--foreground)">{title}</h1>
       <p className="mt-2 text-center text-sm text-(--muted)">{subtitle}</p>
     </div>

--- a/src/features/auth/ui/LoginPage.tsx
+++ b/src/features/auth/ui/LoginPage.tsx
@@ -3,10 +3,11 @@
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import { getAuthStartPath, testAdminLogin } from "@/features/auth/api/authApi";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { getAuthStartPath } from "@/features/auth/api/authApi";
+import { restoreSessionFromRefreshCookie } from "@/features/auth/service/authService";
 import { persistAuthSession } from "@/features/auth/service/authSession";
-import { buildApiUrl, isLocalApiBaseUrl } from "@/shared/config/env";
+import { buildApiUrl } from "@/shared/config/env";
 import { LoginAgreementNotice } from "@/features/auth/ui/LoginAgreementNotice";
 import { LoginBrandPanel } from "@/features/auth/ui/LoginBrandPanel";
 import { LoginLoadingState } from "@/features/auth/ui/LoginLoadingState";
@@ -21,6 +22,7 @@ export function LoginPage() {
     "google" | "github" | null
   >(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const hasTriedCookieRestoreRef = useRef(false);
 
   const redirectedSession = useMemo(() => {
     const accessToken = searchParams.get("access_token");
@@ -46,23 +48,25 @@ export function LoginPage() {
     router.replace("/favorites");
   }, [redirectedSession, router]);
 
+  useEffect(() => {
+    if (redirectedSession || hasTriedCookieRestoreRef.current) {
+      return;
+    }
+
+    hasTriedCookieRestoreRef.current = true;
+
+    void restoreSessionFromRefreshCookie()
+      .then(() => router.replace("/favorites"))
+      .catch(() => {
+        // Stay on the login page when there is no active OAuth cookie session.
+      });
+  }, [redirectedSession, router]);
+
   const handleLogin = async (provider: "google" | "github") => {
     try {
       setErrorMessage(null);
       setIsLoading(true);
       setLoadingProvider(provider);
-
-      if (isLocalApiBaseUrl()) {
-        const session = await testAdminLogin();
-        persistAuthSession({
-          accessToken: session.access_token,
-          refreshToken: session.refresh_token,
-          user: session.user,
-        });
-        router.replace("/favorites");
-        return;
-      }
-
       window.location.assign(buildApiUrl(getAuthStartPath(provider)));
     } catch {
       setIsLoading(false);

--- a/src/features/auth/ui/SocialLoginButton.tsx
+++ b/src/features/auth/ui/SocialLoginButton.tsx
@@ -18,7 +18,7 @@ export function SocialLoginButton({
       type="button"
       onClick={onClick}
       disabled={isLoading}
-      className="flex w-full items-center justify-center gap-3 rounded-lg border border-(--border) bg-(--surface) px-4 py-3 text-sm font-medium text-(--foreground) transition-colors hover:bg-(--surface-muted) disabled:cursor-not-allowed disabled:opacity-50"
+      className="flex w-full cursor-pointer items-center justify-center gap-3 rounded-lg border border-(--border) bg-(--surface) px-4 py-3 text-sm font-medium text-(--foreground) transition-colors hover:bg-(--surface-muted) disabled:cursor-not-allowed disabled:opacity-50"
     >
       {icon}
       <span>{label}</span>

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -3,7 +3,7 @@
 import { useTranslations } from "next-intl";
 import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { HiOutlineClock, HiOutlineStar } from "react-icons/hi";
+import { HiOutlineClock, HiOutlineStar, HiOutlineTrash } from "react-icons/hi";
 import { useRouter } from "next/navigation";
 import { logout } from "@/features/auth/api/authApi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
@@ -50,6 +50,7 @@ export function Sidebar({
   const reservedPathnames = new Set([
     "favorites",
     "recent",
+    "trash",
     "login",
     "pricing",
   ]);
@@ -68,6 +69,11 @@ export function Sidebar({
       href: currentFolderId ? `/${currentFolderId}/recent` : "/recent",
       label: t("recent"),
       icon: <HiOutlineClock className="h-5 w-5" aria-hidden />,
+    },
+    {
+      href: "/trash",
+      label: t("trash"),
+      icon: <HiOutlineTrash className="h-5 w-5" aria-hidden />,
     },
   ];
 

--- a/src/features/trash/api/trashApi.ts
+++ b/src/features/trash/api/trashApi.ts
@@ -1,0 +1,50 @@
+import {
+  TrashClipListResponseDto,
+  TrashClipResponseDto,
+  TrashDeleteResponseDto,
+  TrashFolderListResponseDto,
+  TrashFolderResponseDto,
+} from "@/features/trash/model/trash.dto";
+import { apiRequest } from "@/shared/lib/apiClient";
+
+export const fetchTrashClips = async (accessToken: string) =>
+  apiRequest<TrashClipListResponseDto>("/trash/clips", {
+    accessToken,
+    cache: "no-store",
+  });
+
+export const restoreTrashClip = async (accessToken: string, clipId: string) =>
+  apiRequest<TrashClipResponseDto>(`/trash/clips/${clipId}/restore`, {
+    method: "PATCH",
+    accessToken,
+  });
+
+export const deleteTrashClip = async (accessToken: string, clipId: string) =>
+  apiRequest<TrashDeleteResponseDto>(`/trash/clips/${clipId}`, {
+    method: "DELETE",
+    accessToken,
+  });
+
+export const fetchTrashFolders = async (accessToken: string) =>
+  apiRequest<TrashFolderListResponseDto>("/trash/folders", {
+    accessToken,
+    cache: "no-store",
+  });
+
+export const restoreTrashFolder = async (
+  accessToken: string,
+  folderId: string,
+) =>
+  apiRequest<TrashFolderResponseDto>(`/trash/folders/${folderId}/restore`, {
+    method: "PATCH",
+    accessToken,
+  });
+
+export const deleteTrashFolder = async (
+  accessToken: string,
+  folderId: string,
+) =>
+  apiRequest<TrashDeleteResponseDto>(`/trash/folders/${folderId}`, {
+    method: "DELETE",
+    accessToken,
+  });

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { startTransition, useCallback, useEffect, useState } from "react";
+import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { fetchFolders } from "@/features/folder/api/folderApi";
+import { FolderResponseDto } from "@/features/folder/model/folder.dto";
+import {
+  deleteTrashClip,
+  deleteTrashFolder,
+  fetchTrashClips,
+  fetchTrashFolders,
+  restoreTrashClip,
+  restoreTrashFolder,
+} from "@/features/trash/api/trashApi";
+import {
+  TrashClipResponseDto,
+  TrashFolderResponseDto,
+} from "@/features/trash/model/trash.dto";
+
+export const useTrashPage = () => {
+  const session = useAuthSession();
+  const accessToken = session?.accessToken ?? null;
+  const [clips, setClips] = useState<TrashClipResponseDto[]>([]);
+  const [folders, setFolders] = useState<TrashFolderResponseDto[]>([]);
+  const [activeFolders, setActiveFolders] = useState<FolderResponseDto[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+
+  const loadTrash = useCallback(async () => {
+    if (!accessToken) {
+      startTransition(() => {
+        setClips([]);
+        setFolders([]);
+        setActiveFolders([]);
+        setIsLoading(false);
+      });
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [trashClips, trashFolders, currentFolders] = await Promise.all([
+        fetchTrashClips(accessToken),
+        fetchTrashFolders(accessToken),
+        fetchFolders(accessToken),
+      ]);
+
+      startTransition(() => {
+        setClips(trashClips.items);
+        setFolders(trashFolders.items);
+        setActiveFolders(currentFolders);
+      });
+    } catch {
+      setError("load");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    void loadTrash();
+  }, [loadTrash]);
+
+  const runAction = useCallback(
+    async (actionKey: string, action: () => Promise<unknown>) => {
+      setPendingActionKey(actionKey);
+      setError(null);
+
+      try {
+        await action();
+        await loadTrash();
+      } catch {
+        setError("action");
+      } finally {
+        setPendingActionKey(null);
+      }
+    },
+    [loadTrash],
+  );
+
+  const handleRestoreClip = useCallback(
+    async (clipId: string) => {
+      if (!accessToken) {
+        return;
+      }
+
+      await runAction(`clip-restore-${clipId}`, () =>
+        restoreTrashClip(accessToken, clipId),
+      );
+    },
+    [accessToken, runAction],
+  );
+
+  const handleDeleteClip = useCallback(
+    async (clipId: string) => {
+      if (!accessToken) {
+        return;
+      }
+
+      await runAction(`clip-delete-${clipId}`, () =>
+        deleteTrashClip(accessToken, clipId),
+      );
+    },
+    [accessToken, runAction],
+  );
+
+  const handleRestoreFolder = useCallback(
+    async (folderId: string) => {
+      if (!accessToken) {
+        return;
+      }
+
+      await runAction(`folder-restore-${folderId}`, () =>
+        restoreTrashFolder(accessToken, folderId),
+      );
+    },
+    [accessToken, runAction],
+  );
+
+  const handleDeleteFolder = useCallback(
+    async (folderId: string) => {
+      if (!accessToken) {
+        return;
+      }
+
+      await runAction(`folder-delete-${folderId}`, () =>
+        deleteTrashFolder(accessToken, folderId),
+      );
+    },
+    [accessToken, runAction],
+  );
+
+  const handleClearAll = useCallback(async () => {
+    if (!accessToken) {
+      return;
+    }
+
+    await runAction("trash-clear-all", async () => {
+      for (const clip of clips) {
+        await deleteTrashClip(accessToken, clip.id);
+      }
+
+      for (const folder of folders) {
+        await deleteTrashFolder(accessToken, folder.id);
+      }
+    });
+  }, [accessToken, clips, folders, runAction]);
+
+  return {
+    clips,
+    folders,
+    activeFolders,
+    isLoading,
+    error,
+    hasItems: clips.length > 0 || folders.length > 0,
+    pendingActionKey,
+    reload: loadTrash,
+    handleRestoreClip,
+    handleDeleteClip,
+    handleRestoreFolder,
+    handleDeleteFolder,
+    handleClearAll,
+  };
+};

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -17,6 +17,18 @@ import {
   TrashFolderResponseDto,
 } from "@/features/trash/model/trash.dto";
 
+const MIN_LOADING_MS = 300;
+
+const waitForMinimumLoading = async (startedAt: number) => {
+  const remainingMs = MIN_LOADING_MS - (Date.now() - startedAt);
+
+  if (remainingMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, remainingMs));
+};
+
 export const useTrashPage = () => {
   const session = useAuthSession();
   const accessToken = session?.accessToken ?? null;
@@ -28,7 +40,11 @@ export const useTrashPage = () => {
   const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
 
   const loadTrash = useCallback(async () => {
+    const loadingStartedAt = Date.now();
+
     if (!accessToken) {
+      await waitForMinimumLoading(loadingStartedAt);
+
       startTransition(() => {
         setClips([]);
         setFolders([]);
@@ -56,6 +72,7 @@ export const useTrashPage = () => {
     } catch {
       setError("load");
     } finally {
+      await waitForMinimumLoading(loadingStartedAt);
       setIsLoading(false);
     }
   }, [accessToken]);

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useCallback, useEffect, useState } from "react";
+import { startTransition, useCallback, useEffect, useRef, useState } from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { fetchFolders } from "@/features/folder/api/folderApi";
 import { FolderResponseDto } from "@/features/folder/model/folder.dto";
@@ -38,12 +38,20 @@ export const useTrashPage = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [pendingActionKey, setPendingActionKey] = useState<string | null>(null);
+  const loadRequestIdRef = useRef(0);
 
   const loadTrash = useCallback(async () => {
+    const requestId = loadRequestIdRef.current + 1;
+    loadRequestIdRef.current = requestId;
     const loadingStartedAt = Date.now();
+    const isLatestRequest = () => loadRequestIdRef.current === requestId;
 
     if (!accessToken) {
       await waitForMinimumLoading(loadingStartedAt);
+
+      if (!isLatestRequest()) {
+        return;
+      }
 
       startTransition(() => {
         setClips([]);
@@ -65,15 +73,25 @@ export const useTrashPage = () => {
       ]);
 
       startTransition(() => {
+        if (!isLatestRequest()) {
+          return;
+        }
+
         setClips(trashClips.items);
         setFolders(trashFolders.items);
         setActiveFolders(currentFolders);
       });
     } catch {
+      if (!isLatestRequest()) {
+        return;
+      }
+
       setError("load");
     } finally {
       await waitForMinimumLoading(loadingStartedAt);
-      setIsLoading(false);
+      if (isLatestRequest()) {
+        setIsLoading(false);
+      }
     }
   }, [accessToken]);
 

--- a/src/features/trash/model/trash.dto.ts
+++ b/src/features/trash/model/trash.dto.ts
@@ -1,0 +1,27 @@
+import { ClipApiType } from "@/features/clip/model/clip.dto";
+
+export interface TrashClipResponseDto {
+  id: string;
+  title: string;
+  type: ClipApiType;
+  folderId: string;
+  deletedAt: string | null;
+}
+
+export interface TrashClipListResponseDto {
+  items: TrashClipResponseDto[];
+}
+
+export interface TrashFolderResponseDto {
+  id: string;
+  name: string;
+  deletedAt: string | null;
+}
+
+export interface TrashFolderListResponseDto {
+  items: TrashFolderResponseDto[];
+}
+
+export interface TrashDeleteResponseDto {
+  success: boolean;
+}

--- a/src/features/trash/ui/TrashListRow.tsx
+++ b/src/features/trash/ui/TrashListRow.tsx
@@ -1,0 +1,115 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import {
+  HiOutlineColorSwatch,
+  HiOutlineDocumentText,
+  HiOutlineFolder,
+  HiOutlinePhotograph,
+} from "react-icons/hi";
+import { formatDeletedAt, TrashItemRow } from "@/features/trash/ui/trashRow";
+
+interface TrashListRowProps {
+  row: TrashItemRow;
+  pendingActionKey: string | null;
+  onRestoreFolder: (folderId: string) => void;
+  onDeleteFolder: (folderId: string) => void;
+  onRestoreClip: (clipId: string) => void;
+  onDeleteClip: (clipId: string) => void;
+}
+
+// 휴지통 항목 하나를 파일/폴더 유형과 액션까지 포함해 한 줄로 렌더링하는 컴포넌트입니다.
+export function TrashListRow({
+  row,
+  pendingActionKey,
+  onRestoreFolder,
+  onDeleteFolder,
+  onRestoreClip,
+  onDeleteClip,
+}: TrashListRowProps) {
+  const t = useTranslations("trash");
+  const restoreActionKey =
+    row.kind === "folder"
+      ? `folder-restore-${row.id}`
+      : `clip-restore-${row.id}`;
+  const deleteActionKey =
+    row.kind === "folder" ? `folder-delete-${row.id}` : `clip-delete-${row.id}`;
+
+  return (
+    <article className="px-4 py-4 transition-colors hover:bg-(--surface-elevated)">
+      <div className="flex flex-col gap-3 min-[1200px]:grid min-[1200px]:grid-cols-[minmax(0,1.5fr)_180px_220px_220px] min-[1200px]:items-center min-[1200px]:gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-(--icon-chip) text-(--icon-chip-text)">
+            {row.kind === "folder" ? (
+              <HiOutlineFolder className="h-5 w-5" aria-hidden />
+            ) : row.clipType === "IMAGE" ? (
+              <HiOutlinePhotograph className="h-5 w-5" aria-hidden />
+            ) : row.clipType === "COLOR" ? (
+              <HiOutlineColorSwatch className="h-5 w-5" aria-hidden />
+            ) : (
+              <HiOutlineDocumentText className="h-5 w-5" aria-hidden />
+            )}
+          </div>
+
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-(--foreground)">
+              {row.name}
+            </p>
+            {row.kind === "clip" ? (
+              <p className="mt-1 truncate text-xs text-(--muted)">
+                {t("parentFolder")}: {row.parentFolderName}
+              </p>
+            ) : null}
+            <p className="mt-1 text-xs text-(--muted) min-[1200px]:hidden">
+              {row.typeLabel}
+            </p>
+          </div>
+        </div>
+
+        <div>
+          <span className="inline-flex rounded-full bg-(--surface-elevated) px-2.5 py-1 text-xs font-medium text-(--muted)">
+            {row.typeLabel}
+          </span>
+        </div>
+
+        <p className="text-xs text-(--muted) min-[1200px]:text-sm">
+          <span className="mr-2 min-[1200px]:hidden">{t("deletedAt")}:</span>
+          {formatDeletedAt(row.deletedAt)}
+        </p>
+
+        <div className="flex flex-wrap justify-end gap-2 min-[1200px]:justify-start">
+          <button
+            type="button"
+            disabled={pendingActionKey === restoreActionKey}
+            onClick={() => {
+              if (row.kind === "folder") {
+                onRestoreFolder(row.id);
+                return;
+              }
+
+              onRestoreClip(row.id);
+            }}
+            className="cursor-pointer rounded-lg border border-(--border) px-3 py-2 text-xs font-medium text-(--foreground) transition hover:bg-(--surface-muted)"
+          >
+            {t("restore")}
+          </button>
+          <button
+            type="button"
+            disabled={pendingActionKey === deleteActionKey}
+            onClick={() => {
+              if (row.kind === "folder") {
+                onDeleteFolder(row.id);
+                return;
+              }
+
+              onDeleteClip(row.id);
+            }}
+            className="cursor-pointer rounded-lg bg-red-500/15 px-3 py-2 text-xs font-medium text-red-500 transition hover:bg-red-500/25"
+          >
+            {t("deleteForever")}
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/src/features/trash/ui/TrashListSection.tsx
+++ b/src/features/trash/ui/TrashListSection.tsx
@@ -9,6 +9,7 @@ import { TrashItemRow } from "@/features/trash/ui/trashRow";
 
 interface TrashListSectionProps {
   rows: TrashItemRow[];
+  isLoading?: boolean;
   pendingActionKey: string | null;
   onReload: () => void;
   onClearAll: () => void;
@@ -21,6 +22,7 @@ interface TrashListSectionProps {
 // 휴지통 항목 목록의 헤더, 스크롤 영역, 각 행 렌더링을 묶는 리스트 섹션 컴포넌트입니다.
 export function TrashListSection({
   rows,
+  isLoading = false,
   pendingActionKey,
   onReload,
   onClearAll,
@@ -31,6 +33,7 @@ export function TrashListSection({
 }: TrashListSectionProps) {
   const t = useTranslations("trash");
   const [isClearAllModalOpen, setIsClearAllModalOpen] = useState(false);
+  const skeletonRows = Array.from({ length: 6 }, (_, index) => index);
 
   return (
     <>
@@ -41,13 +44,17 @@ export function TrashListSection({
               {t("listTitle")}
             </h2>
             <p className="text-sm text-(--muted)">
-              {t("totalCount", { count: rows.length })}
+              {isLoading ? t("loading") : t("totalCount", { count: rows.length })}
             </p>
           </div>
           <div className="flex items-center gap-2">
             <button
               type="button"
-              disabled={!rows.length || pendingActionKey === "trash-clear-all"}
+              disabled={
+                isLoading ||
+                !rows.length ||
+                pendingActionKey === "trash-clear-all"
+              }
               onClick={() => setIsClearAllModalOpen(true)}
               className="cursor-pointer rounded-lg bg-red-500/15 px-4 py-2 text-sm font-medium text-red-500 transition hover:bg-red-500/25 disabled:cursor-default disabled:opacity-50"
             >
@@ -55,8 +62,9 @@ export function TrashListSection({
             </button>
             <button
               type="button"
+              disabled={isLoading}
               onClick={onReload}
-              className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-(--border) text-(--foreground) transition hover:bg-(--surface)"
+              className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-(--border) text-(--foreground) transition hover:bg-(--surface) disabled:cursor-default disabled:opacity-50"
               aria-label={t("refresh")}
               title={t("refresh")}
             >
@@ -73,17 +81,19 @@ export function TrashListSection({
         </div>
 
         <div className="clip-scrollbar min-h-0 flex-1 divide-y divide-(--border) overflow-y-auto">
-          {rows.map((row) => (
-            <TrashListRow
-              key={`${row.kind}-${row.id}`}
-              row={row}
-              pendingActionKey={pendingActionKey}
-              onRestoreFolder={onRestoreFolder}
-              onDeleteFolder={onDeleteFolder}
-              onRestoreClip={onRestoreClip}
-              onDeleteClip={onDeleteClip}
-            />
-          ))}
+          {isLoading
+            ? skeletonRows.map((row) => <TrashListSkeletonRow key={row} />)
+            : rows.map((row) => (
+                <TrashListRow
+                  key={`${row.kind}-${row.id}`}
+                  row={row}
+                  pendingActionKey={pendingActionKey}
+                  onRestoreFolder={onRestoreFolder}
+                  onDeleteFolder={onDeleteFolder}
+                  onRestoreClip={onRestoreClip}
+                  onDeleteClip={onDeleteClip}
+                />
+              ))}
         </div>
       </section>
 
@@ -100,5 +110,31 @@ export function TrashListSection({
         }}
       />
     </>
+  );
+}
+
+function TrashListSkeletonRow() {
+  return (
+    <article
+      className="px-4 py-4"
+      aria-hidden
+    >
+      <div className="flex flex-col gap-3 min-[1200px]:grid min-[1200px]:grid-cols-[minmax(0,1.5fr)_180px_220px_220px] min-[1200px]:items-center min-[1200px]:gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="trash-skeleton h-10 w-10 shrink-0 rounded-xl" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <div className="trash-skeleton h-4 w-2/3 rounded-md" />
+            <div className="trash-skeleton h-3 w-1/2 rounded-md" />
+          </div>
+        </div>
+
+        <div className="trash-skeleton h-7 w-24 rounded-full" />
+        <div className="trash-skeleton h-4 w-32 rounded-md" />
+        <div className="flex flex-wrap justify-end gap-2 min-[1200px]:justify-start">
+          <div className="trash-skeleton h-8 w-16 rounded-lg" />
+          <div className="trash-skeleton h-8 w-20 rounded-lg" />
+        </div>
+      </div>
+    </article>
   );
 }

--- a/src/features/trash/ui/TrashListSection.tsx
+++ b/src/features/trash/ui/TrashListSection.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { HiOutlineRefresh } from "react-icons/hi";
+import { DeleteAllClipsModal } from "@/features/clip/ui/DeleteAllClipsModal";
+import { TrashListRow } from "@/features/trash/ui/TrashListRow";
+import { TrashItemRow } from "@/features/trash/ui/trashRow";
+
+interface TrashListSectionProps {
+  rows: TrashItemRow[];
+  pendingActionKey: string | null;
+  onReload: () => void;
+  onClearAll: () => void;
+  onRestoreFolder: (folderId: string) => void;
+  onDeleteFolder: (folderId: string) => void;
+  onRestoreClip: (clipId: string) => void;
+  onDeleteClip: (clipId: string) => void;
+}
+
+// 휴지통 항목 목록의 헤더, 스크롤 영역, 각 행 렌더링을 묶는 리스트 섹션 컴포넌트입니다.
+export function TrashListSection({
+  rows,
+  pendingActionKey,
+  onReload,
+  onClearAll,
+  onRestoreFolder,
+  onDeleteFolder,
+  onRestoreClip,
+  onDeleteClip,
+}: TrashListSectionProps) {
+  const t = useTranslations("trash");
+  const [isClearAllModalOpen, setIsClearAllModalOpen] = useState(false);
+
+  return (
+    <>
+      <section className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-(--border) bg-(--surface)">
+        <div className="flex items-center justify-between gap-3 border-b border-(--border) px-4 py-4">
+          <div>
+            <h2 className="text-base font-semibold text-(--foreground)">
+              {t("listTitle")}
+            </h2>
+            <p className="text-sm text-(--muted)">
+              {t("totalCount", { count: rows.length })}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={!rows.length || pendingActionKey === "trash-clear-all"}
+              onClick={() => setIsClearAllModalOpen(true)}
+              className="cursor-pointer rounded-lg bg-red-500/15 px-4 py-2 text-sm font-medium text-red-500 transition hover:bg-red-500/25 disabled:cursor-default disabled:opacity-50"
+            >
+              {t("clearAll")}
+            </button>
+            <button
+              type="button"
+              onClick={onReload}
+              className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-lg border border-(--border) text-(--foreground) transition hover:bg-(--surface)"
+              aria-label={t("refresh")}
+              title={t("refresh")}
+            >
+              <HiOutlineRefresh className="h-4 w-4" aria-hidden />
+            </button>
+          </div>
+        </div>
+
+        <div className="hidden grid-cols-[minmax(0,1.5fr)_180px_220px_220px] items-center gap-4 border-b border-(--border) bg-(--surface-elevated) px-4 py-3 text-xs font-semibold tracking-wide text-(--muted) uppercase min-[1200px]:grid">
+          <span>{t("columns.name")}</span>
+          <span>{t("columns.type")}</span>
+          <span>{t("columns.deletedAt")}</span>
+          <span>{t("columns.actions")}</span>
+        </div>
+
+        <div className="clip-scrollbar min-h-0 flex-1 divide-y divide-(--border) overflow-y-auto">
+          {rows.map((row) => (
+            <TrashListRow
+              key={`${row.kind}-${row.id}`}
+              row={row}
+              pendingActionKey={pendingActionKey}
+              onRestoreFolder={onRestoreFolder}
+              onDeleteFolder={onDeleteFolder}
+              onRestoreClip={onRestoreClip}
+              onDeleteClip={onDeleteClip}
+            />
+          ))}
+        </div>
+      </section>
+
+      <DeleteAllClipsModal
+        isOpen={isClearAllModalOpen}
+        title={t("clearAllModal.title")}
+        description={t("clearAllModal.description")}
+        cancelLabel={t("cancel")}
+        confirmLabel={t("clearAll")}
+        onCancel={() => setIsClearAllModalOpen(false)}
+        onConfirm={() => {
+          setIsClearAllModalOpen(false);
+          onClearAll();
+        }}
+      />
+    </>
+  );
+}

--- a/src/features/trash/ui/TrashPage.tsx
+++ b/src/features/trash/ui/TrashPage.tsx
@@ -82,20 +82,15 @@ export function TrashPage() {
         </div>
       ) : null}
 
-      {isLoading ? (
-        <div className="flex flex-1 items-center justify-center px-6 py-12">
-          <p className="text-sm text-(--muted)">{t("loading")}</p>
-        </div>
-      ) : null}
-
       {!isLoading && !hasItems ? (
         <TrashPageEmptyState />
       ) : null}
 
-      {!isLoading && hasItems ? (
+      {isLoading || hasItems ? (
         <div className="flex min-h-0 flex-1 flex-col px-4 py-4 min-[1200px]:px-6">
           <TrashListSection
             rows={rows}
+            isLoading={isLoading}
             pendingActionKey={pendingActionKey}
             onReload={() => {
               void reload();

--- a/src/features/trash/ui/TrashPage.tsx
+++ b/src/features/trash/ui/TrashPage.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useTrashPage } from "@/features/trash/hooks/useTrashPage";
+import { TrashListSection } from "@/features/trash/ui/TrashListSection";
+import { TrashPageEmptyState } from "@/features/trash/ui/TrashPageEmptyState";
+import { TrashPageHeader } from "@/features/trash/ui/TrashPageHeader";
+import { TrashItemRow } from "@/features/trash/ui/trashRow";
+
+const getClipTypeLabel = (
+  clipType: "TEXT" | "COLOR" | "IMAGE",
+  t: ReturnType<typeof useTranslations<"trash">>,
+) => {
+  if (clipType === "TEXT") {
+    return t("clipKinds.text");
+  }
+
+  if (clipType === "COLOR") {
+    return t("clipKinds.color");
+  }
+
+  return t("clipKinds.image");
+};
+
+// 휴지통 페이지의 상태에 따라 안내, 빈 상태, 리스트 섹션을 조합하는 루트 컴포넌트입니다.
+export function TrashPage() {
+  const t = useTranslations("trash");
+  const {
+    clips,
+    folders,
+    activeFolders,
+    isLoading,
+    error,
+    hasItems,
+    pendingActionKey,
+    reload,
+    handleRestoreClip,
+    handleDeleteClip,
+    handleRestoreFolder,
+    handleDeleteFolder,
+    handleClearAll,
+  } = useTrashPage();
+  const folderNameById = new Map([
+    ...activeFolders.map((folder) => [folder.id, folder.name] as const),
+    ...folders.map((folder) => [folder.id, folder.name] as const),
+  ]);
+
+  const rows: TrashItemRow[] = [
+    ...folders.map((folder) => ({
+      kind: "folder" as const,
+      id: folder.id,
+      name: folder.name,
+      deletedAt: folder.deletedAt,
+      typeLabel: t("folderType"),
+    })),
+    ...clips.map((clip) => ({
+      kind: "clip" as const,
+      id: clip.id,
+      name: clip.title,
+      deletedAt: clip.deletedAt,
+      typeLabel: `${t("fileType")} · ${getClipTypeLabel(clip.type, t)}`,
+      clipType: clip.type,
+      parentFolderName:
+        folderNameById.get(clip.folderId) ?? t("unknownParentFolder"),
+    })),
+  ].sort((left, right) => {
+    const leftTime = left.deletedAt ? new Date(left.deletedAt).getTime() : 0;
+    const rightTime = right.deletedAt ? new Date(right.deletedAt).getTime() : 0;
+
+    return rightTime - leftTime;
+  });
+
+  return (
+    <div className="bg-background flex h-full min-h-0 flex-col overflow-hidden">
+      <TrashPageHeader />
+
+      {error ? (
+        <div className="px-6 pt-6">
+          <p className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            {t("error")}
+          </p>
+        </div>
+      ) : null}
+
+      {isLoading ? (
+        <div className="flex flex-1 items-center justify-center px-6 py-12">
+          <p className="text-sm text-(--muted)">{t("loading")}</p>
+        </div>
+      ) : null}
+
+      {!isLoading && !hasItems ? (
+        <TrashPageEmptyState />
+      ) : null}
+
+      {!isLoading && hasItems ? (
+        <div className="flex min-h-0 flex-1 flex-col px-4 py-4 min-[1200px]:px-6">
+          <TrashListSection
+            rows={rows}
+            pendingActionKey={pendingActionKey}
+            onReload={() => {
+              void reload();
+            }}
+            onClearAll={() => {
+              void handleClearAll();
+            }}
+            onRestoreFolder={(folderId) => {
+              void handleRestoreFolder(folderId);
+            }}
+            onDeleteFolder={(folderId) => {
+              void handleDeleteFolder(folderId);
+            }}
+            onRestoreClip={(clipId) => {
+              void handleRestoreClip(clipId);
+            }}
+            onDeleteClip={(clipId) => {
+              void handleDeleteClip(clipId);
+            }}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/trash/ui/TrashPageEmptyState.tsx
+++ b/src/features/trash/ui/TrashPageEmptyState.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { HiOutlineTrash } from "react-icons/hi";
+
+// 휴지통에 표시할 항목이 없을 때 비어 있는 상태를 안내하는 컴포넌트입니다.
+export function TrashPageEmptyState() {
+  const t = useTranslations("trash");
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-6 py-12">
+      <div className="flex max-w-sm flex-col items-center rounded-3xl border border-dashed border-(--border) bg-(--surface) px-8 py-10 text-center">
+        <div className="flex h-14 w-14 items-center justify-center rounded-2xl bg-(--icon-chip) text-(--icon-chip-text)">
+          <HiOutlineTrash className="h-7 w-7" aria-hidden />
+        </div>
+        <p className="mt-5 text-base font-semibold text-(--foreground)">
+          {t("emptyTitle")}
+        </p>
+        <p className="mt-2 text-sm leading-relaxed text-(--muted)">
+          {t("emptyDescription")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/trash/ui/TrashPageHeader.tsx
+++ b/src/features/trash/ui/TrashPageHeader.tsx
@@ -9,7 +9,17 @@ export function TrashPageHeader() {
   return (
     <div className="border-b border-(--border) px-4 py-6 min-[1200px]:px-6">
       <div className="flex flex-col gap-3 min-[1200px]:flex-row min-[1200px]:items-center min-[1200px]:justify-between">
-        <p className="text-sm text-(--muted)">{t("description")}</p>
+        <div>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-xl font-semibold text-(--foreground)">
+              {t("title")}
+            </h1>
+            <span className="rounded-full bg-(--surface-muted) px-2.5 py-1 text-xs font-medium text-(--muted)">
+              {t("retentionNotice")}
+            </span>
+          </div>
+          <p className="mt-2 text-sm text-(--muted)">{t("description")}</p>
+        </div>
       </div>
     </div>
   );

--- a/src/features/trash/ui/TrashPageHeader.tsx
+++ b/src/features/trash/ui/TrashPageHeader.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+// 휴지통 페이지 상단에서 현재 페이지 목적을 짧게 안내하는 헤더 컴포넌트입니다.
+export function TrashPageHeader() {
+  const t = useTranslations("trash");
+
+  return (
+    <div className="border-b border-(--border) px-4 py-6 min-[1200px]:px-6">
+      <div className="flex flex-col gap-3 min-[1200px]:flex-row min-[1200px]:items-center min-[1200px]:justify-between">
+        <p className="text-sm text-(--muted)">{t("description")}</p>
+      </div>
+    </div>
+  );
+}

--- a/src/features/trash/ui/trashRow.ts
+++ b/src/features/trash/ui/trashRow.ts
@@ -1,0 +1,26 @@
+export type TrashItemRow =
+  | {
+      kind: "folder";
+      id: string;
+      name: string;
+      deletedAt: string | null;
+      typeLabel: string;
+    }
+  | {
+      kind: "clip";
+      id: string;
+      name: string;
+      deletedAt: string | null;
+      typeLabel: string;
+      clipType: "TEXT" | "COLOR" | "IMAGE";
+      parentFolderName: string;
+    };
+
+export const formatDeletedAt = (deletedAt: string | null) => {
+  if (!deletedAt) {
+    return "-";
+  }
+
+  const date = new Date(deletedAt);
+  return Number.isNaN(date.getTime()) ? deletedAt : date.toLocaleString();
+};

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -90,6 +90,7 @@
   },
   "trash": {
     "title": "Trash",
+    "retentionNotice": "Kept for up to 30 days",
     "description": "Review deleted clips and folders, then restore or permanently remove them.",
     "refresh": "Refresh",
     "clearAll": "Empty trash",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -53,6 +53,7 @@
   "sidebar": {
     "favorites": "Favorites",
     "recent": "Recent",
+    "trash": "Trash",
     "addFolder": "Add Folder",
     "reorderFolder": "Reorder folder",
     "openFolderOptions": "Open folder options",
@@ -86,6 +87,47 @@
     "aboutTitle": "Clipboard Studio v1.0.0",
     "aboutDescription": "A modern clipboard manager for designers and developers",
     "closeButton": "Close"
+  },
+  "trash": {
+    "title": "Trash",
+    "description": "Review deleted clips and folders, then restore or permanently remove them.",
+    "refresh": "Refresh",
+    "clearAll": "Empty trash",
+    "cancel": "Cancel",
+    "loading": "Loading trash items.",
+    "error": "Failed to load trash data. Please try again shortly.",
+    "emptyTitle": "Trash is empty",
+    "emptyDescription": "Deleted clips or folders will appear here.",
+    "listTitle": "Deleted items",
+    "totalCount": "{count, plural, =0 {0 items} one {# item} other {# items}}",
+    "folderType": "Folder",
+    "fileType": "File",
+    "parentFolder": "Parent folder",
+    "unknownParentFolder": "Unknown folder",
+    "clipKinds": {
+      "text": "Text",
+      "color": "Color",
+      "image": "Image"
+    },
+    "columns": {
+      "name": "Name",
+      "type": "Type",
+      "deletedAt": "Deleted at",
+      "actions": "Actions"
+    },
+    "clearAllModal": {
+      "title": "Empty trash",
+      "description": "Are you sure you want to permanently delete every item in trash?"
+    },
+    "clipsTitle": "Deleted clips",
+    "clipsCount": "{count, plural, =0 {0 clips} one {# clip} other {# clips}}",
+    "clipsEmpty": "No deleted clips.",
+    "foldersTitle": "Deleted folders",
+    "foldersCount": "{count, plural, =0 {0 folders} one {# folder} other {# folders}}",
+    "foldersEmpty": "No deleted folders.",
+    "deletedAt": "Deleted at",
+    "restore": "Restore",
+    "deleteForever": "Delete forever"
   },
   "clips": {
     "count": "{count, plural, =0 {0 clips} one {# clip} other {# clips}}",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -53,6 +53,7 @@
   "sidebar": {
     "favorites": "お気に入り",
     "recent": "最近",
+    "trash": "ゴミ箱",
     "addFolder": "フォルダ追加",
     "reorderFolder": "フォルダの並び替え",
     "openFolderOptions": "フォルダオプションを開く",
@@ -86,6 +87,47 @@
     "aboutTitle": "Clipboard Studio v1.0.0",
     "aboutDescription": "デザイナーと開発者のためのモダンなクリップボードマネージャー",
     "closeButton": "閉じる"
+  },
+  "trash": {
+    "title": "ゴミ箱",
+    "description": "削除したクリップとフォルダを確認し、復元または完全削除できます。",
+    "refresh": "再読み込み",
+    "clearAll": "ゴミ箱を空にする",
+    "cancel": "キャンセル",
+    "loading": "ゴミ箱を読み込んでいます。",
+    "error": "ゴミ箱データを読み込めませんでした。しばらくしてから再試行してください。",
+    "emptyTitle": "ゴミ箱は空です",
+    "emptyDescription": "削除されたクリップやフォルダがここに表示されます。",
+    "listTitle": "削除済みアイテム",
+    "totalCount": "{count, plural, =0 {0件} other {#件}}",
+    "folderType": "フォルダ",
+    "fileType": "ファイル",
+    "parentFolder": "親フォルダ",
+    "unknownParentFolder": "不明なフォルダ",
+    "clipKinds": {
+      "text": "テキスト",
+      "color": "カラー",
+      "image": "画像"
+    },
+    "columns": {
+      "name": "名前",
+      "type": "種類",
+      "deletedAt": "削除日時",
+      "actions": "操作"
+    },
+    "clearAllModal": {
+      "title": "ゴミ箱を空にする",
+      "description": "本当にゴミ箱内のすべての項目を完全削除しますか？"
+    },
+    "clipsTitle": "削除済みクリップ",
+    "clipsCount": "{count, plural, =0 {クリップ 0件} other {クリップ #件}}",
+    "clipsEmpty": "削除済みクリップはありません。",
+    "foldersTitle": "削除済みフォルダ",
+    "foldersCount": "{count, plural, =0 {フォルダ 0件} other {フォルダ #件}}",
+    "foldersEmpty": "削除済みフォルダはありません。",
+    "deletedAt": "削除日時",
+    "restore": "復元",
+    "deleteForever": "完全削除"
   },
   "clips": {
     "count": "{count, plural, =0 {0 件のクリップ} other {# 件のクリップ}}",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -90,6 +90,7 @@
   },
   "trash": {
     "title": "ゴミ箱",
+    "retentionNotice": "最大30日間保管されます",
     "description": "削除したクリップとフォルダを確認し、復元または完全削除できます。",
     "refresh": "再読み込み",
     "clearAll": "ゴミ箱を空にする",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -90,6 +90,7 @@
   },
   "trash": {
     "title": "휴지통",
+    "retentionNotice": "최대 30일까지 보관됩니다",
     "description": "삭제된 클립과 폴더를 확인하고 복구하거나 영구 삭제할 수 있습니다.",
     "refresh": "새로고침",
     "clearAll": "비우기",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -53,6 +53,7 @@
   "sidebar": {
     "favorites": "즐겨찾기",
     "recent": "최근 항목",
+    "trash": "휴지통",
     "addFolder": "폴더 추가",
     "reorderFolder": "폴더 순서 변경",
     "openFolderOptions": "폴더 옵션 열기",
@@ -86,6 +87,47 @@
     "aboutTitle": "Clipboard Studio v1.0.0",
     "aboutDescription": "디자이너와 개발자를 위한 현대적인 클립보드 매니저",
     "closeButton": "닫기"
+  },
+  "trash": {
+    "title": "휴지통",
+    "description": "삭제된 클립과 폴더를 확인하고 복구하거나 영구 삭제할 수 있습니다.",
+    "refresh": "새로고침",
+    "clearAll": "비우기",
+    "cancel": "취소",
+    "loading": "휴지통을 불러오는 중입니다.",
+    "error": "휴지통 데이터를 불러오지 못했습니다. 잠시 후 다시 시도해주세요.",
+    "emptyTitle": "휴지통이 비어 있습니다",
+    "emptyDescription": "삭제된 클립이나 폴더가 생기면 이곳에 표시됩니다.",
+    "listTitle": "삭제 항목",
+    "totalCount": "{count, plural, =0 {항목 0개} other {항목 #개}}",
+    "folderType": "폴더",
+    "fileType": "파일",
+    "parentFolder": "부모 폴더",
+    "unknownParentFolder": "알 수 없는 폴더",
+    "clipKinds": {
+      "text": "텍스트",
+      "color": "색상",
+      "image": "이미지"
+    },
+    "columns": {
+      "name": "이름",
+      "type": "유형",
+      "deletedAt": "삭제 시각",
+      "actions": "작업"
+    },
+    "clearAllModal": {
+      "title": "휴지통 비우기",
+      "description": "정말 휴지통의 모든 항목을 영구 삭제하시겠습니까?"
+    },
+    "clipsTitle": "삭제된 클립",
+    "clipsCount": "{count, plural, =0 {클립 0개} other {클립 #개}}",
+    "clipsEmpty": "삭제된 클립이 없습니다.",
+    "foldersTitle": "삭제된 폴더",
+    "foldersCount": "{count, plural, =0 {폴더 0개} other {폴더 #개}}",
+    "foldersEmpty": "삭제된 폴더가 없습니다.",
+    "deletedAt": "삭제 시각",
+    "restore": "복구",
+    "deleteForever": "영구 삭제"
   },
   "clips": {
     "count": "{count, plural, =0 {0개 클립} other {#개 클립}}",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -53,6 +53,7 @@
   "sidebar": {
     "favorites": "收藏",
     "recent": "最近",
+    "trash": "回收站",
     "addFolder": "添加文件夹",
     "reorderFolder": "调整文件夹顺序",
     "openFolderOptions": "打开文件夹选项",
@@ -86,6 +87,47 @@
     "aboutTitle": "Clipboard Studio v1.0.0",
     "aboutDescription": "面向设计师和开发者的现代剪贴板管理器",
     "closeButton": "关闭"
+  },
+  "trash": {
+    "title": "回收站",
+    "description": "查看已删除的剪贴内容和文件夹，并可执行恢复或永久删除。",
+    "refresh": "刷新",
+    "clearAll": "清空回收站",
+    "cancel": "取消",
+    "loading": "正在加载回收站内容。",
+    "error": "无法加载回收站数据。请稍后再试。",
+    "emptyTitle": "回收站为空",
+    "emptyDescription": "删除的剪贴内容或文件夹会显示在这里。",
+    "listTitle": "已删除项目",
+    "totalCount": "{count, plural, =0 {0 个项目} other {# 个项目}}",
+    "folderType": "文件夹",
+    "fileType": "文件",
+    "parentFolder": "父级文件夹",
+    "unknownParentFolder": "未知文件夹",
+    "clipKinds": {
+      "text": "文本",
+      "color": "颜色",
+      "image": "图片"
+    },
+    "columns": {
+      "name": "名称",
+      "type": "类型",
+      "deletedAt": "删除时间",
+      "actions": "操作"
+    },
+    "clearAllModal": {
+      "title": "清空回收站",
+      "description": "确定要永久删除回收站中的全部项目吗？"
+    },
+    "clipsTitle": "已删除剪贴内容",
+    "clipsCount": "{count, plural, =0 {0 个剪贴项} other {# 个剪贴项}}",
+    "clipsEmpty": "没有已删除的剪贴内容。",
+    "foldersTitle": "已删除文件夹",
+    "foldersCount": "{count, plural, =0 {0 个文件夹} other {# 个文件夹}}",
+    "foldersEmpty": "没有已删除的文件夹。",
+    "deletedAt": "删除时间",
+    "restore": "恢复",
+    "deleteForever": "永久删除"
   },
   "clips": {
     "count": "{count, plural, =0 {0 个剪贴项} other {# 个剪贴项}}",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -90,6 +90,7 @@
   },
   "trash": {
     "title": "回收站",
+    "retentionNotice": "最多保留 30 天",
     "description": "查看已删除的剪贴内容和文件夹，并可执行恢复或永久删除。",
     "refresh": "刷新",
     "clearAll": "清空回收站",


### PR DESCRIPTION
## PR 요약

- 휴지통 진입점과 휴지통 페이지를 추가하고, 목록/복구/영구 삭제/비우기 UI를 구현했습니다.

## 변경 내용 상세

### 변경 사항

- 사이드바 1차 메뉴에 `휴지통` 진입점을 추가하고 `/trash` 라우트를 연결했습니다.
- 휴지통 전용 API, 훅, UI 컴포넌트를 추가해 삭제된 클립/폴더 목록 조회, 개별 복구, 개별 영구 삭제, 전체 비우기를 구현했습니다.
- 휴지통 UI를 단일 리스트 섹션으로 구성하고, 파일/폴더 타입 표시, 부모 폴더명 표시, 내부 스크롤, 커스텀 스크롤바를 적용했습니다.
- 비우기 버튼 클릭 시 확인 모달을 한 번 더 거치도록 구성했습니다.
- 휴지통 관련 UI를 컴포넌트 단위로 분리하고 각 파일 상단에 한글 설명 주석을 추가했습니다.

### 변경 이유

- 삭제된 항목을 별도 공간에서 일관되게 관리할 수 있는 휴지통 UX가 필요했습니다.
- 스웨거에 정의된 휴지통 API를 기준으로 조회/복구/영구 삭제 기능을 프론트에서 바로 사용할 수 있도록 연결해야 했습니다.
- 목록이 길어질 때도 가독성과 조작성을 유지할 수 있도록 드라이브 형태의 리스트 UI와 내부 스크롤 구조가 필요했습니다.

## 관련 이슈

- Closes #37

## 기타 참고사항

- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 스크립트 없음
- UI 변경 사항이 있어 추후 스크린샷 첨부 가능