### PR TITLE
#63 / fix(folder) : 현재 폴더 삭제 후 경로 보정

### DIFF
--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -9,6 +9,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { logout } from "@/features/auth/api/authApi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { clearAuthSession } from "@/features/auth/service/authSession";
+import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
 import { useFolders } from "@/features/folder/hooks/useFolders";
 import { FolderNameModal } from "@/features/folder/ui/FolderNameModal";
 import { FolderSidebarFooter } from "@/features/folder/ui/FolderSidebarFooter";
@@ -196,6 +197,33 @@ export function Sidebar({
       });
   }, [ensureAuthenticated, renameFolder, renameFolderId, renameFolderName]);
 
+  const getRedirectPathAfterFolderDelete = useCallback(
+    (deletedFolderId: string) => {
+      const deletedFolderIndex = folders.findIndex(
+        (folder) => folder.id === deletedFolderId,
+      );
+      const remainingFolders = folders.filter(
+        (folder) => folder.id !== deletedFolderId,
+      );
+      const nextFolder =
+        remainingFolders[
+          Math.min(Math.max(deletedFolderIndex, 0), remainingFolders.length - 1)
+        ] ?? null;
+      const [, section] = pathname.split("/").filter(Boolean);
+
+      if (section === "favorites") {
+        return nextFolder ? `/${nextFolder.id}/favorites` : "/favorites";
+      }
+
+      if (section === "recent") {
+        return nextFolder ? `/${nextFolder.id}/recent` : "/recent";
+      }
+
+      return nextFolder ? `/${nextFolder.id}` : "/recent";
+    },
+    [folders, pathname],
+  );
+
   const userLabel =
     session?.user?.authAccounts?.[0]?.email ??
     session?.user?.displayName ??
@@ -298,9 +326,19 @@ export function Sidebar({
                   return;
                 }
 
+                const isDeletingCurrentFolder = pathnameFolderId === folderId;
+                const redirectPath =
+                  getRedirectPathAfterFolderDelete(folderId);
+
                 void removeFolder(folderId)
                   .then(() => {
                     setOpenOptionsFolderId(null);
+                    void invalidateClipQueries(queryClient);
+
+                    if (isDeletingCurrentFolder) {
+                      onCloseMobile?.();
+                      router.replace(redirectPath);
+                    }
                   })
                   .catch(() => {
                     // keep the menu open when the request fails


### PR DESCRIPTION
## PR 요약

- 현재 보고 있는 폴더를 삭제하면 삭제된 폴더 경로에 남지 않도록 안전한 경로로 이동시킵니다.

## 변경 내용 상세

### 변경 사항

- 사이드바 폴더 삭제 성공 시 삭제 대상이 현재 URL의 폴더인지 확인합니다.
- 현재 폴더 삭제라면 다음 사용 가능한 폴더로 이동하고, 폴더가 없으면 `/recent` 또는 `/favorites` 같은 안전한 기본 경로로 이동합니다.
- `/id/favorites`, `/id/recent`에서 삭제한 경우 다음 폴더의 동일 섹션 경로를 유지합니다.
- 폴더 삭제 성공 후 클립 쿼리를 무효화해 삭제된 폴더 기준 목록 상태가 남지 않도록 했습니다.

### 변경 이유

- 기존에는 현재 폴더를 삭제해도 URL이 삭제된 폴더 ID를 계속 가리킬 수 있어 이후 클립 조회 실패 또는 빈 상태처럼 보이는 UX가 발생할 수 있었습니다.

## 관련 이슈

- Closes #63

## 기타 참고사항

- Before: 현재 폴더 삭제 후에도 `/<folderId>` 또는 `/<folderId>/recent`, `/<folderId>/favorites` 경로에 남을 수 있었습니다.
- After: 삭제 성공 후 다음 폴더 또는 기본 안전 경로로 `replace` 이동합니다.
- 스크린샷: 현재 로컬 환경에는 로그인 테스트 세션과 실제 폴더 데이터가 없어 삭제 플로우 화면 캡처는 첨부하지 못했습니다. 라우팅 코드 경로, 타입 검증, 보호 라우트 응답으로 검증했습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 실행 후 `/login` 200 OK, `/some-folder-id` 307 Redirect, `/some-folder-id/recent` 307 Redirect, `/some-folder-id/favorites` 307 Redirect 확인
- `npm run package`: 미실행 - 현재 `package.json`에 스크립트가 없습니다.
- `npm run test:e2e`: 미실행 - 현재 e2e 테스트 스크립트가 없습니다.