### PR TITLE
#54 / chore(settings) : 프로젝트 MCP 설정 추가

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,14 @@
+[mcp_servers.tosspayments-integration-guide]
+command = "npx"
+args = ["-y", "@tosspayments/integration-guide-mcp@latest"]
+
+[mcp_servers.tosspayments-integration-guide.tools.get-v2-documents]
+approval_mode = "approve"
+
+[mcp_servers.context7]
+command = "npx"
+args = ["-y", "@upstash/context7-mcp@latest"]
+
+[mcp_servers.chrome-devtools]
+command = "npx"
+args = ["-y", "chrome-devtools-mcp@latest"]


### PR DESCRIPTION
## PR 요약

- 프로젝트 전용 Codex MCP 설정에 Context7 MCP와 Chrome DevTools MCP를 추가합니다.

## 변경 내용 상세

### 변경 사항

- `.codex/config.toml`에 Context7 MCP 설정을 추가했습니다.
- `.codex/config.toml`에 Chrome DevTools MCP 설정을 추가했습니다.
- 기존 TossPayments MCP 설정은 유지했습니다.

### 변경 이유

- 프로젝트 작업 중 최신 라이브러리 문서 조회와 브라우저 디버깅 도구 연동을 Codex에서 사용할 수 있도록 하기 위해 추가했습니다.

## 관련 이슈

- Closes #54

## 기타 참고사항

- 렌더러/UI 변경이 없어 Before/After 스크린샷은 해당 없음입니다.
- 로컬 검증 결과:
  - `npm run lint`: 통과
  - `npm run start`: 미실행, 설정 파일 변경만 포함하며 서버 지속 실행 명령입니다.
  - `npm run package`: 미실행, 현재 `package.json`에 해당 스크립트가 없습니다.
- `npm ci` 실행 시 기존 의존성 기준 audit 경고 9건이 표시되었습니다.