### PR TITLE
#64 / refactor(folder) : 폴더 정렬 저장 시점 분리

### DIFF
--- a/src/features/folder/hooks/useFolders.ts
+++ b/src/features/folder/hooks/useFolders.ts
@@ -29,6 +29,37 @@ const FOLDER_QUERY_KEYS = {
 const sortFolders = (folders: FolderItem[]) =>
   [...folders].sort((left, right) => left.order - right.order);
 
+const reorderFolderItems = (
+  folders: FolderItem[],
+  sourceId: string,
+  targetId: string,
+) => {
+  if (sourceId === targetId) {
+    return folders;
+  }
+
+  const sourceIndex = folders.findIndex((folder) => folder.id === sourceId);
+  const targetIndex = folders.findIndex((folder) => folder.id === targetId);
+
+  if (sourceIndex === -1 || targetIndex === -1) {
+    return folders;
+  }
+
+  const nextFolders = [...folders];
+  const [sourceFolder] = nextFolders.splice(sourceIndex, 1);
+
+  if (!sourceFolder) {
+    return folders;
+  }
+
+  nextFolders.splice(targetIndex, 0, sourceFolder);
+
+  return nextFolders.map((folder, index) => ({
+    ...folder,
+    order: index,
+  }));
+};
+
 const mapFolder = (folder: FolderResponseDto): FolderItem => ({
   id: folder.id,
   name: folder.name,
@@ -170,31 +201,76 @@ export const useFolders = () => {
     [removeFolderAsync],
   );
 
-  const reorderFolders = useCallback(
-    async (sourceId: string, targetId: string) => {
+  const previewFolderOrder = useCallback(
+    (sourceId: string, targetId: string) => {
       if (!isAuthenticated) {
         throw createAuthRequiredError();
       }
 
       if (sourceId === targetId) {
-        return;
+        return false;
       }
 
-      const sourceIndex = folders.findIndex((folder) => folder.id === sourceId);
-      const targetIndex = folders.findIndex((folder) => folder.id === targetId);
+      let didReorder = false;
 
-      if (sourceIndex === -1 || targetIndex === -1) {
-        return;
-      }
+      setFolders((currentFolders) => {
+        const nextFolders = reorderFolderItems(
+          currentFolders,
+          sourceId,
+          targetId,
+        );
 
-      const payload =
-        sourceIndex < targetIndex
-          ? { targetId: sourceId, afterId: targetId }
-          : { targetId: sourceId, beforeId: targetId };
+        didReorder = nextFolders !== currentFolders;
 
-      await reorderFolderAsync(payload);
+        return nextFolders;
+      });
+
+      return didReorder;
     },
-    [folders, isAuthenticated, reorderFolderAsync],
+    [isAuthenticated, setFolders],
+  );
+
+  const saveFolderOrder = useCallback(
+    async (folderId: string) => {
+      if (!isAuthenticated) {
+        throw createAuthRequiredError();
+      }
+
+      const currentFolders =
+        queryClient.getQueryData<FolderItem[]>(folderQueryKey) ?? folders;
+      const folderIndex = currentFolders.findIndex(
+        (folder) => folder.id === folderId,
+      );
+
+      if (folderIndex === -1) {
+        return;
+      }
+
+      const previousFolder = currentFolders[folderIndex - 1] ?? null;
+      const nextFolder = currentFolders[folderIndex + 1] ?? null;
+
+      if (!previousFolder && !nextFolder) {
+        return;
+      }
+
+      const payload = previousFolder
+        ? { targetId: folderId, afterId: previousFolder.id }
+        : { targetId: folderId, beforeId: nextFolder?.id };
+
+      try {
+        await reorderFolderAsync(payload);
+      } catch (error) {
+        void queryClient.invalidateQueries({ queryKey: folderQueryKey });
+        throw error;
+      }
+    },
+    [
+      folderQueryKey,
+      folders,
+      isAuthenticated,
+      queryClient,
+      reorderFolderAsync,
+    ],
   );
 
   return {
@@ -203,6 +279,7 @@ export const useFolders = () => {
     createFolder,
     renameFolder,
     removeFolder,
-    reorderFolders,
+    previewFolderOrder,
+    saveFolderOrder,
   };
 };

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -39,9 +39,10 @@ export function Sidebar({
     createFolder,
     folders,
     isLoading: isFoldersLoading,
+    previewFolderOrder,
     removeFolder,
     renameFolder,
-    reorderFolders,
+    saveFolderOrder,
   } = useFolders();
   const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
   const [newFolderName, setNewFolderName] = useState("");
@@ -54,6 +55,8 @@ export function Sidebar({
   const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const renameInputRef = useRef<HTMLInputElement>(null);
+  const hasPendingFolderReorderRef = useRef(false);
+  const lastReorderTargetIdRef = useRef<string | null>(null);
   const pathSegments = pathname.split("/").filter(Boolean);
   const pathnameFolderId = pathSegments[0] ?? null;
   const reservedPathnames = new Set([
@@ -140,11 +143,36 @@ export function Sidebar({
         return;
       }
 
-      void reorderFolders(sourceId, targetId).catch(() => {
-        // keep the current order when the request fails
+      if (lastReorderTargetIdRef.current === targetId) {
+        return;
+      }
+
+      const didReorder = previewFolderOrder(sourceId, targetId);
+
+      if (didReorder) {
+        hasPendingFolderReorderRef.current = true;
+        lastReorderTargetIdRef.current = targetId;
+      }
+    },
+    [ensureAuthenticated, previewFolderOrder],
+  );
+
+  const handleCommitFolderReorder = useCallback(
+    (folderId: string | null) => {
+      setDraggingFolderId(null);
+      lastReorderTargetIdRef.current = null;
+
+      if (!folderId || !hasPendingFolderReorderRef.current) {
+        return;
+      }
+
+      hasPendingFolderReorderRef.current = false;
+
+      void saveFolderOrder(folderId).catch(() => {
+        // refresh from the server when the final order cannot be saved
       });
     },
-    [ensureAuthenticated, reorderFolders],
+    [saveFolderOrder],
   );
 
   const closeCreateModal = () => {
@@ -262,10 +290,12 @@ export function Sidebar({
               onNavigate={onCloseMobile}
               onDragStart={(folderId, event) => {
                 setDraggingFolderId(folderId);
+                hasPendingFolderReorderRef.current = false;
+                lastReorderTargetIdRef.current = null;
                 event.dataTransfer.effectAllowed = "move";
                 event.dataTransfer.setData("text/plain", folderId);
               }}
-              onDragEnd={() => setDraggingFolderId(null)}
+              onDragEnd={() => handleCommitFolderReorder(draggingFolderId)}
               onDragOver={(folderId, event) => {
                 event.preventDefault();
                 event.dataTransfer.dropEffect = "move";


### PR DESCRIPTION
## PR 요약

- 폴더 드래그 정렬 중에는 로컬 순서만 갱신하고, 드래그 종료 시 최종 순서를 서버에 한 번 저장하도록 변경합니다.

## 변경 내용 상세

### 변경 사항

- `useFolders`에서 드래그 중 로컬 캐시 순서를 바꾸는 `previewFolderOrder`와 서버에 최종 순서를 저장하는 `saveFolderOrder`를 분리했습니다.
- `Sidebar`의 `dragover`에서는 서버 mutation을 호출하지 않고 로컬 순서만 갱신합니다.
- 같은 대상 위에서 반복 발생하는 `dragover` 이벤트는 무시해 순서가 다시 뒤집히는 문제를 방지했습니다.
- `dragend` 시점에 변경이 있었던 경우에만 최종 위치를 기준으로 reorder API를 한 번 호출합니다.
- 저장 실패 시 폴더 쿼리를 다시 조회해 서버 상태로 복구합니다.

### 변경 이유

- 기존에는 `dragover`마다 reorder API가 호출될 수 있어 폴더를 조금만 움직여도 불필요한 네트워크 요청과 순서 경합이 발생할 수 있었습니다.

## 관련 이슈

- Closes #64

## 기타 참고사항

- Before: 드래그 중 다른 폴더 위를 지날 때마다 서버 정렬 요청이 발생할 수 있었습니다.
- After: 드래그 중에는 클라이언트 캐시만 갱신하고, 드래그 종료 시 최종 위치만 서버에 저장합니다.
- 스크린샷/녹화: 현재 로컬 환경에는 로그인 테스트 세션과 폴더 데이터가 없어 실제 드래그 녹화는 첨부하지 못했습니다. 코드 경로에서 서버 mutation 호출 위치가 `saveFolderOrder` 한 곳으로 제한되는 것을 확인했습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 실행 후 `/login` 200 OK, `/recent` 307 Redirect, `/trash` 307 Redirect 확인
- `npm run package`: 미실행 - 현재 `package.json`에 스크립트가 없습니다.
- `npm run test:e2e`: 미실행 - 현재 e2e 테스트 스크립트가 없습니다.