### PR TITLE
#57 / fix(search) : 검색 디바운스와 캐시 반영 개선

### DIFF
--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -10,12 +10,19 @@ import {
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
-import { updateClipFavoriteCache } from "@/features/clip/service/clipQueryCache";
+import {
+  invalidateClipQueries,
+  moveClipToRecentCache,
+  updateClipFavoriteCache,
+} from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 
 export const useFavoriteClipsPage = () => {
   const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
+  const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const { copyToast, showCopyToast } = useCopyToast();
   const {
     clips,
@@ -27,7 +34,13 @@ export const useFavoriteClipsPage = () => {
   } = useInfiniteClips({
     favorite: true,
     filter: activeFilter,
+    searchQuery: debouncedSearchQuery,
   });
+
+  const refreshClipQueries = useCallback(
+    () => invalidateClipQueries(queryClient),
+    [queryClient],
+  );
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
@@ -41,9 +54,11 @@ export const useFavoriteClipsPage = () => {
 
       if (isAuthenticated) {
         await recordClipView(clip.id);
+        moveClipToRecentCache(queryClient, clip.id);
+        void refreshClipQueries();
       }
     },
-    [isAuthenticated, showCopyToast],
+    [isAuthenticated, queryClient, refreshClipQueries, showCopyToast],
   );
 
   const handleToggleFavorite = useCallback(
@@ -67,9 +82,11 @@ export const useFavoriteClipsPage = () => {
         }
       } catch {
         rollbackFavorite();
+      } finally {
+        void refreshClipQueries();
       }
     },
-    [isAuthenticated, queryClient],
+    [isAuthenticated, queryClient, refreshClipQueries],
   );
 
   return {
@@ -80,7 +97,9 @@ export const useFavoriteClipsPage = () => {
     hasNextPage: Boolean(hasNextPage),
     isFetchingNextPage,
     isLoading: isPending,
+    searchQuery,
     setActiveFilter,
+    setSearchQuery,
     handleCopy,
     handleToggleFavorite,
   };

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -21,10 +21,12 @@ import {
   mapClipResponseToListItem,
   removeClipsFromCache,
   replaceOptimisticClipInCache,
+  moveClipToRecentCache,
   updateClipFavoriteCache,
 } from "@/features/clip/service/clipQueryCache";
 import { ClipListItemResponseDto } from "@/features/clip/model/clip.dto";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { waitForMinimumLoading } from "@/shared/lib/loading";
 import { notifyError } from "@/shared/lib/toast";
 
@@ -92,6 +94,7 @@ export const useFolderClipsPage = () => {
   const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const [isActive, setIsActive] = useState(false);
   const [contextMenu, setContextMenu] = useState<{
     id: string;
@@ -110,7 +113,7 @@ export const useFolderClipsPage = () => {
   } = useInfiniteClips({
     folderId,
     filter: activeFilter,
-    searchQuery,
+    searchQuery: debouncedSearchQuery,
     enabled: Boolean(folderId),
   });
 
@@ -284,9 +287,11 @@ export const useFolderClipsPage = () => {
 
       if (isAuthenticated) {
         await recordClipView(clip.id);
+        moveClipToRecentCache(queryClient, clip.id);
+        void refreshClipQueries();
       }
     },
-    [isAuthenticated, showCopyToast],
+    [isAuthenticated, queryClient, refreshClipQueries, showCopyToast],
   );
 
   const handleCopyFromMenu = useCallback(
@@ -299,11 +304,13 @@ export const useFolderClipsPage = () => {
 
       if (isAuthenticated) {
         await recordClipView(clip.id);
+        moveClipToRecentCache(queryClient, clip.id);
+        void refreshClipQueries();
       }
 
       setContextMenu(null);
     },
-    [isAuthenticated],
+    [isAuthenticated, queryClient, refreshClipQueries],
   );
 
   const handleToggleFavorite = useCallback(
@@ -327,9 +334,11 @@ export const useFolderClipsPage = () => {
         }
       } catch {
         rollbackFavorite();
+      } finally {
+        void refreshClipQueries();
       }
     },
-    [isAuthenticated, queryClient],
+    [isAuthenticated, queryClient, refreshClipQueries],
   );
 
   const handleOpenContextMenu = useCallback(

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -6,13 +6,18 @@ import { recordClipView } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
-import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
+import {
+  invalidateClipQueries,
+  moveClipToRecentCache,
+} from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 
 export const useRecentClipsPage = () => {
   const queryClient = useQueryClient();
   const [activeFilter, setActiveFilter] = useState<FilterType>("all");
   const [searchQuery, setSearchQuery] = useState("");
+  const debouncedSearchQuery = useDebouncedValue(searchQuery);
   const { copyToast, showCopyToast } = useCopyToast();
   const {
     clips,
@@ -24,7 +29,7 @@ export const useRecentClipsPage = () => {
   } = useInfiniteClips({
     recent: true,
     filter: activeFilter,
-    searchQuery,
+    searchQuery: debouncedSearchQuery,
   });
 
   const refreshClipQueries = useCallback(
@@ -44,10 +49,11 @@ export const useRecentClipsPage = () => {
 
       if (isAuthenticated) {
         await recordClipView(clip.id);
-        await refreshClipQueries();
+        moveClipToRecentCache(queryClient, clip.id);
+        void refreshClipQueries();
       }
     },
-    [isAuthenticated, refreshClipQueries, showCopyToast],
+    [isAuthenticated, queryClient, refreshClipQueries, showCopyToast],
   );
 
   return {

--- a/src/features/clip/service/clipQueryCache.ts
+++ b/src/features/clip/service/clipQueryCache.ts
@@ -161,6 +161,7 @@ const updateClipFavoriteData = (
   queryKey: QueryKey,
   clipId: string,
   isFavorite: boolean,
+  favoriteClip: ClipListItemResponseDto | null,
 ) => {
   if (!data) {
     return data;
@@ -169,6 +170,19 @@ const updateClipFavoriteData = (
   const queryOptions = getClipQueryOptions(queryKey);
   const shouldRemoveFromFavorites =
     queryOptions?.favorite === true && !isFavorite;
+  const nextFavoriteClip = favoriteClip
+    ? { ...favoriteClip, likeByMe: isFavorite }
+    : null;
+  const shouldInsertIntoFavorites =
+    queryOptions?.favorite === true &&
+    isFavorite &&
+    nextFavoriteClip &&
+    matchesClipQueryOptions(nextFavoriteClip, queryOptions) &&
+    !data.pages.some((page) => page.items.some((clip) => clip.id === clipId));
+
+  if (shouldInsertIntoFavorites && nextFavoriteClip) {
+    return moveClipToFirstPage(data, nextFavoriteClip);
+  }
 
   return {
     ...data,
@@ -180,6 +194,38 @@ const updateClipFavoriteData = (
             clip.id === clipId ? { ...clip, likeByMe: isFavorite } : clip,
           ),
     })),
+  };
+};
+
+const moveClipToFirstPage = (
+  data: InfiniteData<ClipCursorPageResponseDto> | undefined,
+  clip: ClipListItemResponseDto,
+) => {
+  if (!data) {
+    return data;
+  }
+
+  const [firstPage] = data.pages;
+
+  if (!firstPage) {
+    return data;
+  }
+
+  const pagesWithoutClip = data.pages.map((page) => ({
+    ...page,
+    items: page.items.filter((item) => item.id !== clip.id),
+  }));
+  const [nextFirstPage, ...nextRestPages] = pagesWithoutClip;
+
+  return {
+    ...data,
+    pages: [
+      {
+        ...nextFirstPage,
+        items: [clip, ...nextFirstPage.items],
+      },
+      ...nextRestPages,
+    ],
   };
 };
 
@@ -196,12 +242,28 @@ export const updateClipFavoriteCache = (
 ) => {
   const clipQueries = getClipQueries(queryClient);
   const snapshots = getClipQuerySnapshots(queryClient);
+  const favoriteClip =
+    clipQueries
+      .flatMap((query) => {
+        const data = query.state.data as
+          | InfiniteData<ClipCursorPageResponseDto>
+          | undefined;
+
+        return data?.pages.flatMap((page) => page.items) ?? [];
+      })
+      .find((clip) => clip.id === clipId) ?? null;
 
   for (const query of clipQueries) {
     queryClient.setQueryData<InfiniteData<ClipCursorPageResponseDto>>(
       query.queryKey,
       (data) =>
-        updateClipFavoriteData(data, query.queryKey, clipId, isFavorite),
+        updateClipFavoriteData(
+          data,
+          query.queryKey,
+          clipId,
+          isFavorite,
+          favoriteClip,
+        ),
     );
   }
 
@@ -362,6 +424,42 @@ export const replaceOptimisticClipInCache = (
           })),
         };
       },
+    );
+  }
+};
+
+export const moveClipToRecentCache = (
+  queryClient: QueryClient,
+  clipId: string,
+) => {
+  const clipQueries = getClipQueries(queryClient);
+  const copiedClip = clipQueries
+    .flatMap((query) => {
+      const data = query.state.data as
+        | InfiniteData<ClipCursorPageResponseDto>
+        | undefined;
+
+      return data?.pages.flatMap((page) => page.items) ?? [];
+    })
+    .find((clip) => clip.id === clipId);
+
+  if (!copiedClip) {
+    return;
+  }
+
+  for (const query of clipQueries) {
+    const queryOptions = getClipQueryOptions(query.queryKey);
+
+    if (
+      !queryOptions?.recent ||
+      !matchesClipQueryOptions(copiedClip, queryOptions)
+    ) {
+      continue;
+    }
+
+    queryClient.setQueryData<InfiniteData<ClipCursorPageResponseDto>>(
+      query.queryKey,
+      (data) => moveClipToFirstPage(data, copiedClip),
     );
   }
 };

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -18,7 +18,9 @@ export function FavoriteClipsPage() {
     hasNextPage,
     isFetchingNextPage,
     isLoading,
+    searchQuery,
     setActiveFilter,
+    setSearchQuery,
   } = useFavoriteClipsPage();
 
   return (
@@ -26,6 +28,8 @@ export function FavoriteClipsPage() {
       <FilterBar
         activeFilter={activeFilter}
         onFilterChange={setActiveFilter}
+        searchQuery={searchQuery}
+        onSearchChange={setSearchQuery}
         showStatus={false}
         countLabel={t("count", { count: filteredClips.length })}
       />

--- a/src/shared/hooks/useDebouncedValue.ts
+++ b/src/shared/hooks/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export const useDebouncedValue = <T>(value: T, delayMs = 300) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delayMs);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [delayMs, value]);
+
+  return debouncedValue;
+};


### PR DESCRIPTION
## PR 요약

- 즐겨찾기 검색 동작을 연결하고, 클립 검색 디바운스와 최근/즐겨찾기 캐시 즉시 반영을 개선했습니다.

## 변경 내용 상세

### 변경 사항

- 즐겨찾기 화면에 검색 상태를 추가하고 `FilterBar` 검색 입력을 즐겨찾기 목록 쿼리에 연결했습니다.
- 공통 `useDebouncedValue` 훅을 추가해 폴더/최근/즐겨찾기 검색어를 300ms 디바운스 후 API 쿼리에 반영하도록 변경했습니다.
- 클립 복사 후 recent 쿼리 캐시에서 해당 클립을 첫 페이지 상단으로 이동시키고 background invalidate로 정합성을 보정하도록 개선했습니다.
- 즐겨찾기 토글 시 favorite 쿼리 캐시에 즉시 삽입/제거되도록 보정하고, 이후 invalidate로 서버 상태와 동기화합니다.

### 변경 이유

- 기존 즐겨찾기 검색바는 입력 상태가 연결되지 않아 검색이 동작하지 않았습니다.
- 검색어가 입력마다 바로 쿼리 키와 API 요청에 반영되어 불필요한 요청이 발생할 수 있었습니다.
- 클립 복사/즐겨찾기 토글 후 최근항목과 즐겨찾기 화면 이동 시 캐시 때문에 결과가 즉시 보이지 않는 문제가 있었습니다.

## 관련 이슈

- Closes #57

## 기타 참고사항

- Before/After 스크린샷 또는 녹화: 검색/캐시 반영 동작 변경이라 별도 첨부하지 않았습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 통과, `http://localhost:3002` 응답 확인
- `npm run package`: 실패, 현재 `package.json`에 `package` 스크립트가 없습니다.
- `npm run test:e2e`: 미실행, 현재 e2e 스크립트가 없습니다.
