### PR TITLE
#40 / fix(settings) : SSR 초기 설정으로 테마 깜빡임 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getInitialLocale } from "@/shared/server/getUserLocale";
+import { getInitialUserSettings } from "@/features/settings/server/getInitialUserSettings";
 import { IntlProvider } from "@/shared/ui/IntlProvider";
 import { AppToaster } from "@/shared/ui/AppToaster";
 import { QueryProvider } from "@/shared/ui/QueryProvider";
@@ -16,13 +16,21 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const locale = await getInitialLocale();
+  const initialSettings = await getInitialUserSettings();
 
   return (
-    <html lang={locale}>
-      <body className="bg-slate-50 antialiased">
+    <html
+      lang={initialSettings.language}
+      data-theme={initialSettings.theme}
+      suppressHydrationWarning
+    >
+      <body className="bg-background text-foreground antialiased">
         <QueryProvider>
-          <IntlProvider initialLocale={locale}>
+          <IntlProvider
+            initialLocale={initialSettings.language}
+            initialTheme={initialSettings.theme}
+            preferServerSettings={initialSettings.source === "server"}
+          >
             {children}
             <AppToaster />
           </IntlProvider>

--- a/src/features/settings/server/getInitialUserSettings.ts
+++ b/src/features/settings/server/getInitialUserSettings.ts
@@ -1,0 +1,79 @@
+import { cookies } from "next/headers";
+import type { UserSettingsResponseDto } from "@/features/settings/model/settings.dto";
+import { buildApiUrl } from "@/shared/config/env";
+import {
+  DEFAULT_LOCALE,
+  isAppLocale,
+  type AppLocale,
+} from "@/shared/config/locale";
+import { DEFAULT_THEME, type ThemeMode } from "@/shared/config/settings";
+
+type InitialUserSettingsSource = "server" | "fallback";
+
+export interface InitialUserSettings {
+  language: AppLocale;
+  source: InitialUserSettingsSource;
+  theme: ThemeMode;
+}
+
+const FALLBACK_SETTINGS: InitialUserSettings = {
+  language: DEFAULT_LOCALE,
+  source: "fallback",
+  theme: DEFAULT_THEME,
+};
+
+const mapThemeFromServer = (
+  theme: UserSettingsResponseDto["theme"],
+): ThemeMode => {
+  if (theme === "LIGHT") {
+    return "light";
+  }
+
+  return "dark";
+};
+
+const buildCookieHeader = async () => {
+  const cookieStore = await cookies();
+  const requestCookies = cookieStore.getAll();
+
+  if (requestCookies.length === 0) {
+    return null;
+  }
+
+  return requestCookies
+    .map(({ name, value }) => `${name}=${value}`)
+    .join("; ");
+};
+
+export async function getInitialUserSettings(): Promise<InitialUserSettings> {
+  const cookieHeader = await buildCookieHeader();
+
+  if (!cookieHeader) {
+    return FALLBACK_SETTINGS;
+  }
+
+  try {
+    const response = await fetch(buildApiUrl("/users/me/settings"), {
+      cache: "no-store",
+      headers: {
+        Cookie: cookieHeader,
+      },
+    });
+
+    if (!response.ok) {
+      return FALLBACK_SETTINGS;
+    }
+
+    const settings = (await response.json()) as UserSettingsResponseDto;
+
+    return {
+      language: isAppLocale(settings.language)
+        ? settings.language
+        : FALLBACK_SETTINGS.language,
+      source: "server",
+      theme: mapThemeFromServer(settings.theme),
+    };
+  } catch {
+    return FALLBACK_SETTINGS;
+  }
+}

--- a/src/shared/config/settings.ts
+++ b/src/shared/config/settings.ts
@@ -1,0 +1,6 @@
+import type { AppLocale } from "@/shared/config/locale";
+
+export type ThemeMode = "light" | "dark";
+export type LanguageCode = AppLocale;
+
+export const DEFAULT_THEME: ThemeMode = "dark";

--- a/src/shared/store/settingsStore.ts
+++ b/src/shared/store/settingsStore.ts
@@ -6,10 +6,15 @@ import {
   persist,
   type StateStorage,
 } from "zustand/middleware";
-import { DEFAULT_LOCALE, type AppLocale } from "@/shared/config/locale";
+import { DEFAULT_LOCALE } from "@/shared/config/locale";
+import {
+  DEFAULT_THEME,
+  type LanguageCode,
+  type ThemeMode,
+} from "@/shared/config/settings";
 
-export type ThemeMode = "light" | "dark";
-export type LanguageCode = AppLocale;
+export { DEFAULT_THEME };
+export type { LanguageCode, ThemeMode };
 
 interface SettingsState {
   theme: ThemeMode;
@@ -32,7 +37,7 @@ const noopStorage: StateStorage = {
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set, get) => ({
-      theme: "dark",
+      theme: DEFAULT_THEME,
       language: DEFAULT_LOCALE,
       setTheme: (theme) => set({ theme }),
       toggleTheme: () =>
@@ -47,6 +52,7 @@ export const useSettingsStore = create<SettingsState>()(
     }),
     {
       name: "easy-clip-settings",
+      skipHydration: true,
       storage: createJSONStorage(() =>
         typeof window === "undefined" ? noopStorage : localStorage,
       ),

--- a/src/shared/ui/IntlProvider.tsx
+++ b/src/shared/ui/IntlProvider.tsx
@@ -1,17 +1,23 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import enMessages from "@/messages/en.json";
 import jaMessages from "@/messages/ja.json";
 import koMessages from "@/messages/ko.json";
 import zhMessages from "@/messages/zh.json";
 import { DEFAULT_TIME_ZONE, type AppLocale } from "@/shared/config/locale";
-import { applySettings, useSettingsStore } from "@/shared/store/settingsStore";
+import {
+  applySettings,
+  type ThemeMode,
+  useSettingsStore,
+} from "@/shared/store/settingsStore";
 
 interface IntlProviderProps {
   children: React.ReactNode;
   initialLocale: AppLocale;
+  initialTheme: ThemeMode;
+  preferServerSettings: boolean;
 }
 
 const messagesByLocale = {
@@ -21,9 +27,46 @@ const messagesByLocale = {
   zh: zhMessages,
 } as const;
 
-export function IntlProvider({ children, initialLocale }: IntlProviderProps) {
-  const theme = useSettingsStore((state) => state.theme);
-  const language = useSettingsStore((state) => state.language);
+const useIsomorphicLayoutEffect =
+  typeof window === "undefined" ? useEffect : useLayoutEffect;
+
+export function IntlProvider({
+  children,
+  initialLocale,
+  initialTheme,
+  preferServerSettings,
+}: IntlProviderProps) {
+  const [isSettingsReady, setIsSettingsReady] = useState(false);
+  const storeTheme = useSettingsStore((state) => state.theme);
+  const storeLanguage = useSettingsStore((state) => state.language);
+  const theme = isSettingsReady ? storeTheme : initialTheme;
+  const language = isSettingsReady ? storeLanguage : initialLocale;
+
+  useIsomorphicLayoutEffect(() => {
+    let isMounted = true;
+
+    useSettingsStore.setState({
+      language: initialLocale,
+      theme: initialTheme,
+    });
+
+    if (preferServerSettings) {
+      setIsSettingsReady(true);
+      return () => {
+        isMounted = false;
+      };
+    }
+
+    void Promise.resolve(useSettingsStore.persist.rehydrate()).finally(() => {
+      if (isMounted) {
+        setIsSettingsReady(true);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [initialLocale, initialTheme, preferServerSettings]);
 
   useEffect(() => {
     applySettings(theme, language);


### PR DESCRIPTION
## PR 요약

- SSR 초기 설정을 적용해 새로고침 시 기본 테마에서 유저 설정 테마로 바뀌며 깜빡이는 현상을 줄였습니다.

## 변경 내용 상세

### 변경 사항

- 서버 컴포넌트 단계에서 요청 쿠키를 전달해 `/users/me/settings`를 조회하는 초기 설정 유틸을 추가했습니다.
- `RootLayout`에서 첫 HTML 응답부터 `lang`과 `data-theme`를 유저 설정 기준으로 렌더링하도록 변경했습니다.
- Zustand 설정 store의 자동 persist hydration을 끄고, 서버 초기값을 먼저 주입한 뒤 필요한 경우 localStorage를 수동 hydrate하도록 조정했습니다.
- 전역 `body` 배경/글자색을 CSS theme token 기반으로 맞췄습니다.

### 변경 이유

- 기존에는 클라이언트 마운트 후 세션 복구와 설정 동기화가 끝난 뒤 테마가 적용되어 첫 렌더링 시 기본 테마가 잠깐 노출될 수 있었습니다.
- SSR 단계에서 초기 테마와 언어를 확정하면 첫 paint 전에 `data-theme`가 정해져 새로고침 시각 전환을 줄일 수 있습니다.

## 관련 이슈

- Closes #40

## 기타 참고사항

- Before/After 스크린샷 또는 녹화: 새로고침 시점의 테마 초기 적용 개선이라 별도 첨부하지 않았습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 통과, `http://localhost:3002` 응답 확인
- `npm run package`: 실패, 현재 `package.json`에 `package` 스크립트가 없습니다.
- `npm run test:e2e`: 미실행, 현재 e2e 스크립트가 없습니다.
