### PR TITLE
#66 / fix(landing) : 랜딩 푸터 이메일 링크 수정

### DIFF
--- a/src/features/landing/ui/LandingFooter.tsx
+++ b/src/features/landing/ui/LandingFooter.tsx
@@ -24,7 +24,7 @@ export function LandingFooter({ currentYear }: LandingFooterProps) {
           </a>
 
           <a
-            href="mailto:user@example.com"
+            href="mailto:medic6655@gmail.com"
             className="flex items-center gap-2 transition-colors hover:text-(--foreground)"
           >
             <HiOutlineMail className="h-4 w-4" />


### PR DESCRIPTION
## PR 요약

- 랜딩 푸터의 표시 이메일과 `mailto:` 링크 대상을 동일하게 맞췄습니다.

## 변경 내용 상세

### 변경 사항

- `LandingFooter`의 이메일 링크를 `mailto:user@example.com`에서 `mailto:medic6655@gmail.com`으로 수정했습니다.

### 변경 이유

- 기존에는 사용자가 보는 이메일 주소와 클릭 시 열리는 메일 수신자가 달라 혼란이 발생할 수 있었습니다.

## 관련 이슈

- Closes #66

## 기타 참고사항

- Before: 표시 텍스트는 `medic6655@gmail.com`, 링크 대상은 `user@example.com`이었습니다.
- After: 표시 텍스트와 링크 대상이 모두 `medic6655@gmail.com`입니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 실행 후 `/` 200 OK, HTML에서 `mailto:medic6655@gmail.com` 및 표시 이메일 확인
- `npm run package`: 미실행 - 현재 `package.json`에 스크립트가 없습니다.
- `npm run test:e2e`: 미실행 - 현재 e2e 테스트 스크립트가 없습니다.