### PR TITLE
#43 / feat(clips) : 클립 무한 스크롤 조회 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,13 @@
       "name": "easy-clip-fe",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.101.0",
         "next": "16.1.1",
         "next-intl": "^4.13.0",
         "react": "19.2.3",
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
+        "react-intersection-observer": "^10.0.3",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -2127,6 +2129,32 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.0.tgz",
+      "integrity": "sha512-cQetA74EB+seWySv1TTKr828TnP0u39m6LykwDXIo84SNortpDkp30TMEjkqtYCNP9c40uT/iwl6MLiufEt0Ow==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.0.tgz",
+      "integrity": "sha512-rLlJXSpkqfizLWgkR5+eLeIk0MvTx/meEIR7LRjxic+qxiQP8zVjq7BqQkiCMNLQBlLfuOLqqr6KO5GtrDlmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -6246,6 +6274,21 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "*"
+      }
+    },
+    "node_modules/react-intersection-observer": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/react-intersection-observer/-/react-intersection-observer-10.0.3.tgz",
+      "integrity": "sha512-luICLMbs0zxTO/70Zy7K5jOXkABPEVSAF8T3FdZUlctsrIaPLmx8TZe2SSA+CY2HGWfz2INyNTnp82pxNNsShA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.101.0",
     "next": "16.1.1",
     "next-intl": "^4.13.0",
     "react": "19.2.3",
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",
+    "react-intersection-observer": "^10.0.3",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getInitialLocale } from "@/shared/server/getUserLocale";
 import { IntlProvider } from "@/shared/ui/IntlProvider";
+import { QueryProvider } from "@/shared/ui/QueryProvider";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -19,7 +20,9 @@ export default async function RootLayout({
   return (
     <html lang={locale}>
       <body className="bg-slate-50 antialiased">
-        <IntlProvider initialLocale={locale}>{children}</IntlProvider>
+        <QueryProvider>
+          <IntlProvider initialLocale={locale}>{children}</IntlProvider>
+        </QueryProvider>
       </body>
     </html>
   );

--- a/src/features/clip/api/clipApi.ts
+++ b/src/features/clip/api/clipApi.ts
@@ -8,7 +8,6 @@ import {
 } from "@/features/clip/model/clip.dto";
 import { apiRequest } from "@/shared/lib/apiClient";
 
-//? 이거 뭔지 확인
 export const fetchClips = async (
   accessToken: string,
   options: FetchClipsQueryDto = {},
@@ -32,15 +31,14 @@ export const fetchClips = async (
     searchParams.set("q", options.q.trim());
   }
 
-  const response = await apiRequest<ClipCursorPageResponseDto>(
-    `/clips?${searchParams.toString()}`,
-    {
-      accessToken,
-      cache: "no-store",
-    },
-  );
+  if (options.cursor) {
+    searchParams.set("cursor", options.cursor);
+  }
 
-  return response.items;
+  return apiRequest<ClipCursorPageResponseDto>(`/clips?${searchParams}`, {
+    accessToken,
+    cache: "no-store",
+  });
 };
 
 export const createTextClip = (

--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -1,101 +1,39 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
 import {
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import {
-  fetchClips,
   likeClip,
   recordClipView,
   unlikeClip,
 } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
+import {
+  CLIP_QUERY_KEY,
+  useInfiniteClips,
+} from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
-import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
-import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useFavoriteClipsPage = () => {
-  const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
-  const [isLoading, setIsLoading] = useState(true);
-  const [clips, setClips] = useState<Clip[]>([]);
   const { copyToast, showCopyToast } = useCopyToast();
-  const requestSerialRef = useRef(0);
-  const hasLoadedOnceRef = useRef(false);
+  const {
+    accessToken,
+    clips,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+  } = useInfiniteClips({
+    favorite: true,
+    filter: activeFilter,
+  });
 
-  const loadFavoriteClips = useCallback(async () => {
-    const requestId = requestSerialRef.current + 1;
-    requestSerialRef.current = requestId;
-    const shouldShowSkeleton = !hasLoadedOnceRef.current;
-    const loadingStartedAt = Date.now();
-
-    if (!accessToken) {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips([]);
-        hasLoadedOnceRef.current = true;
-        setIsLoading(false);
-      });
-      return;
-    }
-
-    if (shouldShowSkeleton) {
-      setIsLoading(true);
-    }
-
-    try {
-      const response = await fetchClips(accessToken, {
-        favorite: true,
-      });
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips(response.map(mapClipResponse));
-        hasLoadedOnceRef.current = true;
-      });
-    } finally {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-      if (requestId === requestSerialRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [accessToken]);
-
-  useEffect(() => {
-    hasLoadedOnceRef.current = false;
-    setIsLoading(true);
-  }, [accessToken]);
-
-  useEffect(() => {
-    void loadFavoriteClips();
-  }, [loadFavoriteClips]);
-
-  const filteredClips = useMemo(
-    () =>
-      clips.filter(
-        (clip) => activeFilter === "all" || clip.type === activeFilter,
-      ),
-    [activeFilter, clips],
+  const refreshClipQueries = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
+    [queryClient],
   );
 
   const handleCopy = useCallback(
@@ -127,16 +65,19 @@ export const useFavoriteClipsPage = () => {
         await likeClip(accessToken, clip.id);
       }
 
-      await loadFavoriteClips();
+      await refreshClipQueries();
     },
-    [accessToken, loadFavoriteClips],
+    [accessToken, refreshClipQueries],
   );
 
   return {
     activeFilter,
     copyToast,
-    filteredClips,
-    isLoading,
+    fetchNextPage,
+    filteredClips: clips,
+    hasNextPage: Boolean(hasNextPage),
+    isFetchingNextPage,
+    isLoading: isPending,
     setActiveFilter,
     handleCopy,
     handleToggleFavorite,

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -1,41 +1,36 @@
 "use client";
 
 import { useParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import {
-  startTransition,
   useCallback,
   useEffect,
-  useMemo,
-  useRef,
   useState,
 } from "react";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import {
   createImageClip,
   createTextClip,
-  fetchClips,
   likeClip,
   recordClipView,
   removeClip,
   unlikeClip,
 } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
+import {
+  CLIP_QUERY_KEY,
+  useInfiniteClips,
+} from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
-import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
-import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useFolderClipsPage = () => {
   const params = useParams<{ id?: string }>();
   const router = useRouter();
   const folderId = params?.id ?? "";
-  const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
   const [isActive, setIsActive] = useState(false);
-  const [isLoading, setIsLoading] = useState(true);
-  const [clips, setClips] = useState<Clip[]>([]);
   const [contextMenu, setContextMenu] = useState<{
     id: string;
     x: number;
@@ -43,83 +38,25 @@ export const useFolderClipsPage = () => {
   } | null>(null);
   const [isDeleteAllOpen, setIsDeleteAllOpen] = useState(false);
   const { copyToast, showCopyToast } = useCopyToast();
-  const requestSerialRef = useRef(0);
-  const hasLoadedOnceRef = useRef(false);
+  const {
+    accessToken,
+    clips,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+    queryKey,
+  } = useInfiniteClips({
+    folderId,
+    filter: activeFilter,
+    searchQuery,
+    enabled: Boolean(folderId),
+  });
 
-  const loadFolderClips = useCallback(async () => {
-    const requestId = requestSerialRef.current + 1;
-    requestSerialRef.current = requestId;
-    const shouldShowSkeleton = !hasLoadedOnceRef.current;
-    const loadingStartedAt = Date.now();
-
-    if (!accessToken || !folderId) {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips([]);
-        hasLoadedOnceRef.current = true;
-        setIsLoading(false);
-      });
-      return;
-    }
-
-    if (shouldShowSkeleton) {
-      setIsLoading(true);
-    }
-
-    try {
-      const response = await fetchClips(accessToken, {
-        folderId,
-      });
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips(response.map(mapClipResponse));
-        hasLoadedOnceRef.current = true;
-      });
-    } finally {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-      if (requestId === requestSerialRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [accessToken, folderId]);
-
-  useEffect(() => {
-    hasLoadedOnceRef.current = false;
-    setIsLoading(true);
-  }, [accessToken, folderId]);
-
-  useEffect(() => {
-    void loadFolderClips();
-  }, [loadFolderClips]);
-
-  const filteredClips = useMemo(() => {
-    const clipsByType =
-      activeFilter === "all"
-        ? clips
-        : clips.filter((clip) => clip.type === activeFilter);
-
-    if (!searchQuery.trim()) {
-      return clipsByType;
-    }
-
-    const loweredQuery = searchQuery.toLowerCase();
-    return clipsByType.filter((clip) =>
-      clip.name.toLowerCase().includes(loweredQuery),
-    );
-  }, [activeFilter, clips, searchQuery]);
+  const refreshClipQueries = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
+    [queryClient],
+  );
 
   useEffect(() => {
     const handleBlur = () => setIsActive(false);
@@ -165,9 +102,9 @@ export const useFolderClipsPage = () => {
         folderId,
         text: trimmed,
       });
-      await loadFolderClips();
+      await refreshClipQueries();
     },
-    [accessToken, folderId, loadFolderClips],
+    [accessToken, folderId, refreshClipQueries],
   );
 
   const createImageClipFromPaste = useCallback(
@@ -180,9 +117,9 @@ export const useFolderClipsPage = () => {
         folderId,
         file,
       });
-      await loadFolderClips();
+      await refreshClipQueries();
     },
-    [accessToken, folderId, loadFolderClips],
+    [accessToken, folderId, refreshClipQueries],
   );
 
   useEffect(() => {
@@ -268,9 +205,9 @@ export const useFolderClipsPage = () => {
         await likeClip(accessToken, clip.id);
       }
 
-      await loadFolderClips();
+      await refreshClipQueries();
     },
-    [accessToken, loadFolderClips],
+    [accessToken, refreshClipQueries],
   );
 
   const handleOpenContextMenu = useCallback(
@@ -293,9 +230,9 @@ export const useFolderClipsPage = () => {
 
       await removeClip(accessToken, clipId);
       setContextMenu(null);
-      await loadFolderClips();
+      await refreshClipQueries();
     },
-    [accessToken, loadFolderClips],
+    [accessToken, refreshClipQueries],
   );
 
   const handleDeleteAll = useCallback(async () => {
@@ -305,19 +242,23 @@ export const useFolderClipsPage = () => {
 
     await Promise.all(clips.map((clip) => removeClip(accessToken, clip.id)));
     setIsDeleteAllOpen(false);
-    await loadFolderClips();
-  }, [accessToken, clips, loadFolderClips]);
+    await refreshClipQueries();
+  }, [accessToken, clips, refreshClipQueries]);
 
   return {
     activeFilter,
     clips,
     contextMenu,
     copyToast,
-    filteredClips,
+    fetchNextPage,
+    filteredClips: clips,
     hasClips: clips.length > 0,
+    hasNextPage: Boolean(hasNextPage),
     isActive,
     isDeleteAllOpen,
-    isLoading,
+    isFetchingNextPage,
+    isLoading: isPending,
+    queryKey,
     searchQuery,
     setActiveFilter,
     setContextMenu,

--- a/src/features/clip/hooks/useInfiniteClips.ts
+++ b/src/features/clip/hooks/useInfiniteClips.ts
@@ -1,0 +1,104 @@
+"use client";
+
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { fetchClips } from "@/features/clip/api/clipApi";
+import { Clip } from "@/features/clip/model/clip";
+import { FetchClipsQueryDto } from "@/features/clip/model/clip.dto";
+import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
+import { FilterType } from "@/features/clip/ui/FilterBar";
+import { waitForMinimumLoading } from "@/shared/lib/loading";
+
+const mapFilterToApiType = (
+  filter: FilterType,
+): FetchClipsQueryDto["type"] => {
+  if (filter === "all") {
+    return "ALL";
+  }
+
+  return filter.toUpperCase() as FetchClipsQueryDto["type"];
+};
+
+interface UseInfiniteClipsOptions {
+  folderId?: string;
+  favorite?: boolean;
+  recent?: boolean;
+  filter: FilterType;
+  searchQuery?: string;
+  enabled?: boolean;
+}
+
+export const CLIP_QUERY_KEY = "clips";
+
+export const useInfiniteClips = ({
+  folderId,
+  favorite,
+  recent,
+  filter,
+  searchQuery = "",
+  enabled = true,
+}: UseInfiniteClipsOptions) => {
+  const session = useAuthSession();
+  const accessToken = session?.accessToken ?? null;
+  const normalizedSearchQuery = searchQuery.trim();
+  const queryKey = [
+    CLIP_QUERY_KEY,
+    {
+      folderId: folderId ?? null,
+      favorite: Boolean(favorite),
+      recent: Boolean(recent),
+      type: mapFilterToApiType(filter),
+      q: normalizedSearchQuery,
+    },
+  ] as const;
+
+  const query = useInfiniteQuery({
+    queryKey,
+    enabled: Boolean(accessToken) && enabled,
+    initialPageParam: null as string | null,
+    queryFn: async ({ pageParam }) => {
+      if (!accessToken) {
+        return {
+          items: [],
+          hasMore: false,
+          nextCursor: null,
+        };
+      }
+
+      const loadingStartedAt = Date.now();
+
+      try {
+        return await fetchClips(accessToken, {
+          folderId,
+          favorite,
+          recent,
+          type: mapFilterToApiType(filter),
+          q: normalizedSearchQuery,
+          cursor: pageParam,
+        });
+      } finally {
+        await waitForMinimumLoading(loadingStartedAt);
+      }
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.hasMore ? lastPage.nextCursor : undefined,
+    placeholderData: (previousData) => previousData,
+  });
+
+  const clips = useMemo<Clip[]>(
+    () =>
+      query.data?.pages.flatMap((page) =>
+        page.items.map((clip) => mapClipResponse(clip)),
+      ) ?? [],
+    [query.data],
+  );
+
+  return {
+    ...query,
+    accessToken,
+    clips,
+    isPending: Boolean(accessToken) && enabled && query.isPending,
+    queryKey,
+  };
+};

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -1,109 +1,38 @@
 "use client";
 
-import {
-  startTransition,
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from "react";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import {
-  fetchClips,
-  recordClipView,
-} from "@/features/clip/api/clipApi";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useState } from "react";
+import { recordClipView } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
+import {
+  CLIP_QUERY_KEY,
+  useInfiniteClips,
+} from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
-import { mapClipResponse } from "@/features/clip/service/mapClipResponse";
 import { FilterType } from "@/features/clip/ui/FilterBar";
-import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useRecentClipsPage = () => {
-  const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
-  const [isLoading, setIsLoading] = useState(true);
-  const [clips, setClips] = useState<Clip[]>([]);
   const { copyToast, showCopyToast } = useCopyToast();
-  const requestSerialRef = useRef(0);
-  const hasLoadedOnceRef = useRef(false);
+  const {
+    accessToken,
+    clips,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isPending,
+  } = useInfiniteClips({
+    recent: true,
+    filter: activeFilter,
+    searchQuery,
+  });
 
-  const loadRecentClips = useCallback(async () => {
-    const requestId = requestSerialRef.current + 1;
-    requestSerialRef.current = requestId;
-    const shouldShowSkeleton = !hasLoadedOnceRef.current;
-    const loadingStartedAt = Date.now();
-
-    if (!accessToken) {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips([]);
-        hasLoadedOnceRef.current = true;
-        setIsLoading(false);
-      });
-      return;
-    }
-
-    if (shouldShowSkeleton) {
-      setIsLoading(true);
-    }
-
-    try {
-      const response = await fetchClips(accessToken, {
-        recent: true,
-      });
-
-      if (requestId !== requestSerialRef.current) {
-        return;
-      }
-
-      startTransition(() => {
-        setClips(response.map(mapClipResponse));
-        hasLoadedOnceRef.current = true;
-      });
-    } finally {
-      if (shouldShowSkeleton) {
-        await waitForMinimumLoading(loadingStartedAt);
-      }
-      if (requestId === requestSerialRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [accessToken]);
-
-  useEffect(() => {
-    hasLoadedOnceRef.current = false;
-    setIsLoading(true);
-  }, [accessToken]);
-
-  useEffect(() => {
-    void loadRecentClips();
-  }, [loadRecentClips]);
-
-  const filteredClips = useMemo(() => {
-    const clipsByType =
-      activeFilter === "all"
-        ? clips
-        : clips.filter((clip) => clip.type === activeFilter);
-
-    if (!searchQuery.trim()) {
-      return clipsByType;
-    }
-
-    const loweredQuery = searchQuery.toLowerCase();
-    return clipsByType.filter((clip) =>
-      clip.name.toLowerCase().includes(loweredQuery),
-    );
-  }, [activeFilter, clips, searchQuery]);
+  const refreshClipQueries = useCallback(
+    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
+    [queryClient],
+  );
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
@@ -117,17 +46,20 @@ export const useRecentClipsPage = () => {
 
       if (accessToken) {
         await recordClipView(accessToken, clip.id);
-        await loadRecentClips();
+        await refreshClipQueries();
       }
     },
-    [accessToken, loadRecentClips, showCopyToast],
+    [accessToken, refreshClipQueries, showCopyToast],
   );
 
   return {
     activeFilter,
     copyToast,
-    filteredClips,
-    isLoading,
+    fetchNextPage,
+    filteredClips: clips,
+    hasNextPage: Boolean(hasNextPage),
+    isFetchingNextPage,
+    isLoading: isPending,
     searchQuery,
     hasClips: clips.length > 0,
     setActiveFilter,

--- a/src/features/clip/model/clip.dto.ts
+++ b/src/features/clip/model/clip.dto.ts
@@ -47,6 +47,7 @@ export interface FetchClipsQueryDto {
   recent?: boolean;
   type?: "TEXT" | "COLOR" | "IMAGE" | "ALL";
   q?: string;
+  cursor?: string | null;
 }
 
 export interface CreateTextClipRequestDto {

--- a/src/features/clip/ui/ClipList.tsx
+++ b/src/features/clip/ui/ClipList.tsx
@@ -5,6 +5,8 @@ import { Clip } from "@/features/clip/model/clip";
 
 interface ClipListProps {
   clips: Clip[];
+  loadMoreRef?: React.Ref<HTMLDivElement>;
+  isFetchingNextPage?: boolean;
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
@@ -12,6 +14,8 @@ interface ClipListProps {
 
 export function ClipList({
   clips,
+  loadMoreRef,
+  isFetchingNextPage = false,
   onCopy,
   onToggleFavorite,
   onContextMenu,
@@ -33,6 +37,12 @@ export function ClipList({
           />
         ))}
       </div>
+      <div ref={loadMoreRef} className="h-8" aria-hidden />
+      {isFetchingNextPage ? (
+        <div className="flex justify-center pb-6">
+          <div className="skeleton-shimmer h-2 w-24 rounded-full" />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/features/clip/ui/ClipResultsSection.tsx
+++ b/src/features/clip/ui/ClipResultsSection.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef } from "react";
+import { useInView } from "react-intersection-observer";
 import { Clip } from "@/features/clip/model/clip";
 import { ClipList } from "@/features/clip/ui/ClipList";
 import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
@@ -8,6 +10,9 @@ import { EmptyState } from "@/features/clip/ui/EmptyState";
 interface ClipResultsSectionProps {
   clips: Clip[];
   isLoading?: boolean;
+  hasNextPage?: boolean;
+  isFetchingNextPage?: boolean;
+  onFetchNextPage?: () => void;
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
@@ -16,10 +21,36 @@ interface ClipResultsSectionProps {
 export function ClipResultsSection({
   clips,
   isLoading = false,
+  hasNextPage = false,
+  isFetchingNextPage = false,
+  onFetchNextPage,
   onCopy,
   onToggleFavorite,
   onContextMenu,
 }: ClipResultsSectionProps) {
+  const hasTriggeredInViewRef = useRef(false);
+  const { ref, inView } = useInView({
+    rootMargin: "240px 0px",
+  });
+
+  useEffect(() => {
+    if (!inView) {
+      hasTriggeredInViewRef.current = false;
+      return;
+    }
+
+    if (!inView || !hasNextPage || isFetchingNextPage || !onFetchNextPage) {
+      return;
+    }
+
+    if (hasTriggeredInViewRef.current) {
+      return;
+    }
+
+    hasTriggeredInViewRef.current = true;
+    onFetchNextPage();
+  }, [hasNextPage, inView, isFetchingNextPage, onFetchNextPage]);
+
   if (isLoading) {
     return <ClipListSkeleton />;
   }
@@ -31,6 +62,8 @@ export function ClipResultsSection({
   return (
     <ClipList
       clips={clips}
+      loadMoreRef={ref}
+      isFetchingNextPage={isFetchingNextPage}
       onCopy={onCopy}
       onToggleFavorite={onToggleFavorite}
       onContextMenu={onContextMenu}

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -11,9 +11,12 @@ export function FavoriteClipsPage() {
   const {
     activeFilter,
     copyToast,
+    fetchNextPage,
     filteredClips,
     handleCopy,
     handleToggleFavorite,
+    hasNextPage,
+    isFetchingNextPage,
     isLoading,
     setActiveFilter,
   } = useFavoriteClipsPage();
@@ -28,7 +31,12 @@ export function FavoriteClipsPage() {
       />
       <ClipResultsSection
         clips={filteredClips}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
         isLoading={isLoading}
+        onFetchNextPage={() => {
+          void fetchNextPage();
+        }}
         onCopy={handleCopy}
         onToggleFavorite={handleToggleFavorite}
       />

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -17,6 +17,7 @@ export function FolderClipsPage() {
     clips,
     contextMenu,
     copyToast,
+    fetchNextPage,
     filteredClips,
     handleCopy,
     handleCopyFromMenu,
@@ -24,9 +25,11 @@ export function FolderClipsPage() {
     handleDeleteClip,
     handleOpenContextMenu,
     handleToggleFavorite,
+    hasNextPage,
     hasClips,
     isActive,
     isDeleteAllOpen,
+    isFetchingNextPage,
     isLoading,
     searchQuery,
     setActiveFilter,
@@ -57,7 +60,12 @@ export function FolderClipsPage() {
       ) : null}
       <ClipResultsSection
         clips={filteredClips}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
         isLoading={isLoading}
+        onFetchNextPage={() => {
+          void fetchNextPage();
+        }}
         onCopy={handleCopy}
         onToggleFavorite={handleToggleFavorite}
         onContextMenu={handleOpenContextMenu}

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -13,9 +13,12 @@ export function RecentClipsPage() {
     activeFilter,
     clearAll,
     copyToast,
+    fetchNextPage,
     filteredClips,
     handleCopy,
+    hasNextPage,
     hasClips,
+    isFetchingNextPage,
     isLoading,
     searchQuery,
     setActiveFilter,
@@ -34,7 +37,12 @@ export function RecentClipsPage() {
       />
       <ClipResultsSection
         clips={filteredClips}
+        hasNextPage={hasNextPage}
+        isFetchingNextPage={isFetchingNextPage}
         isLoading={isLoading}
+        onFetchNextPage={() => {
+          void fetchNextPage();
+        }}
         onCopy={handleCopy}
       />
       <DeleteAllButton disabled={!hasClips} onClick={clearAll} />

--- a/src/shared/ui/QueryProvider.tsx
+++ b/src/shared/ui/QueryProvider.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { useState } from "react";
+
+export function QueryProvider({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            staleTime: 30_000,
+          },
+        },
+      }),
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}


### PR DESCRIPTION
## PR 요약

- 클립 목록을 React Query 기반 무한스크롤로 조회하도록 개선했습니다.

## 변경 내용 상세

### 변경 사항

- `useInfiniteClips` 공통 훅을 추가해 폴더/최근/즐겨찾기 클립 목록의 커서 기반 조회를 통합했습니다.
- React Query Provider를 전역에 연결하고 클립 쿼리 캐싱 및 재조회 흐름을 적용했습니다.
- Intersection Observer 기반 다음 페이지 조회를 추가하고, sentinel이 계속 보이는 상태에서 중복 조회되지 않도록 보정했습니다.
- 클립 API 요청에 `cursor` 파라미터를 포함하고 커서 페이지 응답을 그대로 사용하도록 변경했습니다.

### 변경 이유

- 백엔드의 커서 기반 목록 응답과 프론트 조회 흐름을 맞춰 폴더 클립 목록에서 다음 페이지가 안정적으로 조회되도록 하기 위함입니다.
- 페이지별로 중복되던 목록 조회 상태 관리를 공통 훅으로 정리해 유지보수성을 높이기 위함입니다.

## 관련 이슈

- Closes #43

## 기타 참고사항

- Before/After 스크린샷: 렌더러 UI 형태 변경보다는 조회 동작 개선이라 별도 첨부하지 않았습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 미실행, package 스크립트 없음
- `npm run test:e2e`: 미실행, e2e 스크립트 없음