### PR TITLE
#76 / fix(clips) : 이미지 업로드 형식 검증 및 토스트 UI 개선

### DIFF
--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -25,6 +25,11 @@ import {
   moveClipToRecentCache,
   updateClipFavoriteCache,
 } from "@/features/clip/service/clipQueryCache";
+import {
+  isAllowedImageClipFile,
+  isUnsupportedImageClipError,
+  UNSUPPORTED_IMAGE_CLIP_MESSAGE,
+} from "@/features/clip/service/imageClipValidation";
 import { ClipListItemResponseDto } from "@/features/clip/model/clip.dto";
 import { FilterType } from "@/features/clip/ui/FilterBar";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
@@ -202,6 +207,11 @@ export const useFolderClipsPage = () => {
         return;
       }
 
+      if (!isAllowedImageClipFile(file)) {
+        notifyError(UNSUPPORTED_IMAGE_CLIP_MESSAGE);
+        return;
+      }
+
       const previewUrl = URL.createObjectURL(file);
       const optimisticClip = createOptimisticImageClip(
         folderId,
@@ -227,11 +237,13 @@ export const useFolderClipsPage = () => {
           optimisticClip.id,
           mapClipResponseToListItem(createdClip),
         );
-      } catch {
+      } catch (error) {
         await waitForMinimumLoading(optimisticStartedAt);
         rollbackOptimisticClip();
         notifyError(
-          "이미지 클립 저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
+          isUnsupportedImageClipError(error)
+            ? UNSUPPORTED_IMAGE_CLIP_MESSAGE
+            : "이미지 클립 저장에 실패했습니다. 잠시 후 다시 시도해주세요.",
         );
       } finally {
         URL.revokeObjectURL(previewUrl);

--- a/src/features/clip/service/imageClipValidation.ts
+++ b/src/features/clip/service/imageClipValidation.ts
@@ -1,0 +1,27 @@
+import { ApiError } from "@/shared/lib/apiClient";
+
+export const ALLOWED_IMAGE_CLIP_MIME_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+  "image/gif",
+  "image/avif",
+] as const;
+
+export const IMAGE_CLIP_ACCEPT = ALLOWED_IMAGE_CLIP_MIME_TYPES.join(",");
+
+export const UNSUPPORTED_IMAGE_CLIP_MESSAGE =
+  "SVG 파일은 보안상 업로드할 수 없어요. PNG/JPG/WebP 등으로 변환해 주세요.";
+
+const BACKEND_UNSUPPORTED_IMAGE_MESSAGE =
+  "현재 jpeg, png, webp, gif, avif 이미지만 업로드할 수 있습니다.";
+
+export const isAllowedImageClipFile = (file: File) =>
+  ALLOWED_IMAGE_CLIP_MIME_TYPES.includes(
+    file.type as (typeof ALLOWED_IMAGE_CLIP_MIME_TYPES)[number],
+  );
+
+export const isUnsupportedImageClipError = (error: unknown) =>
+  error instanceof ApiError &&
+  error.status === 400 &&
+  error.message === BACKEND_UNSUPPORTED_IMAGE_MESSAGE;

--- a/src/shared/lib/toast.ts
+++ b/src/shared/lib/toast.ts
@@ -1,16 +1,75 @@
 "use client";
 
+import { createElement } from "react";
 import { toast } from "sonner";
 
-export const notifyError = (message: string, description?: string) => {
-  // 앱 전역 알림 정책은 이 헬퍼를 통해 한 곳에서 조정한다.
-  toast.error(message, {
-    description,
+const TOAST_DURATION_MS = 3000;
+
+type ToastVariant = "error" | "success";
+
+const TOAST_ACCENT_CLASS: Record<ToastVariant, string> = {
+  error: "bg-(--danger)",
+  success: "bg-(--success)",
+};
+
+const renderToast = (
+  id: string | number,
+  variant: ToastVariant,
+  message: string,
+  description?: string,
+) =>
+  createElement(
+    "button",
+    {
+      type: "button",
+      onClick: () => toast.dismiss(id),
+      className:
+        "flex w-[360px] max-w-[calc(100vw-32px)] cursor-pointer items-start gap-3 rounded-xl border border-(--border) bg-(--surface-elevated) px-4 py-3 text-left text-(--foreground) shadow-lg shadow-black/10 transition hover:bg-(--surface-muted) focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-(--focus-ring)",
+      "aria-label": `${message} 알림 닫기`,
+    },
+    createElement("span", {
+      className: `mt-1 h-2.5 w-2.5 shrink-0 rounded-full ${TOAST_ACCENT_CLASS[variant]}`,
+      "aria-hidden": true,
+    }),
+    createElement(
+      "span",
+      {
+        className: "min-w-0 flex-1",
+      },
+      createElement(
+        "span",
+        {
+          className: "block text-sm font-semibold leading-5",
+        },
+        message,
+      ),
+      description
+        ? createElement(
+            "span",
+            {
+              className: "mt-1 block text-sm leading-5 text-(--muted)",
+            },
+            description,
+          )
+        : null,
+    ),
+  );
+
+const notify = (
+  variant: ToastVariant,
+  message: string,
+  description?: string,
+) => {
+  toast.custom((id) => renderToast(id, variant, message, description), {
+    duration: TOAST_DURATION_MS,
   });
 };
 
+export const notifyError = (message: string, description?: string) => {
+  // 앱 전역 알림 정책은 이 헬퍼를 통해 한 곳에서 조정한다.
+  notify("error", message, description);
+};
+
 export const notifySuccess = (message: string, description?: string) => {
-  toast.success(message, {
-    description,
-  });
+  notify("success", message, description);
 };

--- a/src/shared/ui/AppToaster.tsx
+++ b/src/shared/ui/AppToaster.tsx
@@ -6,12 +6,13 @@ export function AppToaster() {
   return (
     <Toaster
       position="top-center"
-      richColors
-      closeButton
+      closeButton={false}
+      duration={3000}
       toastOptions={{
+        duration: 3000,
         classNames: {
           toast:
-            "border border-(--border) bg-(--surface-elevated) text-(--foreground)",
+            "bg-transparent p-0 shadow-none",
         },
       }}
     />


### PR DESCRIPTION
## PR 요약

- SVG 이미지 업로드를 프론트에서 차단하고, 토스트 알림 UI와 닫힘 동작을 개선했습니다.

## 변경 내용 상세

### 변경 사항

- 이미지 클립 업로드 전 허용 MIME 타입(`jpeg`, `png`, `webp`, `gif`, `avif`)을 검증하도록 추가했습니다.
- SVG 등 미지원 이미지 형식은 API 요청 전에 차단하고 사용자 친화적인 토스트 메시지를 표시합니다.
- 백엔드의 미지원 이미지 BAD_REQUEST 응답을 동일한 사용자 안내 메시지로 매핑했습니다.
- 토스트 알림의 X 닫기 버튼을 제거하고, 토스트 클릭 또는 3초 자동 닫힘으로 동작하도록 개선했습니다.

### 변경 이유

- 백엔드에서 SVG 업로드를 차단하고 있으므로 프론트에서도 사전에 차단해 불필요한 API 요청을 줄이고, 사용자가 업로드 실패 이유를 명확히 이해할 수 있도록 하기 위함입니다.
- 토스트 UI를 앱 테마에 맞게 정리하고 닫힘 동작을 단순화하기 위함입니다.

## 관련 이슈

- Closes #76

## 기타 참고사항

- Before/After 스크린샷: 토스트 및 업로드 실패 안내 UI 변경입니다. 현재 로컬에서 인증 세션/이미지 업로드 시나리오를 재현할 수 없어 캡처는 첨부하지 못했습니다.
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 미실행
- `npm run package`: 미실행 - 현재 `package.json`에 스크립트가 없습니다.
- `npm run test:e2e`: 미실행 - 현재 e2e 테스트 스크립트가 없습니다.