### PR TITLE
#78 / feat(clips) : 클립 삭제 UX 및 API 연동 개선

### DIFF
--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useState } from "react";
 import {
   createImageClip,
   createTextClip,
+  fetchClips,
   likeClip,
   recordClipView,
   removeClip,
@@ -109,6 +110,11 @@ export const useFolderClipsPage = () => {
     y: number;
   } | null>(null);
   const [isDeleteAllOpen, setIsDeleteAllOpen] = useState(false);
+  const [isDeleteMode, setIsDeleteMode] = useState(false);
+  const [isDeletingClips, setIsDeletingClips] = useState(false);
+  const [selectedClipIds, setSelectedClipIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const { copyToast, showCopyToast } = useCopyToast();
   const {
     clips,
@@ -136,6 +142,18 @@ export const useFolderClipsPage = () => {
     window.addEventListener("blur", handleBlur);
     return () => window.removeEventListener("blur", handleBlur);
   }, []);
+
+  useEffect(() => {
+    const availableClipIds = new Set(clips.map((clip) => clip.id));
+
+    setSelectedClipIds((currentIds) => {
+      const nextIds = new Set(
+        [...currentIds].filter((clipId) => availableClipIds.has(clipId)),
+      );
+
+      return nextIds.size === currentIds.size ? currentIds : nextIds;
+    });
+  }, [clips]);
 
   useEffect(() => {
     if (!contextMenu) {
@@ -166,6 +184,10 @@ export const useFolderClipsPage = () => {
 
   const createTextClipFromPaste = useCallback(
     async (content: string) => {
+      if (isDeleteMode || isDeletingClips) {
+        return;
+      }
+
       const trimmed = content.trim();
       if (!trimmed || !folderId || !isAuthenticated) {
         return;
@@ -199,11 +221,22 @@ export const useFolderClipsPage = () => {
         void refreshClipQueries();
       }
     },
-    [folderId, isAuthenticated, queryClient, refreshClipQueries],
+    [
+      folderId,
+      isAuthenticated,
+      isDeleteMode,
+      isDeletingClips,
+      queryClient,
+      refreshClipQueries,
+    ],
   );
 
   const createImageClipFromPaste = useCallback(
     async (file: File) => {
+      if (isDeleteMode || isDeletingClips) {
+        return;
+      }
+
       if (!folderId || !isAuthenticated) {
         return;
       }
@@ -251,7 +284,14 @@ export const useFolderClipsPage = () => {
         void refreshClipQueries();
       }
     },
-    [folderId, isAuthenticated, queryClient, refreshClipQueries],
+    [
+      folderId,
+      isAuthenticated,
+      isDeleteMode,
+      isDeletingClips,
+      queryClient,
+      refreshClipQueries,
+    ],
   );
 
   useEffect(() => {
@@ -293,6 +333,10 @@ export const useFolderClipsPage = () => {
 
   const handleCopy = useCallback(
     async (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => {
+      if (isDeleteMode || isDeletingClips) {
+        return;
+      }
+
       try {
         await copyClipToClipboard(clip);
       } catch {
@@ -308,11 +352,22 @@ export const useFolderClipsPage = () => {
         void refreshClipQueries();
       }
     },
-    [isAuthenticated, queryClient, refreshClipQueries, showCopyToast],
+    [
+      isAuthenticated,
+      isDeleteMode,
+      isDeletingClips,
+      queryClient,
+      refreshClipQueries,
+      showCopyToast,
+    ],
   );
 
   const handleCopyFromMenu = useCallback(
     async (clip: Clip) => {
+      if (isDeleteMode || isDeletingClips) {
+        return;
+      }
+
       try {
         await copyClipToClipboard(clip);
       } catch {
@@ -328,12 +383,12 @@ export const useFolderClipsPage = () => {
 
       setContextMenu(null);
     },
-    [isAuthenticated, queryClient, refreshClipQueries],
+    [isAuthenticated, isDeleteMode, isDeletingClips, queryClient, refreshClipQueries],
   );
 
   const handleToggleFavorite = useCallback(
     async (clip: Clip) => {
-      if (!isAuthenticated) {
+      if (!isAuthenticated || isDeleteMode || isDeletingClips) {
         return;
       }
 
@@ -356,27 +411,39 @@ export const useFolderClipsPage = () => {
         void refreshClipQueries();
       }
     },
-    [isAuthenticated, queryClient, refreshClipQueries],
+    [
+      isAuthenticated,
+      isDeleteMode,
+      isDeletingClips,
+      queryClient,
+      refreshClipQueries,
+    ],
   );
 
   const handleOpenContextMenu = useCallback(
     (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => {
       event.preventDefault();
+
+      if (isDeleteMode || isDeletingClips) {
+        return;
+      }
+
       setContextMenu({
         id: clip.id,
         x: event.clientX,
         y: event.clientY,
       });
     },
-    [],
+    [isDeleteMode, isDeletingClips],
   );
 
   const handleDeleteClip = useCallback(
     async (clipId: string) => {
-      if (!isAuthenticated) {
+      if (!isAuthenticated || isDeletingClips) {
         return;
       }
 
+      setIsDeletingClips(true);
       await cancelClipQueries(queryClient);
       const rollbackDeletedClip = removeClipsFromCache(queryClient, [clipId]);
       setContextMenu(null);
@@ -387,36 +454,164 @@ export const useFolderClipsPage = () => {
         rollbackDeletedClip();
         notifyError("클립 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
       } finally {
+        setIsDeletingClips(false);
         void refreshClipQueries();
       }
     },
-    [isAuthenticated, queryClient, refreshClipQueries],
+    [isAuthenticated, isDeletingClips, queryClient, refreshClipQueries],
   );
 
-  const handleDeleteAll = useCallback(async () => {
-    if (!isAuthenticated) {
+  const deleteClipsByIds = useCallback(
+    async (clipIds: string[], errorMessage: string) => {
+      if (!isAuthenticated || isDeletingClips) {
+        return false;
+      }
+
+      const uniqueClipIds = [...new Set(clipIds)];
+      if (uniqueClipIds.length === 0) {
+        return false;
+      }
+
+      setIsDeletingClips(true);
+      await cancelClipQueries(queryClient);
+      const rollbackDeletedClips = removeClipsFromCache(queryClient, uniqueClipIds);
+
+      try {
+        await removeClips({ clipIds: uniqueClipIds });
+        return true;
+      } catch {
+        rollbackDeletedClips();
+        notifyError(errorMessage);
+        return false;
+      } finally {
+        setIsDeletingClips(false);
+        void refreshClipQueries();
+      }
+    },
+    [isAuthenticated, isDeletingClips, queryClient, refreshClipQueries],
+  );
+
+  const fetchAllFolderClipIds = useCallback(async () => {
+    const clipIds: string[] = [];
+    let cursor: string | null = null;
+
+    do {
+      const response = await fetchClips({
+        folderId,
+        type: "ALL",
+        cursor,
+      });
+
+      clipIds.push(...response.items.map((clip) => clip.id));
+      cursor = response.hasMore ? response.nextCursor : null;
+    } while (cursor);
+
+    return clipIds;
+  }, [folderId]);
+
+  const handleEnterDeleteMode = useCallback(() => {
+    if (!isAuthenticated || clips.length === 0 || isDeletingClips) {
       return;
     }
 
-    const clipIds = clips.map((clip) => clip.id);
+    setContextMenu(null);
+    setIsActive(false);
+    setIsDeleteMode(true);
+    setSelectedClipIds(new Set());
+  }, [clips.length, isAuthenticated, isDeletingClips]);
+
+  const handleCancelDeleteMode = useCallback(() => {
+    if (isDeletingClips) {
+      return;
+    }
+
+    setIsDeleteMode(false);
+    setSelectedClipIds(new Set());
+  }, [isDeletingClips]);
+
+  const handleToggleClipSelected = useCallback(
+    (clipId: string) => {
+      if (!isDeleteMode || isDeletingClips) {
+        return;
+      }
+
+      setSelectedClipIds((currentIds) => {
+        const nextIds = new Set(currentIds);
+
+        if (nextIds.has(clipId)) {
+          nextIds.delete(clipId);
+        } else {
+          nextIds.add(clipId);
+        }
+
+        return nextIds;
+      });
+    },
+    [isDeleteMode, isDeletingClips],
+  );
+
+  const handleDeleteSelected = useCallback(async () => {
+    const clipIds = [...selectedClipIds];
     if (clipIds.length === 0) {
-      setIsDeleteAllOpen(false);
       return;
     }
 
-    await cancelClipQueries(queryClient);
-    const rollbackDeletedClips = removeClipsFromCache(queryClient, clipIds);
+    const isDeleted = await deleteClipsByIds(
+      clipIds,
+      "선택한 클립 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+    );
+
+    if (isDeleted) {
+      setSelectedClipIds(new Set());
+      setIsDeleteMode(false);
+    }
+  }, [deleteClipsByIds, selectedClipIds]);
+
+  const handleDeleteAll = useCallback(async () => {
+    if (!isAuthenticated || isDeletingClips || !folderId) {
+      return;
+    }
+
     setIsDeleteAllOpen(false);
+    setIsDeletingClips(true);
 
     try {
-      await removeClips({ clipIds });
+      const clipIds = await fetchAllFolderClipIds();
+
+      if (clipIds.length === 0) {
+        setIsDeleteMode(false);
+        setSelectedClipIds(new Set());
+        return;
+      }
+
+      const uniqueClipIds = [...new Set(clipIds)];
+      await cancelClipQueries(queryClient);
+      const rollbackDeletedClips = removeClipsFromCache(queryClient, uniqueClipIds);
+
+      try {
+        await removeClips({ clipIds: uniqueClipIds });
+        setSelectedClipIds(new Set());
+        setIsDeleteMode(false);
+      } catch {
+        rollbackDeletedClips();
+        notifyError(
+          "현재 폴더의 모든 클립 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.",
+        );
+      }
     } catch {
-      rollbackDeletedClips();
-      notifyError("클립 전체 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      notifyError("현재 폴더의 모든 클립 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
     } finally {
+      setIsDeletingClips(false);
       void refreshClipQueries();
     }
-  }, [clips, isAuthenticated, queryClient, refreshClipQueries]);
+  }, [
+    fetchAllFolderClipIds,
+    folderId,
+    isAuthenticated,
+    isDeletingClips,
+    queryClient,
+    refreshClipQueries,
+  ]);
 
   return {
     activeFilter,
@@ -429,6 +624,8 @@ export const useFolderClipsPage = () => {
     hasNextPage: Boolean(hasNextPage),
     isActive,
     isDeleteAllOpen,
+    isDeleteMode,
+    isDeletingClips,
     isError,
     isFetchingNextPage,
     isLoading: isPending,
@@ -439,11 +636,17 @@ export const useFolderClipsPage = () => {
     setIsActive,
     setIsDeleteAllOpen,
     setSearchQuery,
+    selectedClipCount: selectedClipIds.size,
+    selectedClipIds,
     handleCopy,
     handleCopyFromMenu,
+    handleCancelDeleteMode,
     handleDeleteAll,
     handleDeleteClip,
+    handleDeleteSelected,
+    handleEnterDeleteMode,
     handleOpenContextMenu,
+    handleToggleClipSelected,
     handleToggleFavorite,
   };
 };

--- a/src/features/clip/hooks/useRecentClipsPage.ts
+++ b/src/features/clip/hooks/useRecentClipsPage.ts
@@ -71,11 +71,9 @@ export const useRecentClipsPage = () => {
     isFetchingNextPage,
     isLoading: isPending,
     searchQuery,
-    hasClips: clips.length > 0,
     refetchClips: refetch,
     setActiveFilter,
     setSearchQuery,
-    clearAll: () => undefined,
     handleCopy,
   };
 };

--- a/src/features/clip/ui/ClipDeleteActionBar.tsx
+++ b/src/features/clip/ui/ClipDeleteActionBar.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { HiOutlineTrash, HiX } from "react-icons/hi";
+
+interface ClipDeleteActionBarProps {
+  selectedCount: number;
+  totalCount: number;
+  isDeleting?: boolean;
+  onCancel: () => void;
+  onDeleteSelected: () => void;
+  onRequestDeleteAll: () => void;
+}
+
+export function ClipDeleteActionBar({
+  selectedCount,
+  totalCount,
+  isDeleting = false,
+  onCancel,
+  onDeleteSelected,
+  onRequestDeleteAll,
+}: ClipDeleteActionBarProps) {
+  const t = useTranslations("clips.deleteMode");
+  const hasSelection = selectedCount > 0;
+
+  return (
+    <div className="absolute inset-x-4 bottom-4 z-30 flex justify-center md:inset-x-6 md:bottom-6">
+      <div className="flex w-full max-w-3xl flex-col gap-3 rounded-xl border border-(--border) bg-(--surface-elevated) p-3 shadow-xl shadow-black/10 min-[760px]:flex-row min-[760px]:items-center min-[760px]:justify-between">
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-(--foreground)">
+            {t("title")}
+          </p>
+          <p className="mt-1 text-xs text-(--muted)">
+            {t("selectedCount", { selectedCount, totalCount })}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 min-[520px]:flex min-[520px]:items-center min-[760px]:shrink-0">
+          <button
+            type="button"
+            disabled={isDeleting}
+            onClick={onCancel}
+            className="inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-lg border border-(--border) px-3 text-sm font-medium text-(--foreground) transition hover:bg-(--surface-muted) disabled:cursor-default disabled:opacity-50"
+          >
+            <HiX className="h-4 w-4" aria-hidden />
+            {t("cancel")}
+          </button>
+          <button
+            type="button"
+            disabled={isDeleting || !hasSelection}
+            onClick={onDeleteSelected}
+            className="inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-lg bg-(--danger) px-3 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover) disabled:cursor-default disabled:opacity-50"
+          >
+            <HiOutlineTrash className="h-4 w-4" aria-hidden />
+            {isDeleting ? t("deleting") : t("deleteSelected")}
+          </button>
+          <button
+            type="button"
+            disabled={isDeleting || totalCount === 0}
+            onClick={onRequestDeleteAll}
+            className="col-span-2 inline-flex h-10 cursor-pointer items-center justify-center gap-2 rounded-lg border border-red-500/25 px-3 text-sm font-medium text-(--danger) transition hover:bg-red-500/10 disabled:cursor-default disabled:opacity-50 min-[520px]:col-span-1"
+          >
+            <HiOutlineTrash className="h-4 w-4" aria-hidden />
+            {t("deleteAll")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/features/clip/ui/ClipItem.tsx
+++ b/src/features/clip/ui/ClipItem.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useTranslations } from "next-intl";
 import {
+  HiCheck,
   HiOutlineColorSwatch,
   HiOutlineDocumentText,
   HiOutlinePhotograph,
@@ -16,6 +17,10 @@ interface ClipItemProps {
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
+  isDeleteMode?: boolean;
+  isInteractionDisabled?: boolean;
+  isSelected?: boolean;
+  onToggleSelected?: (clipId: string) => void;
 }
 
 export function ClipItem({
@@ -23,9 +28,14 @@ export function ClipItem({
   onCopy,
   onToggleFavorite,
   onContextMenu,
+  isDeleteMode = false,
+  isInteractionDisabled = false,
+  isSelected = false,
+  onToggleSelected,
 }: ClipItemProps) {
   const t = useTranslations("clips.item");
   const isOptimistic = Boolean(clip.isOptimistic);
+  const isDisabled = isOptimistic || isInteractionDisabled;
 
   const getIcon = () => {
     switch (clip.type) {
@@ -88,21 +98,57 @@ export function ClipItem({
 
   return (
     <div
-      className="group relative flex h-52 w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-(--border) bg-(--surface) shadow-sm transition-shadow hover:shadow-md data-[optimistic=true]:cursor-wait data-[optimistic=true]:opacity-75"
+      className="group relative flex h-52 w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-(--border) bg-(--surface) shadow-sm transition-shadow hover:shadow-md data-[disabled=true]:cursor-wait data-[disabled=true]:opacity-75 data-[delete-mode=true]:cursor-pointer data-[selected=true]:border-(--danger) data-[selected=true]:ring-2 data-[selected=true]:ring-(--danger-border)"
       data-optimistic={isOptimistic}
+      data-disabled={isDisabled}
+      data-delete-mode={isDeleteMode}
+      data-selected={isSelected}
       onClick={(event) => {
-        if (!isOptimistic) {
+        if (isDeleteMode) {
+          if (!isDisabled) {
+            onToggleSelected?.(clip.id);
+          }
+          return;
+        }
+
+        if (!isDisabled) {
           onCopy?.(clip, event);
         }
       }}
       onContextMenu={(event) => {
-        if (!isOptimistic) {
+        if (isDeleteMode) {
+          event.preventDefault();
+          return;
+        }
+
+        if (!isDisabled && !isDeleteMode) {
           onContextMenu?.(event, clip);
         }
       }}
       role="button"
       tabIndex={0}
     >
+      {isDeleteMode ? (
+        <div className="absolute top-3 left-3 z-20">
+          <button
+            type="button"
+            disabled={isDisabled}
+            onClick={(event) => {
+              event.stopPropagation();
+              onToggleSelected?.(clip.id);
+            }}
+            className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border shadow-sm backdrop-blur-sm transition-all duration-150 ease-out disabled:cursor-default disabled:opacity-50 ${
+              isSelected
+                ? "border-(--danger) bg-(--danger) text-danger-foreground"
+                : "border-(--border) bg-(--surface-elevated) text-transparent hover:border-(--danger-border) hover:text-(--danger)"
+            }`}
+            aria-pressed={isSelected}
+            aria-label={t("selectForDelete", { name: clip.name })}
+          >
+            <HiCheck className="h-4 w-4" aria-hidden />
+          </button>
+        </div>
+      ) : null}
       {isOptimistic ? (
         <div className="absolute inset-x-3 top-3 z-20 flex justify-start">
           <span className="rounded-full bg-(--primary) px-2.5 py-1 text-[11px] font-semibold text-(--primary-foreground) shadow-sm">
@@ -114,11 +160,11 @@ export function ClipItem({
         type="button"
         onClick={(event) => {
           event.stopPropagation();
-          if (!isOptimistic) {
+          if (!isDisabled && !isDeleteMode) {
             onToggleFavorite?.(clip);
           }
         }}
-        disabled={isOptimistic}
+        disabled={isDisabled || isDeleteMode}
         className="absolute top-3 right-3 z-10 cursor-pointer rounded-full bg-(--favorite-btn-bg) p-1.5 backdrop-blur-sm transition-all duration-200 hover:scale-105 hover:bg-(--favorite-btn-bg-hover) disabled:cursor-wait disabled:opacity-50"
         style={{ boxShadow: "var(--favorite-btn-shadow)" }}
         aria-label={t("toggleFavorite")}

--- a/src/features/clip/ui/ClipList.tsx
+++ b/src/features/clip/ui/ClipList.tsx
@@ -10,6 +10,10 @@ interface ClipListProps {
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
+  isDeleteMode?: boolean;
+  isInteractionDisabled?: boolean;
+  selectedClipIds?: Set<string>;
+  onToggleSelected?: (clipId: string) => void;
 }
 
 export function ClipList({
@@ -19,6 +23,10 @@ export function ClipList({
   onCopy,
   onToggleFavorite,
   onContextMenu,
+  isDeleteMode = false,
+  isInteractionDisabled = false,
+  selectedClipIds = new Set(),
+  onToggleSelected,
 }: ClipListProps) {
   if (clips.length === 0) {
     return null;
@@ -34,6 +42,10 @@ export function ClipList({
             onCopy={onCopy}
             onToggleFavorite={onToggleFavorite}
             onContextMenu={onContextMenu}
+            isDeleteMode={isDeleteMode}
+            isInteractionDisabled={isInteractionDisabled}
+            isSelected={selectedClipIds.has(clip.id)}
+            onToggleSelected={onToggleSelected}
           />
         ))}
       </div>

--- a/src/features/clip/ui/ClipResultsSection.tsx
+++ b/src/features/clip/ui/ClipResultsSection.tsx
@@ -19,6 +19,10 @@ interface ClipResultsSectionProps {
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
   onToggleFavorite?: (clip: Clip) => void;
   onContextMenu?: (event: React.MouseEvent<HTMLDivElement>, clip: Clip) => void;
+  isDeleteMode?: boolean;
+  isInteractionDisabled?: boolean;
+  selectedClipIds?: Set<string>;
+  onToggleSelected?: (clipId: string) => void;
 }
 
 export function ClipResultsSection({
@@ -32,6 +36,10 @@ export function ClipResultsSection({
   onCopy,
   onToggleFavorite,
   onContextMenu,
+  isDeleteMode = false,
+  isInteractionDisabled = false,
+  selectedClipIds = new Set(),
+  onToggleSelected,
 }: ClipResultsSectionProps) {
   const hasTriggeredInViewRef = useRef(false);
   const { ref, inView } = useInView({
@@ -76,6 +84,10 @@ export function ClipResultsSection({
       onCopy={onCopy}
       onToggleFavorite={onToggleFavorite}
       onContextMenu={onContextMenu}
+      isDeleteMode={isDeleteMode}
+      isInteractionDisabled={isInteractionDisabled}
+      selectedClipIds={selectedClipIds}
+      onToggleSelected={onToggleSelected}
     />
   );
 }

--- a/src/features/clip/ui/DeleteAllButton.tsx
+++ b/src/features/clip/ui/DeleteAllButton.tsx
@@ -3,11 +3,13 @@
 import { useTranslations } from "next-intl";
 interface DeleteAllButtonProps {
   disabled?: boolean;
+  label?: string;
   onClick: () => void;
 }
 
 export function DeleteAllButton({
   disabled = false,
+  label,
   onClick,
 }: DeleteAllButtonProps) {
   const t = useTranslations("clips.actions");
@@ -18,7 +20,7 @@ export function DeleteAllButton({
       onClick={onClick}
       className="absolute right-4 bottom-4 rounded-full bg-(--danger) px-4 py-2 text-sm font-semibold text-danger-foreground shadow-lg transition hover:bg-(--danger-hover) disabled:cursor-not-allowed disabled:opacity-50 md:right-6 md:bottom-6"
     >
-      {t("deleteAll")}
+      {label ?? t("deleteAll")}
     </button>
   );
 }

--- a/src/features/clip/ui/DeleteAllClipsModal.tsx
+++ b/src/features/clip/ui/DeleteAllClipsModal.tsx
@@ -6,6 +6,7 @@ interface DeleteAllClipsModalProps {
   description: string;
   cancelLabel: string;
   confirmLabel: string;
+  isConfirming?: boolean;
   onCancel: () => void;
   onConfirm: () => void;
 }
@@ -16,6 +17,7 @@ export function DeleteAllClipsModal({
   description,
   cancelLabel,
   confirmLabel,
+  isConfirming = false,
   onCancel,
   onConfirm,
 }: DeleteAllClipsModalProps) {
@@ -33,15 +35,17 @@ export function DeleteAllClipsModal({
         <div className="flex justify-end gap-2 px-5 py-4">
           <button
             type="button"
+            disabled={isConfirming}
             onClick={onCancel}
-            className="hover:text-foreground rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition"
+            className="hover:text-foreground rounded-lg border border-(--border) px-4 py-2 text-sm font-medium text-(--muted) transition disabled:cursor-default disabled:opacity-50"
           >
             {cancelLabel}
           </button>
           <button
             type="button"
+            disabled={isConfirming}
             onClick={onConfirm}
-            className="rounded-lg bg-(--danger) px-4 py-2 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover)"
+            className="rounded-lg bg-(--danger) px-4 py-2 text-sm font-medium text-danger-foreground transition hover:bg-(--danger-hover) disabled:cursor-default disabled:opacity-50"
           >
             {confirmLabel}
           </button>

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -2,6 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { useFolderClipsPage } from "@/features/clip/hooks/useFolderClipsPage";
+import { ClipDeleteActionBar } from "@/features/clip/ui/ClipDeleteActionBar";
 import { ClipContextMenu } from "@/features/clip/ui/ClipContextMenu";
 import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
 import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
@@ -23,12 +24,18 @@ export function FolderClipsPage() {
     handleCopyFromMenu,
     handleDeleteAll,
     handleDeleteClip,
+    handleDeleteSelected,
+    handleEnterDeleteMode,
+    handleCancelDeleteMode,
     handleOpenContextMenu,
+    handleToggleClipSelected,
     handleToggleFavorite,
     hasNextPage,
     hasClips,
     isActive,
     isDeleteAllOpen,
+    isDeleteMode,
+    isDeletingClips,
     isError,
     isFetchingNextPage,
     isLoading,
@@ -39,14 +46,18 @@ export function FolderClipsPage() {
     setIsActive,
     setIsDeleteAllOpen,
     setSearchQuery,
+    selectedClipCount,
+    selectedClipIds,
   } = useFolderClipsPage();
   const hasClipLoadError = isError && filteredClips.length === 0;
 
   return (
     <div
-      className="bg-background flex h-full flex-col overflow-hidden"
+      className="bg-background relative flex h-full flex-col overflow-hidden"
       onClick={() => {
-        setIsActive(true);
+        if (!isDeleteMode && !isDeletingClips) {
+          setIsActive(true);
+        }
         setContextMenu(null);
       }}
     >
@@ -78,30 +89,54 @@ export function FolderClipsPage() {
         onCopy={handleCopy}
         onToggleFavorite={handleToggleFavorite}
         onContextMenu={handleOpenContextMenu}
+        isDeleteMode={isDeleteMode}
+        isInteractionDisabled={isDeletingClips}
+        selectedClipIds={selectedClipIds}
+        onToggleSelected={handleToggleClipSelected}
       />
-      {!hasClipLoadError ? (
+      {!hasClipLoadError && !isDeleteMode ? (
         <DeleteAllButton
-          disabled={!hasClips}
-          onClick={() => setIsDeleteAllOpen(true)}
+          disabled={!hasClips || isDeletingClips}
+          label={t("actions.deleteClips")}
+          onClick={handleEnterDeleteMode}
+        />
+      ) : null}
+      {!hasClipLoadError && isDeleteMode ? (
+        <ClipDeleteActionBar
+          selectedCount={selectedClipCount}
+          totalCount={filteredClips.length}
+          isDeleting={isDeletingClips}
+          onCancel={handleCancelDeleteMode}
+          onDeleteSelected={handleDeleteSelected}
+          onRequestDeleteAll={() => setIsDeleteAllOpen(true)}
         />
       ) : null}
 
-      <ClipContextMenu
-        clips={clips}
-        contextMenu={contextMenu}
-        copyLabel={t("actions.copy")}
-        deleteLabel={t("actions.delete")}
-        onCopy={handleCopyFromMenu}
-        onDelete={handleDeleteClip}
-      />
+      {!isDeleteMode ? (
+        <ClipContextMenu
+          clips={clips}
+          contextMenu={contextMenu}
+          copyLabel={t("actions.copy")}
+          deleteLabel={t("actions.delete")}
+          onCopy={handleCopyFromMenu}
+          onDelete={handleDeleteClip}
+        />
+      ) : null}
       <ClipCopyToast label={t("copyToast")} position={copyToast} />
       <DeleteAllClipsModal
         isOpen={isDeleteAllOpen}
         title={t("deleteModal.title")}
         description={t("deleteModal.description")}
         cancelLabel={t("actions.cancel")}
-        confirmLabel={t("actions.delete")}
-        onCancel={() => setIsDeleteAllOpen(false)}
+        confirmLabel={
+          isDeletingClips ? t("deleteMode.deleting") : t("actions.delete")
+        }
+        onCancel={() => {
+          if (!isDeletingClips) {
+            setIsDeleteAllOpen(false);
+          }
+        }}
+        isConfirming={isDeletingClips}
         onConfirm={handleDeleteAll}
       />
     </div>

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -4,20 +4,17 @@ import { useTranslations } from "next-intl";
 import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
 import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { useRecentClipsPage } from "@/features/clip/hooks/useRecentClipsPage";
-import { DeleteAllButton } from "@/features/clip/ui/DeleteAllButton";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 
 export function RecentClipsPage() {
   const t = useTranslations("clips");
   const {
     activeFilter,
-    clearAll,
     copyToast,
     fetchNextPage,
     filteredClips,
     handleCopy,
     hasNextPage,
-    hasClips,
     isError,
     isFetchingNextPage,
     isLoading,
@@ -54,9 +51,6 @@ export function RecentClipsPage() {
         }}
         onCopy={handleCopy}
       />
-      {!hasClipLoadError ? (
-        <DeleteAllButton disabled={!hasClips} onClick={clearAll} />
-      ) : null}
       <ClipCopyToast label={t("copyToast")} position={copyToast} />
     </div>
   );

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -185,19 +185,29 @@
     },
     "item": {
       "saving": "Saving",
-      "toggleFavorite": "Toggle favorite"
+      "toggleFavorite": "Toggle favorite",
+      "selectForDelete": "Select {name} for deletion"
     },
     "actions": {
       "copy": "Copy",
       "rename": "Rename",
       "delete": "Delete",
+      "deleteClips": "Delete clips",
       "deleteAll": "Delete All",
       "cancel": "Cancel",
       "change": "Save"
     },
+    "deleteMode": {
+      "title": "Delete clips",
+      "selectedCount": "{selectedCount} selected / {totalCount} on screen",
+      "deleteSelected": "Delete selected",
+      "deleteAll": "Delete all",
+      "deleting": "Deleting",
+      "cancel": "Cancel"
+    },
     "deleteModal": {
-      "title": "Delete all clips",
-      "description": "Are you sure you want to delete every clip?"
+      "title": "Delete current folder clips",
+      "description": "Are you sure you want to delete every clip in the current folder?"
     },
     "renameModal": {
       "title": "Rename",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -185,19 +185,29 @@
     },
     "item": {
       "saving": "保存中",
-      "toggleFavorite": "お気に入りを切り替え"
+      "toggleFavorite": "お気に入りを切り替え",
+      "selectForDelete": "{name}を削除対象として選択"
     },
     "actions": {
       "copy": "コピー",
       "rename": "名前を変更",
       "delete": "削除",
+      "deleteClips": "クリップを削除",
       "deleteAll": "すべて削除",
       "cancel": "キャンセル",
       "change": "変更"
     },
+    "deleteMode": {
+      "title": "クリップ削除モード",
+      "selectedCount": "選択 {selectedCount} 件 / 現在の画面 {totalCount} 件",
+      "deleteSelected": "削除する",
+      "deleteAll": "すべて削除",
+      "deleting": "削除中",
+      "cancel": "キャンセル"
+    },
     "deleteModal": {
-      "title": "すべてのクリップを削除",
-      "description": "本当にすべてのクリップを削除しますか？"
+      "title": "現在のフォルダをすべて削除",
+      "description": "本当に現在のフォルダ内のすべてのクリップを削除しますか？"
     },
     "renameModal": {
       "title": "名前を変更",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -185,19 +185,29 @@
     },
     "item": {
       "saving": "저장 중",
-      "toggleFavorite": "즐겨찾기 전환"
+      "toggleFavorite": "즐겨찾기 전환",
+      "selectForDelete": "{name} 삭제 선택"
     },
     "actions": {
       "copy": "복사",
       "rename": "이름 변경",
       "delete": "삭제",
+      "deleteClips": "클립 삭제",
       "deleteAll": "전체 삭제",
       "cancel": "취소",
       "change": "변경"
     },
+    "deleteMode": {
+      "title": "클립 삭제 모드",
+      "selectedCount": "선택 {selectedCount}개 / 현재 화면 {totalCount}개",
+      "deleteSelected": "삭제하기",
+      "deleteAll": "전체 삭제",
+      "deleting": "삭제 중",
+      "cancel": "취소"
+    },
     "deleteModal": {
-      "title": "모든 클립 삭제",
-      "description": "정말 모든 클립을 삭제하시겠습니까?"
+      "title": "현재 폴더 전체 삭제",
+      "description": "정말 현재 폴더의 모든 클립을 삭제하시겠습니까?"
     },
     "renameModal": {
       "title": "이름 변경",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -185,19 +185,29 @@
     },
     "item": {
       "saving": "保存中",
-      "toggleFavorite": "切换收藏"
+      "toggleFavorite": "切换收藏",
+      "selectForDelete": "选择删除 {name}"
     },
     "actions": {
       "copy": "复制",
       "rename": "重命名",
       "delete": "删除",
+      "deleteClips": "删除剪贴内容",
       "deleteAll": "全部删除",
       "cancel": "取消",
       "change": "保存"
     },
+    "deleteMode": {
+      "title": "删除剪贴内容",
+      "selectedCount": "已选择 {selectedCount} 个 / 当前屏幕 {totalCount} 个",
+      "deleteSelected": "删除所选",
+      "deleteAll": "全部删除",
+      "deleting": "删除中",
+      "cancel": "取消"
+    },
     "deleteModal": {
-      "title": "删除所有剪贴内容",
-      "description": "确定要删除全部剪贴内容吗？"
+      "title": "删除当前文件夹内容",
+      "description": "确定要删除当前文件夹中的全部剪贴内容吗？"
     },
     "renameModal": {
       "title": "重命名",


### PR DESCRIPTION
## PR 요약

- 현재 폴더의 클립 삭제 UX를 삭제 모드 기반으로 바꾸고, 선택/전체 삭제를 다중 삭제 API로 연동했습니다.

## 변경 내용 상세

### 변경 사항

- 기존 우하단 `전체 삭제` 버튼을 `클립 삭제` 진입 버튼으로 변경
- 삭제 모드에서 클립 카드를 선택할 수 있는 원형 선택 컨트롤 추가
- 삭제 모드 액션바 추가: 선택 개수, 취소, 삭제하기, 전체 삭제
- 선택 삭제는 선택된 `clipIds`로 `DELETE /clips`를 한 번만 호출
- 전체 삭제는 현재 폴더의 모든 클립 id를 페이지네이션으로 수집한 뒤 `DELETE /clips` 호출
- 삭제 모드/삭제 요청 중 복사, 즐겨찾기, 우클릭 메뉴, 붙여넣기 저장 액션 차단
- 최근 클립 화면의 동작 없는 전체 삭제 버튼 제거
- 삭제 관련 다국어 문구 추가 및 현재 폴더 전체 삭제 문구 명확화

### 변경 이유

- 기존 UI는 전체 삭제 버튼 중심이고 선택 삭제 모드가 없어 사용자가 삭제 대상을 명확하게 고르기 어려웠습니다.
- 선택 삭제를 단건 반복 호출하지 않고 백엔드 다중 삭제 API 계약에 맞춰 한 번의 요청으로 처리하기 위해 변경했습니다.
- 전체 삭제의 범위가 현재 폴더 내부 클립으로 확정되어, `DELETE /clips/all`이 아닌 `DELETE /clips` 다중 삭제 API를 사용하도록 정리했습니다.

## 관련 이슈

- Closes #78

## 기타 참고사항

- Before/After 스크린샷: 미첨부
- 로컬 검증 결과:
  - npm run lint: 통과
  - npm run build: 통과
  - npm run start -- -p 3002: 통과
  - npm run package: 실패 (package 스크립트가 package.json에 없음)
  - npm run test:e2e: 해당 없음 (스크립트 없음)