### PR TITLE
#49 / feat(settings) : 쿠키 기반 인증 재발급 흐름 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "19.2.3",
         "react-icons": "^5.5.0",
         "react-intersection-observer": "^10.0.3",
+        "sonner": "^2.0.7",
         "zustand": "^5.0.9"
       },
       "devDependencies": {
@@ -6693,6 +6694,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/source-map-js": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "19.2.3",
     "react-icons": "^5.5.0",
     "react-intersection-observer": "^10.0.3",
+    "sonner": "^2.0.7",
     "zustand": "^5.0.9"
   },
   "devDependencies": {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { getInitialLocale } from "@/shared/server/getUserLocale";
 import { IntlProvider } from "@/shared/ui/IntlProvider";
+import { AppToaster } from "@/shared/ui/AppToaster";
 import { QueryProvider } from "@/shared/ui/QueryProvider";
 import "./globals.css";
 
@@ -21,7 +22,10 @@ export default async function RootLayout({
     <html lang={locale}>
       <body className="bg-slate-50 antialiased">
         <QueryProvider>
-          <IntlProvider initialLocale={locale}>{children}</IntlProvider>
+          <IntlProvider initialLocale={locale}>
+            {children}
+            <AppToaster />
+          </IntlProvider>
         </QueryProvider>
       </body>
     </html>

--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -8,23 +8,21 @@ import { apiRequest } from "@/shared/lib/apiClient";
 
 export const getAuthStartPath = (provider: AuthProvider) => `/auth/${provider}`;
 
-export const fetchMyProfile = async (accessToken: string) =>
+export const fetchMyProfile = async () =>
   apiRequest<UserProfileResponseDto>("/users/me", {
-    accessToken,
     cache: "no-store",
   });
 
-export const logout = async (accessToken: string) =>
+export const logout = async () =>
   apiRequest<LogoutResponseDto>("/auth/logout", {
     method: "POST",
-    accessToken,
-    credentials: "include",
+    skipAuthRefresh: true,
   });
 
 export const refreshAccessToken = async () =>
   apiRequest<RefreshAccessTokenResponseDto>("/auth/refresh", {
     method: "POST",
-    credentials: "include",
+    skipAuthRefresh: true,
   });
 
 // 테스트 어드민 로그인 API는 실제 OAuth 연동 전 임시 우회용으로 사용했습니다.

--- a/src/features/auth/model/auth.dto.ts
+++ b/src/features/auth/model/auth.dto.ts
@@ -18,6 +18,7 @@ export interface AuthSignInResponseDto {
 
 export interface RefreshAccessTokenResponseDto {
   access_token: string;
+  refresh_token?: string;
 }
 
 export interface UserProfileResponseDto {

--- a/src/features/auth/model/auth.ts
+++ b/src/features/auth/model/auth.ts
@@ -10,7 +10,5 @@ export interface AuthSessionUser {
 }
 
 export interface AuthSession {
-  accessToken: string;
-  refreshToken?: string | null;
   user: AuthSessionUser | null;
 }

--- a/src/features/auth/service/authService.ts
+++ b/src/features/auth/service/authService.ts
@@ -1,17 +1,13 @@
-import {
-  fetchMyProfile,
-  refreshAccessToken,
-} from "@/features/auth/api/authApi";
+import { fetchMyProfile } from "@/features/auth/api/authApi";
 import { AuthSession } from "@/features/auth/model/auth";
 import {
   clearAuthSession,
   persistAuthSession,
 } from "@/features/auth/service/authSession";
 
-export const syncSessionProfile = async (session: AuthSession) => {
-  const profile = await fetchMyProfile(session.accessToken);
+export const syncSessionProfile = async () => {
+  const profile = await fetchMyProfile();
   const nextSession: AuthSession = {
-    ...session,
     user: profile,
   };
 
@@ -19,16 +15,7 @@ export const syncSessionProfile = async (session: AuthSession) => {
   return nextSession;
 };
 
-export const restoreSessionFromRefreshCookie = async () => {
-  const token = await refreshAccessToken();
-  const session = await syncSessionProfile({
-    accessToken: token.access_token,
-    refreshToken: null,
-    user: null,
-  });
-
-  return session;
-};
+export const restoreSessionFromRefreshCookie = () => syncSessionProfile();
 
 export const clearSessionOnUnauthorized = () => {
   clearAuthSession();

--- a/src/features/auth/service/authSession.ts
+++ b/src/features/auth/service/authSession.ts
@@ -2,64 +2,31 @@
 
 import { AuthSession } from "@/features/auth/model/auth";
 
-const AUTH_SESSION_STORAGE_KEY = "easy-clip-auth-session";
 const AUTH_SESSION_EVENT = "auth-session:change";
-let cachedSessionRaw: string | null | undefined;
 let cachedSession: AuthSession | null = null;
 
 const dispatchSessionChange = () => {
   window.dispatchEvent(new Event(AUTH_SESSION_EVENT));
 };
 
-export const readAuthSession = (): AuthSession | null => {
-  const stored =
-    typeof window === "undefined"
-      ? null
-      : localStorage.getItem(AUTH_SESSION_STORAGE_KEY);
-
-  if (stored === cachedSessionRaw) {
-    return cachedSession;
-  }
-
-  if (!stored) {
-    cachedSessionRaw = null;
-    cachedSession = null;
-    return null;
-  }
-
-  try {
-    cachedSessionRaw = stored;
-    cachedSession = JSON.parse(stored) as AuthSession;
-    return cachedSession;
-  } catch {
-    cachedSessionRaw = null;
-    cachedSession = null;
-    return null;
-  }
-};
+export const readAuthSession = (): AuthSession | null => cachedSession;
 
 export const persistAuthSession = (session: AuthSession) => {
-  const serializedSession = JSON.stringify(session);
-  cachedSessionRaw = serializedSession;
   cachedSession = session;
-  localStorage.setItem(AUTH_SESSION_STORAGE_KEY, serializedSession);
+  // 인증 토큰은 httpOnly 쿠키에만 두고, 클라이언트에는 사용자 상태만 보관한다.
   dispatchSessionChange();
 };
 
 export const clearAuthSession = () => {
-  cachedSessionRaw = null;
   cachedSession = null;
-  localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
   dispatchSessionChange();
 };
 
 export const subscribeToAuthSession = (callback: () => void) => {
   const handler = () => callback();
-  window.addEventListener("storage", handler);
   window.addEventListener(AUTH_SESSION_EVENT, handler);
 
   return () => {
-    window.removeEventListener("storage", handler);
     window.removeEventListener(AUTH_SESSION_EVENT, handler);
   };
 };

--- a/src/features/auth/ui/AuthBootstrap.tsx
+++ b/src/features/auth/ui/AuthBootstrap.tsx
@@ -1,46 +1,56 @@
 "use client";
 
 import { useEffect, useRef } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { syncUserSettings } from "@/features/settings/service/settingsService";
-import { ApiError } from "@/shared/lib/apiClient";
+import { ApiError, subscribeToAuthExpired } from "@/shared/lib/apiClient";
 import {
   clearSessionOnUnauthorized,
   restoreSessionFromRefreshCookie,
-  syncSessionProfile,
 } from "@/features/auth/service/authService";
 
 export function AuthBootstrap() {
   const session = useAuthSession();
-  const lastTokenRef = useRef<string | null>(null);
-  const hasTriedCookieRestoreRef = useRef(false);
+  const router = useRouter();
+  const pathname = usePathname();
+  const queryClient = useQueryClient();
+  const hasBootstrappedRef = useRef(false);
 
   useEffect(() => {
-    if (!session?.accessToken) {
-      lastTokenRef.current = null;
-      if (!hasTriedCookieRestoreRef.current) {
-        hasTriedCookieRestoreRef.current = true;
+    const unsubscribe = subscribeToAuthExpired(() => {
+      clearSessionOnUnauthorized();
+      queryClient.clear();
 
-        void restoreSessionFromRefreshCookie().catch(() => {
-          // No refresh cookie means the user is simply logged out.
-        });
+      if (pathname !== "/login") {
+        router.push("/login");
       }
+    });
+
+    return unsubscribe;
+  }, [pathname, queryClient, router]);
+
+  useEffect(() => {
+    if (hasBootstrappedRef.current) {
       return;
     }
 
-    const currentSession = session;
-    const accessToken = currentSession.accessToken;
+    hasBootstrappedRef.current = true;
 
-    if (lastTokenRef.current === accessToken) {
+    void restoreSessionFromRefreshCookie().catch((error: unknown) => {
+      if (error instanceof ApiError && error.status === 401) {
+        clearSessionOnUnauthorized();
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!session?.user) {
       return;
     }
 
-    lastTokenRef.current = accessToken;
-
-    void Promise.all([
-      syncSessionProfile(currentSession),
-      syncUserSettings(accessToken),
-    ]).catch((error: unknown) => {
+    void syncUserSettings().catch((error: unknown) => {
       if (error instanceof ApiError && error.status === 401) {
         clearSessionOnUnauthorized();
       }

--- a/src/features/auth/ui/AuthBootstrap.tsx
+++ b/src/features/auth/ui/AuthBootstrap.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
+import { logout } from "@/features/auth/api/authApi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { syncUserSettings } from "@/features/settings/service/settingsService";
 import { ApiError, subscribeToAuthExpired } from "@/shared/lib/apiClient";
@@ -10,6 +11,7 @@ import {
   clearSessionOnUnauthorized,
   restoreSessionFromRefreshCookie,
 } from "@/features/auth/service/authService";
+import { notifyError } from "@/shared/lib/toast";
 
 export function AuthBootstrap() {
   const session = useAuthSession();
@@ -38,12 +40,26 @@ export function AuthBootstrap() {
 
     hasBootstrappedRef.current = true;
 
-    void restoreSessionFromRefreshCookie().catch((error: unknown) => {
-      if (error instanceof ApiError && error.status === 401) {
+    void restoreSessionFromRefreshCookie().catch(async (error: unknown) => {
+      if (!(error instanceof ApiError)) {
+        return;
+      }
+
+      if (error.status === 401) {
         clearSessionOnUnauthorized();
+        return;
+      }
+
+      if (error.status === 404) {
+        clearSessionOnUnauthorized();
+        queryClient.clear();
+        // 쿠키는 있지만 서버에 유저가 없으면 사용자를 랜딩으로 되돌려 재진입을 유도한다.
+        notifyError("존재하지 않는 유저입니다.");
+        await logout().catch(() => undefined);
+        router.push("/");
       }
     });
-  }, []);
+  }, [queryClient, router]);
 
   useEffect(() => {
     if (!session?.user) {

--- a/src/features/auth/ui/LoginPage.tsx
+++ b/src/features/auth/ui/LoginPage.tsx
@@ -2,11 +2,10 @@
 
 import Link from "next/link";
 import { useTranslations } from "next-intl";
-import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useEffect, useRef, useState } from "react";
 import { getAuthStartPath } from "@/features/auth/api/authApi";
 import { restoreSessionFromRefreshCookie } from "@/features/auth/service/authService";
-import { persistAuthSession } from "@/features/auth/service/authSession";
 import { buildApiUrl } from "@/shared/config/env";
 import { LoginAgreementNotice } from "@/features/auth/ui/LoginAgreementNotice";
 import { LoginBrandPanel } from "@/features/auth/ui/LoginBrandPanel";
@@ -16,7 +15,6 @@ import { LoginSocialActions } from "@/features/auth/ui/LoginSocialActions";
 export function LoginPage() {
   const t = useTranslations("login");
   const router = useRouter();
-  const searchParams = useSearchParams();
   const [isLoading, setIsLoading] = useState(false);
   const [loadingProvider, setLoadingProvider] = useState<
     "google" | "github" | null
@@ -24,43 +22,20 @@ export function LoginPage() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const hasTriedCookieRestoreRef = useRef(false);
 
-  const redirectedSession = useMemo(() => {
-    const accessToken = searchParams.get("access_token");
-    const refreshToken = searchParams.get("refresh_token");
-
-    if (!accessToken || !refreshToken) {
-      return null;
-    }
-
-    return {
-      accessToken,
-      refreshToken,
-      user: null,
-    };
-  }, [searchParams]);
-
   useEffect(() => {
-    if (!redirectedSession) {
-      return;
-    }
-
-    persistAuthSession(redirectedSession);
-    router.replace("/favorites");
-  }, [redirectedSession, router]);
-
-  useEffect(() => {
-    if (redirectedSession || hasTriedCookieRestoreRef.current) {
+    if (hasTriedCookieRestoreRef.current) {
       return;
     }
 
     hasTriedCookieRestoreRef.current = true;
 
+    // OAuth redirect 이후에도 URL 토큰을 저장하지 않고 쿠키 기반 내 정보 조회로 세션을 복구한다.
     void restoreSessionFromRefreshCookie()
       .then(() => router.replace("/favorites"))
       .catch(() => {
         // Stay on the login page when there is no active OAuth cookie session.
       });
-  }, [redirectedSession, router]);
+  }, [router]);
 
   const handleLogin = async (provider: "google" | "github") => {
     try {

--- a/src/features/clip/api/clipApi.ts
+++ b/src/features/clip/api/clipApi.ts
@@ -9,7 +9,6 @@ import {
 import { apiRequest } from "@/shared/lib/apiClient";
 
 export const fetchClips = async (
-  accessToken: string,
   options: FetchClipsQueryDto = {},
 ) => {
   const searchParams = new URLSearchParams();
@@ -36,61 +35,48 @@ export const fetchClips = async (
   }
 
   return apiRequest<ClipCursorPageResponseDto>(`/clips?${searchParams}`, {
-    accessToken,
     cache: "no-store",
   });
 };
 
-export const createTextClip = (
-  accessToken: string,
-  payload: CreateTextClipRequestDto,
-) => {
+export const createTextClip = (payload: CreateTextClipRequestDto) => {
   const formData = new FormData();
   formData.set("folderId", payload.folderId);
   formData.set("text", payload.text);
 
   return apiRequest<ClipResponseDto>("/clips", {
     method: "POST",
-    accessToken,
     body: formData,
   });
 };
 
-export const createImageClip = (
-  accessToken: string,
-  payload: CreateImageClipRequestDto,
-) => {
+export const createImageClip = (payload: CreateImageClipRequestDto) => {
   const formData = new FormData();
   formData.set("folderId", payload.folderId);
   formData.set("file", payload.file);
 
   return apiRequest<ClipResponseDto>("/clips", {
     method: "POST",
-    accessToken,
     body: formData,
   });
 };
 
-export const removeClip = (accessToken: string, clipId: string) =>
+export const removeClip = (clipId: string) =>
   apiRequest<ClipResponseDto>(`/clips/${clipId}`, {
     method: "DELETE",
-    accessToken,
   });
 
-export const likeClip = (accessToken: string, clipId: string) =>
+export const likeClip = (clipId: string) =>
   apiRequest<LikeClipResponseDto>(`/clips/${clipId}/likes`, {
     method: "POST",
-    accessToken,
   });
 
-export const unlikeClip = (accessToken: string, clipId: string) =>
+export const unlikeClip = (clipId: string) =>
   apiRequest<LikeClipResponseDto>(`/clips/${clipId}/likes`, {
     method: "DELETE",
-    accessToken,
   });
 
-export const recordClipView = (accessToken: string, clipId: string) =>
+export const recordClipView = (clipId: string) =>
   apiRequest<null>(`/clips/${clipId}/views`, {
     method: "POST",
-    accessToken,
   });

--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -18,10 +18,10 @@ export const useFavoriteClipsPage = () => {
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const { copyToast, showCopyToast } = useCopyToast();
   const {
-    accessToken,
     clips,
     fetchNextPage,
     hasNextPage,
+    isAuthenticated,
     isFetchingNextPage,
     isPending,
   } = useInfiniteClips({
@@ -39,16 +39,16 @@ export const useFavoriteClipsPage = () => {
         // no-op
       }
 
-      if (accessToken) {
-        await recordClipView(accessToken, clip.id);
+      if (isAuthenticated) {
+        await recordClipView(clip.id);
       }
     },
-    [accessToken, showCopyToast],
+    [isAuthenticated, showCopyToast],
   );
 
   const handleToggleFavorite = useCallback(
     async (clip: Clip) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
@@ -61,15 +61,15 @@ export const useFavoriteClipsPage = () => {
 
       try {
         if (nextFavorite) {
-          await likeClip(accessToken, clip.id);
+          await likeClip(clip.id);
         } else {
-          await unlikeClip(accessToken, clip.id);
+          await unlikeClip(clip.id);
         }
       } catch {
         rollbackFavorite();
       }
     },
-    [accessToken, queryClient],
+    [isAuthenticated, queryClient],
   );
 
   return {

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -42,10 +42,10 @@ export const useFolderClipsPage = () => {
   const [isDeleteAllOpen, setIsDeleteAllOpen] = useState(false);
   const { copyToast, showCopyToast } = useCopyToast();
   const {
-    accessToken,
     clips,
     fetchNextPage,
     hasNextPage,
+    isAuthenticated,
     isFetchingNextPage,
     isPending,
   } = useInfiniteClips({
@@ -85,43 +85,43 @@ export const useFolderClipsPage = () => {
   }, [contextMenu]);
 
   const ensureAuthenticated = useCallback(() => {
-    if (accessToken) {
+    if (isAuthenticated) {
       return true;
     }
 
     router.push("/login");
     return false;
-  }, [accessToken, router]);
+  }, [isAuthenticated, router]);
 
   const createTextClipFromPaste = useCallback(
     async (content: string) => {
       const trimmed = content.trim();
-      if (!trimmed || !folderId || !accessToken) {
+      if (!trimmed || !folderId || !isAuthenticated) {
         return;
       }
 
-      await createTextClip(accessToken, {
+      await createTextClip({
         folderId,
         text: trimmed,
       });
       await refreshClipQueries();
     },
-    [accessToken, folderId, refreshClipQueries],
+    [folderId, isAuthenticated, refreshClipQueries],
   );
 
   const createImageClipFromPaste = useCallback(
     async (file: File) => {
-      if (!folderId || !accessToken) {
+      if (!folderId || !isAuthenticated) {
         return;
       }
 
-      await createImageClip(accessToken, {
+      await createImageClip({
         folderId,
         file,
       });
       await refreshClipQueries();
     },
-    [accessToken, folderId, refreshClipQueries],
+    [folderId, isAuthenticated, refreshClipQueries],
   );
 
   useEffect(() => {
@@ -171,11 +171,11 @@ export const useFolderClipsPage = () => {
         // no-op
       }
 
-      if (accessToken) {
-        await recordClipView(accessToken, clip.id);
+      if (isAuthenticated) {
+        await recordClipView(clip.id);
       }
     },
-    [accessToken, showCopyToast],
+    [isAuthenticated, showCopyToast],
   );
 
   const handleCopyFromMenu = useCallback(
@@ -186,18 +186,18 @@ export const useFolderClipsPage = () => {
         // no-op
       }
 
-      if (accessToken) {
-        await recordClipView(accessToken, clip.id);
+      if (isAuthenticated) {
+        await recordClipView(clip.id);
       }
 
       setContextMenu(null);
     },
-    [accessToken],
+    [isAuthenticated],
   );
 
   const handleToggleFavorite = useCallback(
     async (clip: Clip) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
@@ -210,15 +210,15 @@ export const useFolderClipsPage = () => {
 
       try {
         if (nextFavorite) {
-          await likeClip(accessToken, clip.id);
+          await likeClip(clip.id);
         } else {
-          await unlikeClip(accessToken, clip.id);
+          await unlikeClip(clip.id);
         }
       } catch {
         rollbackFavorite();
       }
     },
-    [accessToken, queryClient],
+    [isAuthenticated, queryClient],
   );
 
   const handleOpenContextMenu = useCallback(
@@ -235,26 +235,26 @@ export const useFolderClipsPage = () => {
 
   const handleDeleteClip = useCallback(
     async (clipId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
-      await removeClip(accessToken, clipId);
+      await removeClip(clipId);
       setContextMenu(null);
       await refreshClipQueries();
     },
-    [accessToken, refreshClipQueries],
+    [isAuthenticated, refreshClipQueries],
   );
 
   const handleDeleteAll = useCallback(async () => {
-    if (!accessToken) {
+    if (!isAuthenticated) {
       return;
     }
 
-    await Promise.all(clips.map((clip) => removeClip(accessToken, clip.id)));
+    await Promise.all(clips.map((clip) => removeClip(clip.id)));
     setIsDeleteAllOpen(false);
     await refreshClipQueries();
-  }, [accessToken, clips, refreshClipQueries]);
+  }, [clips, isAuthenticated, refreshClipQueries]);
 
   return {
     activeFilter,

--- a/src/features/clip/hooks/useInfiniteClips.ts
+++ b/src/features/clip/hooks/useInfiniteClips.ts
@@ -40,7 +40,7 @@ export const useInfiniteClips = ({
   enabled = true,
 }: UseInfiniteClipsOptions) => {
   const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const isAuthenticated = Boolean(session?.user);
   const normalizedSearchQuery = searchQuery.trim();
   const queryKey = [
     CLIP_QUERY_KEY,
@@ -55,10 +55,10 @@ export const useInfiniteClips = ({
 
   const query = useInfiniteQuery({
     queryKey,
-    enabled: Boolean(accessToken) && enabled,
+    enabled: isAuthenticated && enabled,
     initialPageParam: null as string | null,
     queryFn: async ({ pageParam }) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return {
           items: [],
           hasMore: false,
@@ -69,7 +69,7 @@ export const useInfiniteClips = ({
       const loadingStartedAt = Date.now();
 
       try {
-        return await fetchClips(accessToken, {
+        return await fetchClips({
           folderId,
           favorite,
           recent,
@@ -96,9 +96,9 @@ export const useInfiniteClips = ({
 
   return {
     ...query,
-    accessToken,
+    isAuthenticated,
     clips,
-    isPending: Boolean(accessToken) && enabled && query.isPending,
+    isPending: isAuthenticated && enabled && query.isPending,
     queryKey,
   };
 };

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -15,10 +15,10 @@ export const useRecentClipsPage = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const { copyToast, showCopyToast } = useCopyToast();
   const {
-    accessToken,
     clips,
     fetchNextPage,
     hasNextPage,
+    isAuthenticated,
     isFetchingNextPage,
     isPending,
   } = useInfiniteClips({
@@ -42,12 +42,12 @@ export const useRecentClipsPage = () => {
         // no-op
       }
 
-      if (accessToken) {
-        await recordClipView(accessToken, clip.id);
+      if (isAuthenticated) {
+        await recordClipView(clip.id);
         await refreshClipQueries();
       }
     },
-    [accessToken, refreshClipQueries, showCopyToast],
+    [isAuthenticated, refreshClipQueries, showCopyToast],
   );
 
   return {

--- a/src/features/folder/api/folderApi.ts
+++ b/src/features/folder/api/folderApi.ts
@@ -6,19 +6,14 @@ import {
 } from "@/features/folder/model/folder.dto";
 import { apiRequest } from "@/shared/lib/apiClient";
 
-export const fetchFolders = (accessToken: string) =>
+export const fetchFolders = () =>
   apiRequest<FolderResponseDto[]>("/folders", {
-    accessToken,
     cache: "no-store",
   });
 
-export const createFolder = (
-  accessToken: string,
-  payload: CreateFolderRequestDto,
-) =>
+export const createFolder = (payload: CreateFolderRequestDto) =>
   apiRequest<FolderResponseDto>("/folders", {
     method: "POST",
-    accessToken,
     headers: {
       "Content-Type": "application/json",
     },
@@ -26,32 +21,25 @@ export const createFolder = (
   });
 
 export const updateFolder = (
-  accessToken: string,
   folderId: string,
   payload: UpdateFolderRequestDto,
 ) =>
   apiRequest<FolderResponseDto>(`/folders/${folderId}`, {
     method: "PATCH",
-    accessToken,
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify(payload),
   });
 
-export const deleteFolder = (accessToken: string, folderId: string) =>
+export const deleteFolder = (folderId: string) =>
   apiRequest<FolderResponseDto>(`/folders/${folderId}`, {
     method: "DELETE",
-    accessToken,
   });
 
-export const reorderFolder = (
-  accessToken: string,
-  payload: ReorderFolderRequestDto,
-) =>
+export const reorderFolder = (payload: ReorderFolderRequestDto) =>
   apiRequest<FolderResponseDto>("/folders/reorder", {
     method: "PATCH",
-    accessToken,
     headers: {
       "Content-Type": "application/json",
     },

--- a/src/features/folder/hooks/useFolders.ts
+++ b/src/features/folder/hooks/useFolders.ts
@@ -39,7 +39,7 @@ const createAuthRequiredError = () => new Error("AUTH_REQUIRED");
 
 export const useFolders = () => {
   const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const isAuthenticated = Boolean(session?.user);
   const userId = session?.user?.id ?? null;
   const queryClient = useQueryClient();
   const folderQueryKey = useMemo(
@@ -49,16 +49,16 @@ export const useFolders = () => {
 
   const folderQuery = useQuery({
     queryKey: folderQueryKey,
-    enabled: Boolean(accessToken),
+    enabled: isAuthenticated,
     queryFn: async () => {
       const loadingStartedAt = Date.now();
 
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return [];
       }
 
       try {
-        const response = await fetchFolders(accessToken);
+        const response = await fetchFolders();
         return sortFolders(response.map(mapFolder));
       } finally {
         await waitForMinimumLoading(loadingStartedAt);
@@ -67,8 +67,8 @@ export const useFolders = () => {
   });
 
   const folders = useMemo(
-    () => (accessToken ? (folderQuery.data ?? []) : []),
-    [accessToken, folderQuery.data],
+    () => (isAuthenticated ? (folderQuery.data ?? []) : []),
+    [isAuthenticated, folderQuery.data],
   );
   const setFolders = useCallback(
     (updater: (currentFolders: FolderItem[]) => FolderItem[]) => {
@@ -82,11 +82,11 @@ export const useFolders = () => {
 
   const { mutateAsync: createFolderAsync } = useMutation({
     mutationFn: async (name: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
-      return createFolderRequest(accessToken, { name });
+      return createFolderRequest({ name });
     },
     onSuccess: (createdFolder) => {
       setFolders((currentFolders) =>
@@ -103,11 +103,11 @@ export const useFolders = () => {
       folderId: string;
       name: string;
     }) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
-      return updateFolderRequest(accessToken, folderId, { name });
+      return updateFolderRequest(folderId, { name });
     },
     onSuccess: (updatedFolder) => {
       setFolders((currentFolders) =>
@@ -122,11 +122,11 @@ export const useFolders = () => {
 
   const { mutateAsync: removeFolderAsync } = useMutation({
     mutationFn: async (folderId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
-      await deleteFolderRequest(accessToken, folderId);
+      await deleteFolderRequest(folderId);
       return folderId;
     },
     onSuccess: (folderId) => {
@@ -137,12 +137,12 @@ export const useFolders = () => {
   });
 
   const { mutateAsync: reorderFolderAsync } = useMutation({
-    mutationFn: async (payload: Parameters<typeof reorderFolderRequest>[1]) => {
-      if (!accessToken) {
+    mutationFn: async (payload: Parameters<typeof reorderFolderRequest>[0]) => {
+      if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
-      return reorderFolderRequest(accessToken, payload);
+      return reorderFolderRequest(payload);
     },
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: folderQueryKey });
@@ -172,7 +172,7 @@ export const useFolders = () => {
 
   const reorderFolders = useCallback(
     async (sourceId: string, targetId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
@@ -194,12 +194,12 @@ export const useFolders = () => {
 
       await reorderFolderAsync(payload);
     },
-    [accessToken, folders, reorderFolderAsync],
+    [folders, isAuthenticated, reorderFolderAsync],
   );
 
   return {
     folders,
-    isLoading: Boolean(accessToken) && folderQuery.isPending,
+    isLoading: isAuthenticated && folderQuery.isPending,
     createFolder,
     renameFolder,
     removeFolder,

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HiOutlineClock, HiOutlineStar, HiOutlineTrash } from "react-icons/hi";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { logout } from "@/features/auth/api/authApi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { clearAuthSession } from "@/features/auth/service/authSession";
@@ -31,7 +32,9 @@ export function Sidebar({
   const t = useTranslations("sidebar");
   const pathname = usePathname();
   const router = useRouter();
+  const queryClient = useQueryClient();
   const session = useAuthSession();
+  const isAuthenticated = Boolean(session?.user);
   const {
     createFolder,
     folders,
@@ -118,14 +121,14 @@ export function Sidebar({
   }, [onCloseMobile, pathname]);
 
   const ensureAuthenticated = useCallback(() => {
-    if (session?.accessToken) {
+    if (isAuthenticated) {
       return true;
     }
 
     onCloseMobile?.();
     router.push("/login");
     return false;
-  }, [onCloseMobile, router, session?.accessToken]);
+  }, [isAuthenticated, onCloseMobile, router]);
 
   const handleReorderFolders = useCallback(
     (sourceId: string, targetId: string) => {
@@ -202,17 +205,18 @@ export function Sidebar({
     onCloseMobile?.();
 
     try {
-      if (session?.accessToken) {
-        await logout(session.accessToken);
+      if (isAuthenticated) {
+        await logout();
       }
     } catch {
       // clear client session even when the server session is already invalid
     } finally {
       clearAuthSession();
+      queryClient.clear();
       router.push("/login");
       router.refresh();
     }
-  }, [onCloseMobile, router, session?.accessToken]);
+  }, [isAuthenticated, onCloseMobile, queryClient, router]);
 
   return (
     <>

--- a/src/features/settings/api/settingsApi.ts
+++ b/src/features/settings/api/settingsApi.ts
@@ -4,19 +4,16 @@ import {
 } from "@/features/settings/model/settings.dto";
 import { apiRequest } from "@/shared/lib/apiClient";
 
-export const fetchMySettings = async (accessToken: string) =>
+export const fetchMySettings = async () =>
   apiRequest<UserSettingsResponseDto>("/users/me/settings", {
-    accessToken,
     cache: "no-store",
   });
 
 export const updateMySettings = async (
-  accessToken: string,
   payload: UpdateUserSettingsDto,
 ) =>
   apiRequest<UserSettingsResponseDto>("/users/me/settings", {
     method: "PATCH",
-    accessToken,
     headers: {
       "Content-Type": "application/json",
     },

--- a/src/features/settings/service/settingsService.ts
+++ b/src/features/settings/service/settingsService.ts
@@ -45,8 +45,8 @@ export const isServerSupportedLanguage = (
 ): language is ServerSupportedLanguage =>
   SERVER_SUPPORTED_LANGUAGES.includes(language as ServerSupportedLanguage);
 
-export const syncUserSettings = async (accessToken: string) => {
-  const settings = await fetchMySettings(accessToken);
+export const syncUserSettings = async () => {
+  const settings = await fetchMySettings();
   const currentLanguage = useSettingsStore.getState().language;
 
   useSettingsStore.getState().hydrateFromServer({
@@ -60,7 +60,6 @@ export const syncUserSettings = async (accessToken: string) => {
 };
 
 export const persistUserSettings = async (
-  accessToken: string,
   nextSettings: {
     theme?: ThemeMode;
     language?: LanguageCode;
@@ -83,7 +82,7 @@ export const persistUserSettings = async (
     return null;
   }
 
-  const settings = await updateMySettings(accessToken, payload);
+  const settings = await updateMySettings(payload);
 
   useSettingsStore.getState().hydrateFromServer({
     theme: mapThemeFromServer(settings.theme),

--- a/src/features/trash/api/trashApi.ts
+++ b/src/features/trash/api/trashApi.ts
@@ -7,44 +7,32 @@ import {
 } from "@/features/trash/model/trash.dto";
 import { apiRequest } from "@/shared/lib/apiClient";
 
-export const fetchTrashClips = async (accessToken: string) =>
+export const fetchTrashClips = async () =>
   apiRequest<TrashClipListResponseDto>("/trash/clips", {
-    accessToken,
     cache: "no-store",
   });
 
-export const restoreTrashClip = async (accessToken: string, clipId: string) =>
+export const restoreTrashClip = async (clipId: string) =>
   apiRequest<TrashClipResponseDto>(`/trash/clips/${clipId}/restore`, {
     method: "PATCH",
-    accessToken,
   });
 
-export const deleteTrashClip = async (accessToken: string, clipId: string) =>
+export const deleteTrashClip = async (clipId: string) =>
   apiRequest<TrashDeleteResponseDto>(`/trash/clips/${clipId}`, {
     method: "DELETE",
-    accessToken,
   });
 
-export const fetchTrashFolders = async (accessToken: string) =>
+export const fetchTrashFolders = async () =>
   apiRequest<TrashFolderListResponseDto>("/trash/folders", {
-    accessToken,
     cache: "no-store",
   });
 
-export const restoreTrashFolder = async (
-  accessToken: string,
-  folderId: string,
-) =>
+export const restoreTrashFolder = async (folderId: string) =>
   apiRequest<TrashFolderResponseDto>(`/trash/folders/${folderId}/restore`, {
     method: "PATCH",
-    accessToken,
   });
 
-export const deleteTrashFolder = async (
-  accessToken: string,
-  folderId: string,
-) =>
+export const deleteTrashFolder = async (folderId: string) =>
   apiRequest<TrashDeleteResponseDto>(`/trash/folders/${folderId}`, {
     method: "DELETE",
-    accessToken,
   });

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -20,7 +20,7 @@ import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const useTrashPage = () => {
   const session = useAuthSession();
-  const accessToken = session?.accessToken ?? null;
+  const isAuthenticated = Boolean(session?.user);
   const [clips, setClips] = useState<TrashClipResponseDto[]>([]);
   const [folders, setFolders] = useState<TrashFolderResponseDto[]>([]);
   const [activeFolders, setActiveFolders] = useState<FolderResponseDto[]>([]);
@@ -35,7 +35,7 @@ export const useTrashPage = () => {
     const loadingStartedAt = Date.now();
     const isLatestRequest = () => loadRequestIdRef.current === requestId;
 
-    if (!accessToken) {
+    if (!isAuthenticated) {
       await waitForMinimumLoading(loadingStartedAt);
 
       if (!isLatestRequest()) {
@@ -56,9 +56,9 @@ export const useTrashPage = () => {
 
     try {
       const [trashClips, trashFolders, currentFolders] = await Promise.all([
-        fetchTrashClips(accessToken),
-        fetchTrashFolders(accessToken),
-        fetchFolders(accessToken),
+        fetchTrashClips(),
+        fetchTrashFolders(),
+        fetchFolders(),
       ]);
 
       startTransition(() => {
@@ -82,7 +82,7 @@ export const useTrashPage = () => {
         setIsLoading(false);
       }
     }
-  }, [accessToken]);
+  }, [isAuthenticated]);
 
   useEffect(() => {
     void loadTrash();
@@ -107,71 +107,71 @@ export const useTrashPage = () => {
 
   const handleRestoreClip = useCallback(
     async (clipId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
       await runAction(`clip-restore-${clipId}`, () =>
-        restoreTrashClip(accessToken, clipId),
+        restoreTrashClip(clipId),
       );
     },
-    [accessToken, runAction],
+    [isAuthenticated, runAction],
   );
 
   const handleDeleteClip = useCallback(
     async (clipId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
       await runAction(`clip-delete-${clipId}`, () =>
-        deleteTrashClip(accessToken, clipId),
+        deleteTrashClip(clipId),
       );
     },
-    [accessToken, runAction],
+    [isAuthenticated, runAction],
   );
 
   const handleRestoreFolder = useCallback(
     async (folderId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
       await runAction(`folder-restore-${folderId}`, () =>
-        restoreTrashFolder(accessToken, folderId),
+        restoreTrashFolder(folderId),
       );
     },
-    [accessToken, runAction],
+    [isAuthenticated, runAction],
   );
 
   const handleDeleteFolder = useCallback(
     async (folderId: string) => {
-      if (!accessToken) {
+      if (!isAuthenticated) {
         return;
       }
 
       await runAction(`folder-delete-${folderId}`, () =>
-        deleteTrashFolder(accessToken, folderId),
+        deleteTrashFolder(folderId),
       );
     },
-    [accessToken, runAction],
+    [isAuthenticated, runAction],
   );
 
   const handleClearAll = useCallback(async () => {
-    if (!accessToken) {
+    if (!isAuthenticated) {
       return;
     }
 
     await runAction("trash-clear-all", async () => {
       for (const clip of clips) {
-        await deleteTrashClip(accessToken, clip.id);
+        await deleteTrashClip(clip.id);
       }
 
       for (const folder of folders) {
-        await deleteTrashFolder(accessToken, folder.id);
+        await deleteTrashFolder(folder.id);
       }
     });
-  }, [accessToken, clips, folders, runAction]);
+  }, [clips, folders, isAuthenticated, runAction]);
 
   return {
     clips,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const ACCESS_TOKEN_COOKIE_NAME = "easy_clip_access_token";
+const REFRESH_TOKEN_COOKIE_NAME = "easy_clip_refresh_token";
+const MAIN_APP_PATH = "/favorites";
+const LOGIN_PATH = "/login";
+
+const PUBLIC_PATHS = new Set(["/", LOGIN_PATH, "/pricing"]);
+
+const hasAuthCookie = (request: NextRequest) =>
+  request.cookies.has(ACCESS_TOKEN_COOKIE_NAME) ||
+  request.cookies.has(REFRESH_TOKEN_COOKIE_NAME);
+
+const redirectTo = (request: NextRequest, path: string) => {
+  const redirectUrl = request.nextUrl.clone();
+  redirectUrl.pathname = path;
+  redirectUrl.search = "";
+
+  return NextResponse.redirect(redirectUrl);
+};
+
+export function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+  const isPublicPath = PUBLIC_PATHS.has(pathname);
+  const isAuthenticated = hasAuthCookie(request);
+
+  if (isAuthenticated && isPublicPath) {
+    // 로그인된 사용자는 랜딩/로그인/가격 페이지 대신 메인 앱 도메인에서만 활동한다.
+    return redirectTo(request, MAIN_APP_PATH);
+  }
+
+  if (!isAuthenticated && !isPublicPath) {
+    // 쿠키가 전혀 없으면 앱 라우트 진입 전에 로그인 화면으로 보낸다.
+    return redirectTo(request, LOGIN_PATH);
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: [
+    "/((?!_next/static|_next/image|favicon.ico|.*\\..*).*)",
+  ],
+};

--- a/src/shared/lib/apiClient.ts
+++ b/src/shared/lib/apiClient.ts
@@ -1,8 +1,9 @@
 import { buildApiUrl } from "@/shared/config/env";
 
 type ApiRequestOptions = Omit<RequestInit, "headers"> & {
-  accessToken?: string | null;
   headers?: HeadersInit;
+  skipAuthRefresh?: boolean;
+  hasRetriedAuth?: boolean;
 };
 
 export class ApiError extends Error {
@@ -15,40 +16,131 @@ export class ApiError extends Error {
   }
 }
 
-const mergeHeaders = (
-  headers: HeadersInit | undefined,
-  accessToken?: string | null,
-) => {
-  const merged = new Headers(headers);
+let refreshPromise: Promise<void> | null = null;
 
-  if (accessToken) {
-    merged.set("Authorization", `Bearer ${accessToken}`);
+const AUTH_EXPIRED_EVENT = "auth-session:expired";
+const REFRESH_RETRY_DELAYS_MS = [300, 800] as const;
+
+const dispatchAuthExpired = () => {
+  if (typeof window === "undefined") {
+    return;
   }
 
-  return merged;
+  window.dispatchEvent(new Event(AUTH_EXPIRED_EVENT));
+};
+
+export const subscribeToAuthExpired = (callback: () => void) => {
+  window.addEventListener(AUTH_EXPIRED_EVENT, callback);
+
+  return () => window.removeEventListener(AUTH_EXPIRED_EVENT, callback);
+};
+
+const isAuthRefreshExcludedPath = (path: string) =>
+  path === "/auth/refresh" || path === "/auth/logout";
+
+const readErrorMessage = async (response: Response) => {
+  let message = `Request failed with status ${response.status}`;
+
+  try {
+    const errorBody = (await response.json()) as { message?: string };
+    if (typeof errorBody.message === "string" && errorBody.message) {
+      message = errorBody.message;
+    }
+  } catch {
+    // 응답 본문이 JSON이 아니어도 status 기준 에러 처리는 유지한다.
+  }
+
+  return message;
+};
+
+const wait = (delayMs: number) =>
+  new Promise((resolve) => window.setTimeout(resolve, delayMs));
+
+const isRetryableRefreshError = (error: unknown) => {
+  if (!(error instanceof ApiError)) {
+    return true;
+  }
+
+  return error.status === 408 || error.status === 429 || error.status >= 500;
+};
+
+const refreshWithRetry = async () => {
+  for (let attempt = 0; attempt <= REFRESH_RETRY_DELAYS_MS.length; attempt += 1) {
+    try {
+      await apiRequest<unknown>("/auth/refresh", {
+        method: "POST",
+        skipAuthRefresh: true,
+      });
+      return;
+    } catch (error) {
+      const isLastAttempt = attempt === REFRESH_RETRY_DELAYS_MS.length;
+
+      if (isLastAttempt || !isRetryableRefreshError(error)) {
+        throw error;
+      }
+
+      // 일시적인 네트워크/서버 지연은 짧게 기다렸다가 refresh만 재시도한다.
+      await wait(REFRESH_RETRY_DELAYS_MS[attempt]);
+    }
+  }
+};
+
+const requestTokenRefresh = async () => {
+  if (!refreshPromise) {
+    // 동시에 여러 요청이 401을 받아도 refresh 호출은 이 Promise 하나로 합친다.
+    refreshPromise = refreshWithRetry()
+      .catch((error) => {
+        dispatchAuthExpired();
+        throw error;
+      })
+      .finally(() => {
+        refreshPromise = null;
+      });
+  }
+
+  return refreshPromise;
 };
 
 export const apiRequest = async <T>(
   path: string,
-  { accessToken, headers, ...init }: ApiRequestOptions = {},
-) => {
+  {
+    headers,
+    skipAuthRefresh = false,
+    hasRetriedAuth = false,
+    credentials,
+    ...init
+  }: ApiRequestOptions = {},
+): Promise<T> => {
   const response = await fetch(buildApiUrl(path), {
     ...init,
-    headers: mergeHeaders(headers, accessToken),
+    // httpOnly 쿠키 기반 인증이므로 모든 API 요청에 쿠키를 포함한다.
+    credentials: credentials ?? "include",
+    headers: new Headers(headers),
   });
 
   if (!response.ok) {
-    let message = `Request failed with status ${response.status}`;
+    if (
+      response.status === 401 &&
+      !skipAuthRefresh &&
+      !hasRetriedAuth &&
+      !isAuthRefreshExcludedPath(path)
+    ) {
+      await requestTokenRefresh();
 
-    try {
-      const errorBody = (await response.json()) as { message?: string };
-      if (typeof errorBody.message === "string" && errorBody.message) {
-        message = errorBody.message;
-      }
-    } catch {
-      // ignore invalid error bodies
+      return apiRequest<T>(path, {
+        ...init,
+        headers,
+        credentials,
+        skipAuthRefresh,
+        hasRetriedAuth: true,
+      });
     }
 
+    if (response.status === 401 && (hasRetriedAuth || skipAuthRefresh)) {
+      dispatchAuthExpired();
+    }
+
+    const message = await readErrorMessage(response);
     throw new ApiError(message, response.status);
   }
 

--- a/src/shared/lib/toast.ts
+++ b/src/shared/lib/toast.ts
@@ -1,0 +1,10 @@
+"use client";
+
+import { toast } from "sonner";
+
+export const notifyError = (message: string, description?: string) => {
+  // 앱 전역 알림 정책은 이 헬퍼를 통해 한 곳에서 조정한다.
+  toast.error(message, {
+    description,
+  });
+};

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { Toaster } from "sonner";
+
+export function AppToaster() {
+  return (
+    <Toaster
+      position="top-center"
+      richColors
+      closeButton
+      toastOptions={{
+        classNames: {
+          toast:
+            "border border-(--border) bg-(--surface-elevated) text-(--foreground)",
+        },
+      }}
+    />
+  );
+}

--- a/src/shared/ui/SettingsModal.tsx
+++ b/src/shared/ui/SettingsModal.tsx
@@ -35,14 +35,14 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     setErrorMessage(null);
     setTheme(nextTheme);
 
-    if (!session?.accessToken) {
+    if (!session?.user) {
       return;
     }
 
     setSavingField("theme");
 
     try {
-      await persistUserSettings(session.accessToken, { theme: nextTheme });
+      await persistUserSettings({ theme: nextTheme });
     } catch {
       setTheme(previousTheme);
       setErrorMessage(t("saveError"));
@@ -57,14 +57,14 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     setErrorMessage(null);
     setLanguage(nextLanguage);
 
-    if (!session?.accessToken) {
+    if (!session?.user) {
       return;
     }
 
     setSavingField("language");
 
     try {
-      await persistUserSettings(session.accessToken, { language: nextLanguage });
+      await persistUserSettings({ language: nextLanguage });
     } catch {
       setLanguage(previousLanguage);
       setErrorMessage(t("saveError"));


### PR DESCRIPTION
## PR 요약

- httpOnly 쿠키 기반 JWT 인증 흐름에 맞춰 공통 API 클라이언트, 인증 상태, Route Guard, 사용자 없음 알림 처리를 정리했습니다.

## 변경 내용 상세

### 변경 사항

- 공통 `apiRequest`에서 모든 요청에 `credentials: "include"`를 기본 적용하고, 401 발생 시 `/auth/refresh` 후 원요청을 1회 재시도하도록 구현했습니다.
- refresh 요청은 동시 401 상황에서도 단일 Promise를 공유하며, 네트워크 오류/408/429/5xx에 한해 최대 3회까지 재시도합니다.
- access/refresh token을 localStorage 또는 클라이언트 세션에 저장하던 흐름을 제거하고, `/users/me` 조회 결과로 사용자 상태를 동기화하도록 변경했습니다.
- 폴더/클립/설정/휴지통 API 호출부에서 Bearer token 인자 전달을 제거하고 쿠키 기반 요청으로 마이그레이션했습니다.
- `src/proxy.ts`를 추가해 쿠키 유무에 따라 앱 라우트와 공개 라우트를 가드합니다.
- Sonner를 추가하고 공용 Toaster/알림 헬퍼를 shared 계층에 구성했습니다.
- `/users/me`가 404를 반환하면 “존재하지 않는 유저입니다.” 알림을 표시하고, 서버 로그아웃으로 쿠키 clear를 요청한 뒤 랜딩으로 이동하도록 처리했습니다.

### 변경 이유

- 백엔드가 access token과 refresh token을 httpOnly 쿠키로 내려주는 구조에 맞춰 프론트 인증 흐름을 쿠키 기반으로 통일하기 위함입니다.
- access token 만료 시 사용자가 수동 재로그인하지 않아도 refresh token으로 세션을 복구하고, 동시 요청에서도 refresh API 중복 호출을 막기 위함입니다.
- 클라이언트 저장소에 토큰을 보관하지 않도록 정리해 보안 요구사항을 맞추기 위함입니다.
- 인증 상태에 따라 접근 가능한 라우트를 명확히 분리하고, 삭제/미존재 사용자 케이스에서 사용자에게 명확한 피드백을 주기 위함입니다.

## 관련 이슈

- Closes #49

## 기타 참고사항

- Before/After 스크린샷: 인증 요청/라우팅 동작 변경이라 별도 UI 스크린샷은 첨부하지 않았습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 미실행, package 스크립트 없음
- `npm run test:e2e`: 미실행, e2e 스크립트 없음
- `npm i sonner` 후 npm audit 기준 기존 포함 9개 취약점이 보고됐으나, 이번 PR 범위와 직접 관련된 수정은 하지 않았습니다.