### PR TITLE
#45 / refactor(clips) : 서버 상태 캐시 관리 구조 정리

### DIFF
--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -8,11 +8,9 @@ import {
   unlikeClip,
 } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
-import {
-  CLIP_QUERY_KEY,
-  useInfiniteClips,
-} from "@/features/clip/hooks/useInfiniteClips";
+import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import { updateClipFavoriteCache } from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 
 export const useFavoriteClipsPage = () => {
@@ -30,11 +28,6 @@ export const useFavoriteClipsPage = () => {
     favorite: true,
     filter: activeFilter,
   });
-
-  const refreshClipQueries = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
-    [queryClient],
-  );
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
@@ -59,15 +52,24 @@ export const useFavoriteClipsPage = () => {
         return;
       }
 
-      if (clip.isFavorite) {
-        await unlikeClip(accessToken, clip.id);
-      } else {
-        await likeClip(accessToken, clip.id);
-      }
+      const nextFavorite = !clip.isFavorite;
+      const rollbackFavorite = updateClipFavoriteCache(
+        queryClient,
+        clip.id,
+        nextFavorite,
+      );
 
-      await refreshClipQueries();
+      try {
+        if (nextFavorite) {
+          await likeClip(accessToken, clip.id);
+        } else {
+          await unlikeClip(accessToken, clip.id);
+        }
+      } catch {
+        rollbackFavorite();
+      }
     },
-    [accessToken, refreshClipQueries],
+    [accessToken, queryClient],
   );
 
   return {

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -17,10 +17,13 @@ import {
 } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import {
-  CLIP_QUERY_KEY,
   useInfiniteClips,
 } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import {
+  invalidateClipQueries,
+  updateClipFavoriteCache,
+} from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 
 export const useFolderClipsPage = () => {
@@ -45,7 +48,6 @@ export const useFolderClipsPage = () => {
     hasNextPage,
     isFetchingNextPage,
     isPending,
-    queryKey,
   } = useInfiniteClips({
     folderId,
     filter: activeFilter,
@@ -54,7 +56,7 @@ export const useFolderClipsPage = () => {
   });
 
   const refreshClipQueries = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
+    () => invalidateClipQueries(queryClient),
     [queryClient],
   );
 
@@ -199,15 +201,24 @@ export const useFolderClipsPage = () => {
         return;
       }
 
-      if (clip.isFavorite) {
-        await unlikeClip(accessToken, clip.id);
-      } else {
-        await likeClip(accessToken, clip.id);
-      }
+      const nextFavorite = !clip.isFavorite;
+      const rollbackFavorite = updateClipFavoriteCache(
+        queryClient,
+        clip.id,
+        nextFavorite,
+      );
 
-      await refreshClipQueries();
+      try {
+        if (nextFavorite) {
+          await likeClip(accessToken, clip.id);
+        } else {
+          await unlikeClip(accessToken, clip.id);
+        }
+      } catch {
+        rollbackFavorite();
+      }
     },
-    [accessToken, refreshClipQueries],
+    [accessToken, queryClient],
   );
 
   const handleOpenContextMenu = useCallback(
@@ -258,7 +269,6 @@ export const useFolderClipsPage = () => {
     isDeleteAllOpen,
     isFetchingNextPage,
     isLoading: isPending,
-    queryKey,
     searchQuery,
     setActiveFilter,
     setContextMenu,

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -4,11 +4,9 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useState } from "react";
 import { recordClipView } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
-import {
-  CLIP_QUERY_KEY,
-  useInfiniteClips,
-} from "@/features/clip/hooks/useInfiniteClips";
+import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 
 export const useRecentClipsPage = () => {
@@ -30,7 +28,7 @@ export const useRecentClipsPage = () => {
   });
 
   const refreshClipQueries = useCallback(
-    () => queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
+    () => invalidateClipQueries(queryClient),
     [queryClient],
   );
 

--- a/src/features/clip/service/clipQueryCache.ts
+++ b/src/features/clip/service/clipQueryCache.ts
@@ -1,0 +1,74 @@
+"use client";
+
+import {
+  InfiniteData,
+  QueryClient,
+  QueryKey,
+} from "@tanstack/react-query";
+import { CLIP_QUERY_KEY } from "@/features/clip/hooks/useInfiniteClips";
+import { ClipCursorPageResponseDto } from "@/features/clip/model/clip.dto";
+
+type ClipQueryOptions = {
+  favorite?: boolean;
+};
+
+const getClipQueryOptions = (queryKey: QueryKey) =>
+  queryKey[1] as ClipQueryOptions | undefined;
+
+const updateClipFavoriteData = (
+  data: InfiniteData<ClipCursorPageResponseDto> | undefined,
+  queryKey: QueryKey,
+  clipId: string,
+  isFavorite: boolean,
+) => {
+  if (!data) {
+    return data;
+  }
+
+  const queryOptions = getClipQueryOptions(queryKey);
+  const shouldRemoveFromFavorites =
+    queryOptions?.favorite === true && !isFavorite;
+
+  return {
+    ...data,
+    pages: data.pages.map((page) => ({
+      ...page,
+      items: shouldRemoveFromFavorites
+        ? page.items.filter((clip) => clip.id !== clipId)
+        : page.items.map((clip) =>
+            clip.id === clipId ? { ...clip, likeByMe: isFavorite } : clip,
+          ),
+    })),
+  };
+};
+
+export const invalidateClipQueries = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] });
+
+export const updateClipFavoriteCache = (
+  queryClient: QueryClient,
+  clipId: string,
+  isFavorite: boolean,
+) => {
+  const clipQueries = queryClient
+    .getQueryCache()
+    .findAll({ queryKey: [CLIP_QUERY_KEY] });
+  const snapshots = clipQueries.map((query) => ({
+    queryKey: query.queryKey,
+    data: query.state.data,
+  }));
+
+  for (const query of clipQueries) {
+    queryClient.setQueryData<InfiniteData<ClipCursorPageResponseDto>>(
+      query.queryKey,
+      (data) =>
+        updateClipFavoriteData(data, query.queryKey, clipId, isFavorite),
+    );
+  }
+
+  return () => {
+    for (const snapshot of snapshots) {
+      queryClient.setQueryData(snapshot.queryKey, snapshot.data);
+    }
+  };
+};

--- a/src/features/folder/hooks/useFolders.ts
+++ b/src/features/folder/hooks/useFolders.ts
@@ -1,6 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  useCallback,
+  useMemo,
+} from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import {
   createFolder as createFolderRequest,
@@ -10,10 +18,13 @@ import {
   updateFolder as updateFolderRequest,
 } from "@/features/folder/api/folderApi";
 import { FolderItem } from "@/features/folder/model/folder";
-import {
-  FolderResponseDto,
-} from "@/features/folder/model/folder.dto";
+import { FolderResponseDto } from "@/features/folder/model/folder.dto";
 import { waitForMinimumLoading } from "@/shared/lib/loading";
+
+export const FOLDER_QUERY_KEY = "folders";
+const FOLDER_QUERY_KEYS = {
+  all: [FOLDER_QUERY_KEY] as const,
+};
 
 const sortFolders = (folders: FolderItem[]) =>
   [...folders].sort((left, right) => left.order - right.order);
@@ -29,95 +40,134 @@ const createAuthRequiredError = () => new Error("AUTH_REQUIRED");
 export const useFolders = () => {
   const session = useAuthSession();
   const accessToken = session?.accessToken ?? null;
-  const [folders, setFolders] = useState<FolderItem[]>([]);
-  const [isLoading, setIsLoading] = useState(false);
-  const requestSerialRef = useRef(0);
+  const userId = session?.user?.id ?? null;
+  const queryClient = useQueryClient();
+  const folderQueryKey = useMemo(
+    () => [...FOLDER_QUERY_KEYS.all, userId] as const,
+    [userId],
+  );
 
-  const refreshFolders = useCallback(async () => {
-    const requestId = requestSerialRef.current + 1;
-    requestSerialRef.current = requestId;
-    const loadingStartedAt = Date.now();
+  const folderQuery = useQuery({
+    queryKey: folderQueryKey,
+    enabled: Boolean(accessToken),
+    queryFn: async () => {
+      const loadingStartedAt = Date.now();
 
-    if (!accessToken) {
-      await waitForMinimumLoading(loadingStartedAt);
-      if (requestId !== requestSerialRef.current) {
+      if (!accessToken) {
         return [];
       }
 
-      setFolders([]);
-      setIsLoading(false);
-      return [];
-    }
-
-    setIsLoading(true);
-
-    try {
-      const response = await fetchFolders(accessToken);
-      const nextFolders = sortFolders(response.map(mapFolder));
-      if (requestId !== requestSerialRef.current) {
-        return nextFolders;
+      try {
+        const response = await fetchFolders(accessToken);
+        return sortFolders(response.map(mapFolder));
+      } finally {
+        await waitForMinimumLoading(loadingStartedAt);
       }
+    },
+  });
 
-      setFolders(nextFolders);
-      return nextFolders;
-    } finally {
-      await waitForMinimumLoading(loadingStartedAt);
-      if (requestId === requestSerialRef.current) {
-        setIsLoading(false);
-      }
-    }
-  }, [accessToken]);
+  const folders = useMemo(
+    () => (accessToken ? (folderQuery.data ?? []) : []),
+    [accessToken, folderQuery.data],
+  );
+  const setFolders = useCallback(
+    (updater: (currentFolders: FolderItem[]) => FolderItem[]) => {
+      queryClient.setQueryData<FolderItem[]>(
+        folderQueryKey,
+        (currentFolders) => updater(currentFolders ?? []),
+      );
+    },
+    [folderQueryKey, queryClient],
+  );
 
-  useEffect(() => {
-    void refreshFolders();
-  }, [refreshFolders]);
-
-  const createFolder = useCallback(
-    async (name: string) => {
+  const { mutateAsync: createFolderAsync } = useMutation({
+    mutationFn: async (name: string) => {
       if (!accessToken) {
         throw createAuthRequiredError();
       }
 
-      const createdFolder = await createFolderRequest(accessToken, { name });
+      return createFolderRequest(accessToken, { name });
+    },
+    onSuccess: (createdFolder) => {
       setFolders((currentFolders) =>
         sortFolders([...currentFolders, mapFolder(createdFolder)]),
       );
     },
-    [accessToken],
-  );
+  });
 
-  const renameFolder = useCallback(
-    async (folderId: string, name: string) => {
+  const { mutateAsync: renameFolderAsync } = useMutation({
+    mutationFn: async ({
+      folderId,
+      name,
+    }: {
+      folderId: string;
+      name: string;
+    }) => {
       if (!accessToken) {
         throw createAuthRequiredError();
       }
 
-      const updatedFolder = await updateFolderRequest(accessToken, folderId, {
-        name,
-      });
+      return updateFolderRequest(accessToken, folderId, { name });
+    },
+    onSuccess: (updatedFolder) => {
       setFolders((currentFolders) =>
         sortFolders(
           currentFolders.map((folder) =>
-            folder.id === folderId ? mapFolder(updatedFolder) : folder,
+            folder.id === updatedFolder.id ? mapFolder(updatedFolder) : folder,
           ),
         ),
       );
     },
-    [accessToken],
-  );
+  });
 
-  const removeFolder = useCallback(
-    async (folderId: string) => {
+  const { mutateAsync: removeFolderAsync } = useMutation({
+    mutationFn: async (folderId: string) => {
       if (!accessToken) {
         throw createAuthRequiredError();
       }
 
       await deleteFolderRequest(accessToken, folderId);
+      return folderId;
+    },
+    onSuccess: (folderId) => {
       setFolders((currentFolders) =>
         currentFolders.filter((folder) => folder.id !== folderId),
       );
     },
-    [accessToken],
+  });
+
+  const { mutateAsync: reorderFolderAsync } = useMutation({
+    mutationFn: async (payload: Parameters<typeof reorderFolderRequest>[1]) => {
+      if (!accessToken) {
+        throw createAuthRequiredError();
+      }
+
+      return reorderFolderRequest(accessToken, payload);
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: folderQueryKey });
+    },
+  });
+
+  const createFolder = useCallback(
+    async (name: string) => {
+      await createFolderAsync(name);
+    },
+    [createFolderAsync],
+  );
+
+  const renameFolder = useCallback(
+    async (folderId: string, name: string) => {
+      await renameFolderAsync({ folderId, name });
+    },
+    [renameFolderAsync],
+  );
+
+  const removeFolder = useCallback(
+    async (folderId: string) => {
+      await removeFolderAsync(folderId);
+    },
+    [removeFolderAsync],
   );
 
   const reorderFolders = useCallback(
@@ -142,15 +192,14 @@ export const useFolders = () => {
           ? { targetId: sourceId, afterId: targetId }
           : { targetId: sourceId, beforeId: targetId };
 
-      await reorderFolderRequest(accessToken, payload);
-      await refreshFolders();
+      await reorderFolderAsync(payload);
     },
-    [accessToken, folders, refreshFolders],
+    [accessToken, folders, reorderFolderAsync],
   );
 
   return {
     folders,
-    isLoading,
+    isLoading: Boolean(accessToken) && folderQuery.isPending,
     createFolder,
     renameFolder,
     removeFolder,


### PR DESCRIPTION
## PR 요약

- TanStack Query 기반으로 폴더 서버 상태와 클립 캐시 갱신 흐름을 정리했습니다.

## 변경 내용 상세

### 변경 사항

- `useFolders`의 폴더 조회를 `useQuery` 기반으로 전환했습니다.
- 폴더 생성, 이름 변경, 삭제, 정렬을 `useMutation` 기반으로 정리했습니다.
- 클립 쿼리 invalidate와 즐겨찾기 캐시 갱신을 `clipQueryCache` 서비스로 분리했습니다.
- 즐겨찾기 토글 시 클립 캐시를 즉시 갱신하고 실패하면 이전 상태로 롤백하도록 개선했습니다.
- 최근/폴더 클립 훅의 클립 쿼리 갱신 진입점을 공통 헬퍼로 맞췄습니다.

### 변경 이유

- 서버 상태와 UI 상태의 책임을 분리하고, 클립/폴더 데이터 갱신 정책을 React Query 캐시 중심으로 일관되게 관리하기 위해서입니다.
- 즐겨찾기 토글 후 전체 재조회에 의존하던 흐름을 줄이고 사용자에게 즉시 반영되는 UI를 제공하기 위해서입니다.

## 관련 이슈

- Closes #45

## 기타 참고사항

- Before/After 스크린샷: 데이터/캐시 관리 구조 개선 작업이라 별도 첨부하지 않았습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 미실행, package 스크립트 없음
- `npm run test:e2e`: 미실행, e2e 스크립트 없음