### PR TITLE
#59 / fix(clips) : 이미지 클립 복사 동작 수정

### DIFF
--- a/src/features/clip/hooks/useFavoriteClipsPage.ts
+++ b/src/features/clip/hooks/useFavoriteClipsPage.ts
@@ -10,6 +10,7 @@ import {
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import { copyClipToClipboard } from "@/features/clip/service/clipClipboard";
 import {
   invalidateClipQueries,
   moveClipToRecentCache,
@@ -17,6 +18,7 @@ import {
 } from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
+import { notifyError } from "@/shared/lib/toast";
 
 export const useFavoriteClipsPage = () => {
   const queryClient = useQueryClient();
@@ -44,13 +46,14 @@ export const useFavoriteClipsPage = () => {
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
-      showCopyToast(event.clientX, event.clientY);
-
       try {
-        await navigator.clipboard.writeText(clip.content);
+        await copyClipToClipboard(clip);
       } catch {
-        // no-op
+        notifyError("클립을 복사하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        return;
       }
+
+      showCopyToast(event.clientX, event.clientY);
 
       if (isAuthenticated) {
         await recordClipView(clip.id);

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -14,6 +14,7 @@ import {
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import { copyClipToClipboard } from "@/features/clip/service/clipClipboard";
 import {
   addOptimisticClipToCache,
   cancelClipQueries,
@@ -277,13 +278,14 @@ export const useFolderClipsPage = () => {
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
-      showCopyToast(event.clientX, event.clientY);
-
       try {
-        await navigator.clipboard.writeText(clip.content);
+        await copyClipToClipboard(clip);
       } catch {
-        // no-op
+        notifyError("클립을 복사하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        return;
       }
+
+      showCopyToast(event.clientX, event.clientY);
 
       if (isAuthenticated) {
         await recordClipView(clip.id);
@@ -297,9 +299,10 @@ export const useFolderClipsPage = () => {
   const handleCopyFromMenu = useCallback(
     async (clip: Clip) => {
       try {
-        await navigator.clipboard.writeText(clip.content);
+        await copyClipToClipboard(clip);
       } catch {
-        // no-op
+        notifyError("클립을 복사하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        return;
       }
 
       if (isAuthenticated) {

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -6,12 +6,14 @@ import { recordClipView } from "@/features/clip/api/clipApi";
 import { useCopyToast } from "@/features/clip/hooks/useCopyToast";
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import { Clip } from "@/features/clip/model/clip";
+import { copyClipToClipboard } from "@/features/clip/service/clipClipboard";
 import {
   invalidateClipQueries,
   moveClipToRecentCache,
 } from "@/features/clip/service/clipQueryCache";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
+import { notifyError } from "@/shared/lib/toast";
 
 export const useRecentClipsPage = () => {
   const queryClient = useQueryClient();
@@ -39,13 +41,14 @@ export const useRecentClipsPage = () => {
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
-      showCopyToast(event.clientX, event.clientY);
-
       try {
-        await navigator.clipboard.writeText(clip.content);
+        await copyClipToClipboard(clip);
       } catch {
-        // no-op
+        notifyError("클립을 복사하지 못했습니다. 잠시 후 다시 시도해주세요.");
+        return;
       }
+
+      showCopyToast(event.clientX, event.clientY);
 
       if (isAuthenticated) {
         await recordClipView(clip.id);

--- a/src/features/clip/service/clipClipboard.ts
+++ b/src/features/clip/service/clipClipboard.ts
@@ -1,0 +1,112 @@
+"use client";
+
+import { Clip } from "@/features/clip/model/clip";
+
+const IMAGE_CLIPBOARD_FALLBACK_TYPE = "image/png";
+
+export class ClipClipboardError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClipClipboardError";
+  }
+}
+
+const assertClipboardApi = () => {
+  if (!navigator.clipboard) {
+    throw new ClipClipboardError("Clipboard API is not available.");
+  }
+};
+
+const writeTextToClipboard = async (text: string) => {
+  assertClipboardApi();
+  await navigator.clipboard.writeText(text);
+};
+
+const fetchImageBlob = async (imageUrl: string) => {
+  const response = await fetch(imageUrl, {
+    mode: "cors",
+  });
+
+  if (!response.ok) {
+    throw new ClipClipboardError("Failed to fetch image clip.");
+  }
+
+  const blob = await response.blob();
+
+  if (!blob.type.startsWith("image/")) {
+    throw new ClipClipboardError("Fetched clip is not an image.");
+  }
+
+  return blob;
+};
+
+const convertImageBlobToPng = async (blob: Blob) => {
+  const imageBitmap = await createImageBitmap(blob);
+  const canvas = document.createElement("canvas");
+  canvas.width = imageBitmap.width;
+  canvas.height = imageBitmap.height;
+
+  const context = canvas.getContext("2d");
+
+  if (!context) {
+    imageBitmap.close();
+    throw new ClipClipboardError("Canvas is not available.");
+  }
+
+  context.drawImage(imageBitmap, 0, 0);
+  imageBitmap.close();
+
+  return new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob((pngBlob) => {
+      if (!pngBlob) {
+        reject(new ClipClipboardError("Failed to convert image clip."));
+        return;
+      }
+
+      resolve(pngBlob);
+    }, IMAGE_CLIPBOARD_FALLBACK_TYPE);
+  });
+};
+
+const writeImageBlobToClipboard = async (blob: Blob) => {
+  assertClipboardApi();
+
+  if (!navigator.clipboard.write || typeof ClipboardItem === "undefined") {
+    throw new ClipClipboardError("Image clipboard API is not available.");
+  }
+
+  try {
+    await navigator.clipboard.write([
+      new ClipboardItem({
+        [blob.type]: blob,
+      }),
+    ]);
+    return;
+  } catch (error) {
+    if (blob.type === IMAGE_CLIPBOARD_FALLBACK_TYPE) {
+      throw error;
+    }
+  }
+
+  const pngBlob = await convertImageBlobToPng(blob);
+
+  await navigator.clipboard.write([
+    new ClipboardItem({
+      [IMAGE_CLIPBOARD_FALLBACK_TYPE]: pngBlob,
+    }),
+  ]);
+};
+
+const copyImageClipToClipboard = async (imageUrl: string) => {
+  const imageBlob = await fetchImageBlob(imageUrl);
+  await writeImageBlobToClipboard(imageBlob);
+};
+
+export const copyClipToClipboard = async (clip: Clip) => {
+  if (clip.type === "image") {
+    await copyImageClipToClipboard(clip.content);
+    return;
+  }
+
+  await writeTextToClipboard(clip.content);
+};


### PR DESCRIPTION
## PR 요약

- 이미지 클립 복사 시 R2/CDN URL 문자열이 아니라 실제 이미지 데이터가 클립보드에 들어가도록 수정했습니다.

## 변경 내용 상세

### 변경 사항

- 클립 타입별 복사 처리를 `copyClipToClipboard` 공통 유틸로 분리했습니다.
- 이미지 클립은 이미지 URL을 `fetch`해 `Blob`으로 변환한 뒤 `ClipboardItem`으로 복사하도록 변경했습니다.
- 브라우저가 원본 이미지 MIME 복사를 거부하는 경우 PNG로 변환해 한 번 더 복사하도록 fallback을 추가했습니다.
- 폴더/최근/즐겨찾기 화면의 중복 `navigator.clipboard.writeText` 호출을 공통 유틸 사용으로 교체했습니다.
- 복사 성공 후에만 성공 토스트와 최근항목 조회 기록이 반영되도록 조정했습니다.
- 복사 실패 시 에러 토스트를 표시하도록 변경했습니다.

### 변경 이유

- 기존에는 이미지 클립도 텍스트 클립처럼 URL 문자열을 `writeText`로 복사해, 붙여넣기 시 실제 이미지가 아닌 R2/CDN URL만 들어가는 문제가 있었습니다.
- 이미지 클립은 URL을 이미지 Blob으로 읽어 브라우저 Clipboard API의 이미지 쓰기 기능을 사용해야 실제 이미지로 붙여넣을 수 있습니다.

## 관련 이슈

- Closes #59

## 기타 참고사항

- Before/After 스크린샷 또는 녹화: 클립보드 복사 동작 변경이라 별도 첨부하지 않았습니다.
- R2/CDN 이미지 URL은 브라우저에서 `fetch` 가능한 CORS 설정이 필요합니다. 개발 환경에서는 `http://localhost:3001` 등 실제 프론트 origin을 R2 CORS 허용 origin에 포함해야 합니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 통과, `http://localhost:3002` 응답 확인
- `npm run package`: 실패, 현재 `package.json`에 `package` 스크립트가 없습니다.
- `npm run test:e2e`: 미실행, 현재 e2e 스크립트가 없습니다.
