### PR TITLE
#72 / fix(settings) : 드롭다운 호버 영역 보정

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -51,6 +51,7 @@
   --modal-section-bg: #f8fafc;
   --modal-icon-bg: #e5e7eb;
   --modal-icon-fg: #4b5563;
+  --dropdown-option-hover: #e2e8f0;
   --landing-header-bg: rgba(255, 255, 255, 0.9);
   --landing-brand-bg: #334155;
   --landing-brand-fg: #ffffff;
@@ -125,6 +126,7 @@
   --modal-section-bg: rgba(255, 255, 255, 0.05);
   --modal-icon-bg: rgba(255, 255, 255, 0.1);
   --modal-icon-fg: #e5e7eb;
+  --dropdown-option-hover: rgba(99, 102, 241, 0.22);
   --landing-header-bg: rgba(30, 30, 31, 0.9);
   --landing-brand-bg: #4f46e5;
   --landing-brand-fg: #f8fafc;

--- a/src/features/folder/ui/FolderSidebarFooter.tsx
+++ b/src/features/folder/ui/FolderSidebarFooter.tsx
@@ -68,11 +68,11 @@ export function FolderSidebarFooter({
     <div className="border-t border-(--border) px-4 py-4">
       <div ref={menuRef} className="relative">
         {isMenuOpen ? (
-          <div className="absolute right-0 bottom-full left-0 z-20 mb-2 overflow-hidden rounded-xl border border-(--border) bg-(--surface-elevated) py-2 shadow-xl">
+          <div className="absolute right-0 bottom-full left-0 z-20 mb-2 overflow-hidden rounded-xl border border-(--border) bg-(--surface-elevated) shadow-xl">
             <button
               type="button"
               onClick={() => handleMenuAction(onOpenSettings)}
-              className="text-foreground hover:bg-(--surface-muted) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
+              className="text-foreground hover:bg-(--dropdown-option-hover) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
             >
               <HiOutlineCog className="h-5 w-5 text-(--muted)" aria-hidden />
               {settingsLabel}
@@ -80,7 +80,7 @@ export function FolderSidebarFooter({
             <button
               type="button"
               onClick={() => handleMenuAction(onUpgradePlan)}
-              className="text-foreground hover:bg-(--surface-muted) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
+              className="text-foreground hover:bg-(--dropdown-option-hover) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
             >
               <HiOutlineCreditCard
                 className="h-5 w-5 text-(--muted)"
@@ -91,7 +91,7 @@ export function FolderSidebarFooter({
             <button
               type="button"
               onClick={() => handleMenuAction(onLogout)}
-              className="text-foreground hover:bg-(--surface-muted) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
+              className="text-foreground hover:bg-(--dropdown-option-hover) flex w-full cursor-pointer items-center gap-3 px-3 py-2.5 text-left text-sm font-medium transition-colors"
             >
               <HiOutlineLogout
                 className="h-5 w-5 text-(--muted)"

--- a/src/shared/ui/StyledSelect.tsx
+++ b/src/shared/ui/StyledSelect.tsx
@@ -92,8 +92,8 @@ export function StyledSelect({
                     }}
                     className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors ${
                       isSelected
-                        ? "bg-(--surface-muted) text-(--foreground)"
-                        : "text-(--muted) hover:bg-(--surface-muted) hover:text-(--foreground)"
+                        ? "bg-(--dropdown-option-hover) text-(--foreground)"
+                        : "text-(--muted) hover:bg-(--dropdown-option-hover) hover:text-(--foreground)"
                     }`}
                     role="option"
                     aria-selected={isSelected}

--- a/src/shared/ui/StyledSelect.tsx
+++ b/src/shared/ui/StyledSelect.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { HiCheck, HiChevronDown } from "react-icons/hi";
+import { HiChevronDown } from "react-icons/hi";
 
 interface StyledSelectOption {
   value: string;
@@ -62,7 +62,7 @@ export function StyledSelect({
         type="button"
         disabled={disabled}
         onClick={() => setIsOpen((previous) => !previous)}
-        className="text-foreground flex h-11 w-full items-center justify-between rounded-xl border border-(--border) bg-(--surface) px-4 text-sm font-medium transition-colors hover:bg-(--surface-muted)"
+        className="text-foreground flex h-11 w-full cursor-pointer items-center justify-between rounded-xl border border-(--border) bg-(--surface) px-4 text-sm font-medium transition-colors hover:bg-(--surface-muted) disabled:cursor-default"
         aria-haspopup="listbox"
         aria-expanded={isOpen}
       >
@@ -90,7 +90,7 @@ export function StyledSelect({
                       onChange(option.value);
                       setIsOpen(false);
                     }}
-                    className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors ${
+                    className={`flex w-full cursor-pointer items-center px-4 py-3 text-left text-sm transition-colors disabled:cursor-default ${
                       isSelected
                         ? "bg-(--dropdown-option-hover) text-(--foreground)"
                         : "text-(--muted) hover:bg-(--dropdown-option-hover) hover:text-(--foreground)"
@@ -99,15 +99,6 @@ export function StyledSelect({
                     aria-selected={isSelected}
                   >
                     <span className="truncate font-medium">{option.label}</span>
-                    <span
-                      className={`flex h-5 w-5 items-center justify-center rounded-full ${
-                        isSelected
-                          ? "bg-(--icon-chip) text-(--icon-chip-text)"
-                          : "text-transparent"
-                      }`}
-                    >
-                      <HiCheck className="h-3.5 w-3.5" aria-hidden />
-                    </span>
                   </button>
                 </li>
               );

--- a/src/shared/ui/StyledSelect.tsx
+++ b/src/shared/ui/StyledSelect.tsx
@@ -77,7 +77,7 @@ export function StyledSelect({
 
       {isOpen ? (
         <div className="absolute top-[calc(100%+0.5rem)] left-0 z-50 w-full overflow-hidden rounded-2xl border border-(--border) bg-(--surface-elevated) shadow-[0_18px_40px_rgba(15,23,42,0.16)]">
-          <ul className="py-2" role="listbox">
+          <ul role="listbox">
             {options.map((option) => {
               const isSelected = option.value === value;
 


### PR DESCRIPTION
## PR 요약

- 공통 드롭다운과 유저 드롭다운의 옵션 hover 강조가 리스트 최상단/최하단 끝까지 적용되도록 보정했습니다.
- hover 강조 색상을 더 선명한 공통 토큰으로 개선하고, 드롭다운 항목 커서를 명시했습니다.

## 변경 내용 상세

### 변경 사항

- `StyledSelect` 드롭다운 리스트의 상하 padding을 제거했습니다.
- 유저 드롭다운(`FolderSidebarFooter`) 메뉴 컨테이너의 상하 padding을 제거했습니다.
- `--dropdown-option-hover` 테마 토큰을 추가하고, 공통 드롭다운/유저 드롭다운 hover 및 선택 배경에 적용했습니다.
- `StyledSelect` 트리거와 옵션 버튼에 `cursor-pointer`를 명시했습니다.
- `StyledSelect` 옵션 우측 체크 아이콘 UI를 제거해 항목 레이아웃을 단순화했습니다.
- 라이트 모드에서는 기존 `--surface-muted`보다 진한 `#e2e8f0`, 다크 모드에서는 배경 대비가 더 분명한 `rgba(99, 102, 241, 0.22)`를 사용했습니다.

### 변경 이유

- 기존에는 드롭다운 내부 padding 때문에 첫 번째/마지막 옵션 hover 배경과 컨테이너 상하단 사이에 빈 영역이 남았습니다.
- 기존 hover 색상은 다크 모드에서 컨테이너 배경과 차이가 작아 강조 상태를 알아보기 어려웠습니다.
- 옵션 버튼의 커서 피드백과 우측 체크 UI가 드롭다운 사용감/시각 밀도를 어색하게 만들 수 있어 정리했습니다.

## 관련 이슈

- Closes #72

## 기타 참고사항

- Before: 첫 번째/마지막 옵션 hover 시 강조 배경이 드롭다운 상하단 끝까지 닿지 않았고, hover 색상 대비가 약했습니다.
- After: 공통 드롭다운과 유저 드롭다운 모두 옵션 hover 배경이 컨테이너 모서리까지 이어지고, hover 색상 가시성과 커서 피드백이 개선됐습니다.
- 스크린샷: 현재 로컬 환경에는 로그인 테스트 세션이 없어 설정/클립 필터/유저 드롭다운 hover 상태 캡처는 첨부하지 못했습니다. 코드 경로와 빌드/라우트 응답으로 검증했습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start -- --port 3002`: 실행 후 `/` 200 OK, `/login` 200 OK, `/favorites` 307 Redirect 확인
- `npm run package`: 미실행 - 현재 `package.json`에 스크립트가 없습니다.
- `npm run test:e2e`: 미실행 - 현재 e2e 테스트 스크립트가 없습니다.