### PR TITLE
#41 / feat(clips) : 로딩 스켈레톤 UI 개선

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -238,7 +238,7 @@ a {
   }
 }
 
-.trash-skeleton {
+.skeleton-shimmer {
   background-image: linear-gradient(
     90deg,
     var(--surface-muted) 0%,

--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { startTransition, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import {
   fetchClips,
@@ -12,29 +19,71 @@ import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { Clip } from "@/features/clip/model/clip";
 import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useFavoriteClipsPage = () => {
   const session = useAuthSession();
   const accessToken = session?.accessToken ?? null;
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
+  const [isLoading, setIsLoading] = useState(true);
   const [clips, setClips] = useState<Clip[]>([]);
   const { copyToast, showCopyToast } = useCopyToast();
+  const requestSerialRef = useRef(0);
+  const hasLoadedOnceRef = useRef(false);
 
   const loadFavoriteClips = useCallback(async () => {
+    const requestId = requestSerialRef.current + 1;
+    requestSerialRef.current = requestId;
+    const shouldShowSkeleton = !hasLoadedOnceRef.current;
+    const loadingStartedAt = Date.now();
+
     if (!accessToken) {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
       startTransition(() => {
         setClips([]);
+        hasLoadedOnceRef.current = true;
+        setIsLoading(false);
       });
       return;
     }
 
-    const response = await fetchClips(accessToken, {
-      favorite: true,
-    });
+    if (shouldShowSkeleton) {
+      setIsLoading(true);
+    }
 
-    startTransition(() => {
-      setClips(response.map(mapClipResponse));
-    });
+    try {
+      const response = await fetchClips(accessToken, {
+        favorite: true,
+      });
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
+      startTransition(() => {
+        setClips(response.map(mapClipResponse));
+        hasLoadedOnceRef.current = true;
+      });
+    } finally {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+      if (requestId === requestSerialRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    hasLoadedOnceRef.current = false;
+    setIsLoading(true);
   }, [accessToken]);
 
   useEffect(() => {
@@ -87,6 +136,7 @@ export const useFavoriteClipsPage = () => {
     activeFilter,
     copyToast,
     filteredClips,
+    isLoading,
     setActiveFilter,
     handleCopy,
     handleToggleFavorite,

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -23,6 +23,7 @@ import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { Clip } from "@/features/clip/model/clip";
 import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useFolderClipsPage = () => {
   const params = useParams<{ id?: string }>();
@@ -33,6 +34,7 @@ export const useFolderClipsPage = () => {
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [isActive, setIsActive] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
   const [clips, setClips] = useState<Clip[]>([]);
   const [contextMenu, setContextMenu] = useState<{
     id: string;
@@ -42,29 +44,61 @@ export const useFolderClipsPage = () => {
   const [isDeleteAllOpen, setIsDeleteAllOpen] = useState(false);
   const { copyToast, showCopyToast } = useCopyToast();
   const requestSerialRef = useRef(0);
+  const hasLoadedOnceRef = useRef(false);
 
   const loadFolderClips = useCallback(async () => {
+    const requestId = requestSerialRef.current + 1;
+    requestSerialRef.current = requestId;
+    const shouldShowSkeleton = !hasLoadedOnceRef.current;
+    const loadingStartedAt = Date.now();
+
     if (!accessToken || !folderId) {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
       startTransition(() => {
         setClips([]);
+        hasLoadedOnceRef.current = true;
+        setIsLoading(false);
       });
       return;
     }
 
-    const requestId = requestSerialRef.current + 1;
-    requestSerialRef.current = requestId;
-
-    const response = await fetchClips(accessToken, {
-      folderId,
-    });
-
-    if (requestId !== requestSerialRef.current) {
-      return;
+    if (shouldShowSkeleton) {
+      setIsLoading(true);
     }
 
-    startTransition(() => {
-      setClips(response.map(mapClipResponse));
-    });
+    try {
+      const response = await fetchClips(accessToken, {
+        folderId,
+      });
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
+      startTransition(() => {
+        setClips(response.map(mapClipResponse));
+        hasLoadedOnceRef.current = true;
+      });
+    } finally {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+      if (requestId === requestSerialRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [accessToken, folderId]);
+
+  useEffect(() => {
+    hasLoadedOnceRef.current = false;
+    setIsLoading(true);
   }, [accessToken, folderId]);
 
   useEffect(() => {
@@ -283,6 +317,7 @@ export const useFolderClipsPage = () => {
     hasClips: clips.length > 0,
     isActive,
     isDeleteAllOpen,
+    isLoading,
     searchQuery,
     setActiveFilter,
     setContextMenu,

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -1,6 +1,13 @@
 "use client";
 
-import { startTransition, useCallback, useEffect, useMemo, useState } from "react";
+import {
+  startTransition,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import {
   fetchClips,
@@ -10,30 +17,72 @@ import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { Clip } from "@/features/clip/model/clip";
 import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useRecentClipsPage = () => {
   const session = useAuthSession();
   const accessToken = session?.accessToken ?? null;
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
   const [clips, setClips] = useState<Clip[]>([]);
   const { copyToast, showCopyToast } = useCopyToast();
+  const requestSerialRef = useRef(0);
+  const hasLoadedOnceRef = useRef(false);
 
   const loadRecentClips = useCallback(async () => {
+    const requestId = requestSerialRef.current + 1;
+    requestSerialRef.current = requestId;
+    const shouldShowSkeleton = !hasLoadedOnceRef.current;
+    const loadingStartedAt = Date.now();
+
     if (!accessToken) {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
       startTransition(() => {
         setClips([]);
+        hasLoadedOnceRef.current = true;
+        setIsLoading(false);
       });
       return;
     }
 
-    const response = await fetchClips(accessToken, {
-      recent: true,
-    });
+    if (shouldShowSkeleton) {
+      setIsLoading(true);
+    }
 
-    startTransition(() => {
-      setClips(response.map(mapClipResponse));
-    });
+    try {
+      const response = await fetchClips(accessToken, {
+        recent: true,
+      });
+
+      if (requestId !== requestSerialRef.current) {
+        return;
+      }
+
+      startTransition(() => {
+        setClips(response.map(mapClipResponse));
+        hasLoadedOnceRef.current = true;
+      });
+    } finally {
+      if (shouldShowSkeleton) {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+      if (requestId === requestSerialRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [accessToken]);
+
+  useEffect(() => {
+    hasLoadedOnceRef.current = false;
+    setIsLoading(true);
   }, [accessToken]);
 
   useEffect(() => {
@@ -78,8 +127,9 @@ export const useRecentClipsPage = () => {
     activeFilter,
     copyToast,
     filteredClips,
+    isLoading,
     searchQuery,
-    hasClips: false,
+    hasClips: clips.length > 0,
     setActiveFilter,
     setSearchQuery,
     clearAll: () => undefined,

--- a/src/features/clip/ui/ClipListSkeleton.tsx
+++ b/src/features/clip/ui/ClipListSkeleton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+const SKELETON_CARD_COUNT = 8;
+
+export function ClipListSkeleton() {
+  return (
+    <div className="clip-scrollbar flex-1 overflow-auto px-4 py-4 md:px-6">
+      <div className="grid grid-cols-1 gap-4 min-[800px]:grid-cols-2 min-[1200px]:grid-cols-3 min-[1440px]:grid-cols-4">
+        {Array.from({ length: SKELETON_CARD_COUNT }, (_, index) => (
+          <div
+            key={index}
+            className="flex min-h-44 flex-col justify-between rounded-2xl border border-(--border) bg-(--surface) p-4"
+            aria-hidden
+          >
+            <div className="space-y-3">
+              <div className="flex items-center justify-between gap-3">
+                <div className="skeleton-shimmer h-5 w-24 rounded-md" />
+                <div className="skeleton-shimmer h-8 w-8 rounded-full" />
+              </div>
+              <div className="space-y-2">
+                <div className="skeleton-shimmer h-4 w-full rounded-md" />
+                <div className="skeleton-shimmer h-4 w-5/6 rounded-md" />
+                <div className="skeleton-shimmer h-4 w-2/3 rounded-md" />
+              </div>
+            </div>
+            <div className="flex items-center justify-between gap-3 pt-6">
+              <div className="skeleton-shimmer h-3 w-20 rounded-md" />
+              <div className="skeleton-shimmer h-7 w-16 rounded-full" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/features/clip/ui/ClipResultsSection.tsx
+++ b/src/features/clip/ui/ClipResultsSection.tsx
@@ -2,10 +2,12 @@
 
 import { Clip } from "@/features/clip/model/clip";
 import { ClipList } from "@/features/clip/ui/ClipList";
+import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 import { EmptyState } from "@/features/clip/ui/EmptyState";
 
 interface ClipResultsSectionProps {
   clips: Clip[];
+  isLoading?: boolean;
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
@@ -13,10 +15,15 @@ interface ClipResultsSectionProps {
 
 export function ClipResultsSection({
   clips,
+  isLoading = false,
   onCopy,
   onToggleFavorite,
   onContextMenu,
 }: ClipResultsSectionProps) {
+  if (isLoading) {
+    return <ClipListSkeleton />;
+  }
+
   if (!clips.length) {
     return <EmptyState />;
   }

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -14,6 +14,7 @@ export function FavoriteClipsPage() {
     filteredClips,
     handleCopy,
     handleToggleFavorite,
+    isLoading,
     setActiveFilter,
   } = useFavoriteClipsPage();
 
@@ -27,6 +28,7 @@ export function FavoriteClipsPage() {
       />
       <ClipResultsSection
         clips={filteredClips}
+        isLoading={isLoading}
         onCopy={handleCopy}
         onToggleFavorite={handleToggleFavorite}
       />

--- a/src/features/clip/ui/FavoritesEntryPage.tsx
+++ b/src/features/clip/ui/FavoritesEntryPage.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useFolders } from "@/features/folder/hooks/useFolders";
 import { FavoriteClipsPage } from "@/features/clip/ui/FavoriteClipsPage";
+import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 
 export function FavoritesEntryPage() {
   const router = useRouter();
@@ -18,7 +19,7 @@ export function FavoritesEntryPage() {
   }, [folders, router]);
 
   if (isLoading) {
-    return null;
+    return <ClipListSkeleton />;
   }
 
   if (!folders.length) {

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -27,6 +27,7 @@ export function FolderClipsPage() {
     hasClips,
     isActive,
     isDeleteAllOpen,
+    isLoading,
     searchQuery,
     setActiveFilter,
     setContextMenu,
@@ -56,6 +57,7 @@ export function FolderClipsPage() {
       ) : null}
       <ClipResultsSection
         clips={filteredClips}
+        isLoading={isLoading}
         onCopy={handleCopy}
         onToggleFavorite={handleToggleFavorite}
         onContextMenu={handleOpenContextMenu}

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -16,6 +16,7 @@ export function RecentClipsPage() {
     filteredClips,
     handleCopy,
     hasClips,
+    isLoading,
     searchQuery,
     setActiveFilter,
     setSearchQuery,
@@ -31,7 +32,11 @@ export function RecentClipsPage() {
         showStatus={false}
         countLabel={t("count", { count: filteredClips.length })}
       />
-      <ClipResultsSection clips={filteredClips} onCopy={handleCopy} />
+      <ClipResultsSection
+        clips={filteredClips}
+        isLoading={isLoading}
+        onCopy={handleCopy}
+      />
       <DeleteAllButton disabled={!hasClips} onClick={clearAll} />
       <ClipCopyToast label={t("copyToast")} position={copyToast} />
     </div>

--- a/src/features/clip/ui/RecentEntryPage.tsx
+++ b/src/features/clip/ui/RecentEntryPage.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { useFolders } from "@/features/folder/hooks/useFolders";
 import { RecentClipsPage } from "@/features/clip/ui/RecentClipsPage";
+import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 
 export function RecentEntryPage() {
   const router = useRouter();
@@ -18,7 +19,7 @@ export function RecentEntryPage() {
   }, [folders, router]);
 
   if (isLoading) {
-    return null;
+    return <ClipListSkeleton />;
   }
 
   if (!folders.length) {

--- a/src/features/folder/hooks/useFolders.ts
+++ b/src/features/folder/hooks/useFolders.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import {
   createFolder as createFolderRequest,
@@ -13,6 +13,7 @@ import { FolderItem } from "@/features/folder/model/folder";
 import {
   FolderResponseDto,
 } from "@/features/folder/model/folder.dto";
+import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 const sortFolders = (folders: FolderItem[]) =>
   [...folders].sort((left, right) => left.order - right.order);
@@ -30,10 +31,21 @@ export const useFolders = () => {
   const accessToken = session?.accessToken ?? null;
   const [folders, setFolders] = useState<FolderItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
+  const requestSerialRef = useRef(0);
 
   const refreshFolders = useCallback(async () => {
+    const requestId = requestSerialRef.current + 1;
+    requestSerialRef.current = requestId;
+    const loadingStartedAt = Date.now();
+
     if (!accessToken) {
+      await waitForMinimumLoading(loadingStartedAt);
+      if (requestId !== requestSerialRef.current) {
+        return [];
+      }
+
       setFolders([]);
+      setIsLoading(false);
       return [];
     }
 
@@ -42,10 +54,17 @@ export const useFolders = () => {
     try {
       const response = await fetchFolders(accessToken);
       const nextFolders = sortFolders(response.map(mapFolder));
+      if (requestId !== requestSerialRef.current) {
+        return nextFolders;
+      }
+
       setFolders(nextFolders);
       return nextFolders;
     } finally {
-      setIsLoading(false);
+      await waitForMinimumLoading(loadingStartedAt);
+      if (requestId === requestSerialRef.current) {
+        setIsLoading(false);
+      }
     }
   }, [accessToken]);
 

--- a/src/features/folder/ui/FolderSidebarSection.tsx
+++ b/src/features/folder/ui/FolderSidebarSection.tsx
@@ -12,6 +12,7 @@ import { FolderOptionsMenu } from "@/features/folder/ui/FolderOptionsMenu";
 
 interface FolderSidebarSectionProps {
   folders: FolderItem[];
+  isLoading?: boolean;
   pathname: string;
   addFolderLabel: string;
   reorderFolderLabel: string;
@@ -32,6 +33,7 @@ interface FolderSidebarSectionProps {
 
 export function FolderSidebarSection({
   folders,
+  isLoading = false,
   pathname,
   addFolderLabel,
   reorderFolderLabel,
@@ -49,6 +51,8 @@ export function FolderSidebarSection({
   onRenameFolder,
   onDeleteFolder,
 }: FolderSidebarSectionProps) {
+  const skeletonRows = Array.from({ length: 4 }, (_, index) => index);
+
   return (
     <div className="space-y-2 border-t border-(--border) pt-4">
       <button
@@ -61,63 +65,78 @@ export function FolderSidebarSection({
       </button>
 
       <ul className="space-y-1 px-2">
-        {folders.map((folder) => (
-          <li
-            key={folder.id}
-            onDragOver={(event) => onDragOver(folder.id, event)}
-            className={`relative rounded-lg ${
-              draggingFolderId === folder.id ? "opacity-50" : ""
-            }`}
-          >
-            <div
-              className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
-                pathname === `/${folder.id}`
-                  ? "text-foreground bg-(--surface)"
-                  : "text-muted hover:text-foreground hover:bg-(--surface)"
-              }`}
-            >
-              <button
-                type="button"
-                draggable
-                onDragStart={(event) => onDragStart(folder.id, event)}
-                onDragEnd={onDragEnd}
-                className="text-muted hover:text-foreground cursor-grab rounded p-1"
-                aria-label={reorderFolderLabel}
+        {isLoading
+          ? skeletonRows.map((row) => <FolderSidebarSkeletonRow key={row} />)
+          : folders.map((folder) => (
+              <li
+                key={folder.id}
+                onDragOver={(event) => onDragOver(folder.id, event)}
+                className={`relative rounded-lg ${
+                  draggingFolderId === folder.id ? "opacity-50" : ""
+                }`}
               >
-                <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
-              </button>
+                <div
+                  className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
+                    pathname === `/${folder.id}`
+                      ? "text-foreground bg-(--surface)"
+                      : "text-muted hover:text-foreground hover:bg-(--surface)"
+                  }`}
+                >
+                  <button
+                    type="button"
+                    draggable
+                    onDragStart={(event) => onDragStart(folder.id, event)}
+                    onDragEnd={onDragEnd}
+                    className="text-muted hover:text-foreground cursor-grab rounded p-1"
+                    aria-label={reorderFolderLabel}
+                  >
+                    <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
+                  </button>
 
-              <Link
-                href={`/${folder.id}`}
-                onClick={onNavigate}
-                className="flex flex-1 items-center gap-2 truncate"
-              >
-                <HiOutlineFolder className="h-5 w-5" aria-hidden />
-                <span className="truncate">{folder.name}</span>
-              </Link>
+                  <Link
+                    href={`/${folder.id}`}
+                    onClick={onNavigate}
+                    className="flex flex-1 items-center gap-2 truncate"
+                  >
+                    <HiOutlineFolder className="h-5 w-5" aria-hidden />
+                    <span className="truncate">{folder.name}</span>
+                  </Link>
 
-              <button
-                type="button"
-                onClick={() => onToggleOptions(folder.id)}
-                className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
-                aria-label={openFolderOptionsLabel}
-                data-folder-options
-              >
-                <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
-              </button>
-            </div>
+                  <button
+                    type="button"
+                    onClick={() => onToggleOptions(folder.id)}
+                    className="text-muted hover:text-foreground cursor-pointer rounded p-1 transition"
+                    aria-label={openFolderOptionsLabel}
+                    data-folder-options
+                  >
+                    <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
+                  </button>
+                </div>
 
-            {openOptionsFolderId === folder.id ? (
-              <FolderOptionsMenu
-                renameLabel={renameLabel}
-                deleteLabel={deleteLabel}
-                onRename={() => onRenameFolder(folder.id)}
-                onDelete={() => onDeleteFolder(folder.id)}
-              />
-            ) : null}
-          </li>
-        ))}
+                {openOptionsFolderId === folder.id ? (
+                  <FolderOptionsMenu
+                    renameLabel={renameLabel}
+                    deleteLabel={deleteLabel}
+                    onRename={() => onRenameFolder(folder.id)}
+                    onDelete={() => onDeleteFolder(folder.id)}
+                  />
+                ) : null}
+              </li>
+            ))}
       </ul>
     </div>
+  );
+}
+
+function FolderSidebarSkeletonRow() {
+  return (
+    <li className="rounded-lg px-2 py-2" aria-hidden>
+      <div className="flex items-center gap-2">
+        <div className="skeleton-shimmer h-6 w-6 rounded-md" />
+        <div className="skeleton-shimmer h-5 w-5 rounded-md" />
+        <div className="skeleton-shimmer h-4 flex-1 rounded-md" />
+        <div className="skeleton-shimmer h-6 w-6 rounded-md" />
+      </div>
+    </li>
   );
 }

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -32,8 +32,14 @@ export function Sidebar({
   const pathname = usePathname();
   const router = useRouter();
   const session = useAuthSession();
-  const { createFolder, folders, removeFolder, renameFolder, reorderFolders } =
-    useFolders();
+  const {
+    createFolder,
+    folders,
+    isLoading: isFoldersLoading,
+    removeFolder,
+    renameFolder,
+    reorderFolders,
+  } = useFolders();
   const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
   const [openOptionsFolderId, setOpenOptionsFolderId] = useState<string | null>(
@@ -236,6 +242,7 @@ export function Sidebar({
 
             <FolderSidebarSection
               folders={folders}
+              isLoading={isFoldersLoading}
               pathname={pathname}
               addFolderLabel={t("addFolder")}
               reorderFolderLabel={t("reorderFolder")}

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -16,18 +16,7 @@ import {
   TrashClipResponseDto,
   TrashFolderResponseDto,
 } from "@/features/trash/model/trash.dto";
-
-const MIN_LOADING_MS = 300;
-
-const waitForMinimumLoading = async (startedAt: number) => {
-  const remainingMs = MIN_LOADING_MS - (Date.now() - startedAt);
-
-  if (remainingMs <= 0) {
-    return;
-  }
-
-  await new Promise((resolve) => setTimeout(resolve, remainingMs));
-};
+import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useTrashPage = () => {
   const session = useAuthSession();

--- a/src/features/trash/ui/TrashListSection.tsx
+++ b/src/features/trash/ui/TrashListSection.tsx
@@ -121,18 +121,18 @@ function TrashListSkeletonRow() {
     >
       <div className="flex flex-col gap-3 min-[1200px]:grid min-[1200px]:grid-cols-[minmax(0,1.5fr)_180px_220px_220px] min-[1200px]:items-center min-[1200px]:gap-4">
         <div className="flex min-w-0 items-center gap-3">
-          <div className="trash-skeleton h-10 w-10 shrink-0 rounded-xl" />
+          <div className="skeleton-shimmer h-10 w-10 shrink-0 rounded-xl" />
           <div className="min-w-0 flex-1 space-y-2">
-            <div className="trash-skeleton h-4 w-2/3 rounded-md" />
-            <div className="trash-skeleton h-3 w-1/2 rounded-md" />
+            <div className="skeleton-shimmer h-4 w-2/3 rounded-md" />
+            <div className="skeleton-shimmer h-3 w-1/2 rounded-md" />
           </div>
         </div>
 
-        <div className="trash-skeleton h-7 w-24 rounded-full" />
-        <div className="trash-skeleton h-4 w-32 rounded-md" />
+        <div className="skeleton-shimmer h-7 w-24 rounded-full" />
+        <div className="skeleton-shimmer h-4 w-32 rounded-md" />
         <div className="flex flex-wrap justify-end gap-2 min-[1200px]:justify-start">
-          <div className="trash-skeleton h-8 w-16 rounded-lg" />
-          <div className="trash-skeleton h-8 w-20 rounded-lg" />
+          <div className="skeleton-shimmer h-8 w-16 rounded-lg" />
+          <div className="skeleton-shimmer h-8 w-20 rounded-lg" />
         </div>
       </div>
     </article>

--- a/src/shared/lib/loading.ts
+++ b/src/shared/lib/loading.ts
@@ -1,0 +1,11 @@
+export const MIN_LOADING_MS = 300;
+
+export const waitForMinimumLoading = async (startedAt: number) => {
+  const remainingMs = MIN_LOADING_MS - (Date.now() - startedAt);
+
+  if (remainingMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, remainingMs));
+};


### PR DESCRIPTION
## PR 요약

- 주요 목록 화면의 로딩 상태를 쉬머 스켈레톤 UI로 개선합니다.

## 변경 내용 상세

### 변경 사항

- 클립 카드 그리드용 스켈레톤 UI를 추가했습니다.
- 휴지통 전용 `trash-skeleton` 스타일을 공통 `skeleton-shimmer` 스타일로 정리했습니다.
- 폴더별 클립, 즐겨찾기, 최근 항목, `/favorites`, `/recent` 진입 화면에 스켈레톤 로딩을 적용했습니다.
- 사이드바 폴더 목록 로딩 중 행 형태 스켈레톤을 표시하도록 개선했습니다.
- 로딩 최소 표시 시간 0.3초를 공통 유틸로 분리했습니다.
- 클립 목록은 초기 로딩에서만 스켈레톤을 표시하고, 붙여넣기/즐겨찾기/복사 후 재조회에서는 기존 리스트를 유지하도록 조정했습니다.

### 변경 이유

- API 요청 중 빈 상태나 깜빡임이 먼저 노출되는 문제를 줄이고, 실제 레이아웃과 유사한 로딩 상태를 제공하기 위함입니다.

## 관련 이슈

- Closes #41

## 기타 참고사항

- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 스크립트 없음
