### PR TITLE
#79 / fix(clips) : TanStack Query 데이터 최신화 누락 수정

### DIFF
--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -34,6 +34,7 @@ import {
 } from "@/features/clip/service/imageClipValidation";
 import { ClipListItemResponseDto } from "@/features/clip/model/clip.dto";
 import { FilterType } from "@/features/clip/ui/FilterBar";
+import { invalidateTrashQueries } from "@/features/trash/service/trashQueryCache";
 import { useDebouncedValue } from "@/shared/hooks/useDebouncedValue";
 import { waitForMinimumLoading } from "@/shared/lib/loading";
 import { notifyError } from "@/shared/lib/toast";
@@ -446,16 +447,21 @@ export const useFolderClipsPage = () => {
       setIsDeletingClips(true);
       await cancelClipQueries(queryClient);
       const rollbackDeletedClip = removeClipsFromCache(queryClient, [clipId]);
+      let isDeleted = false;
       setContextMenu(null);
 
       try {
         await removeClip(clipId);
+        isDeleted = true;
       } catch {
         rollbackDeletedClip();
         notifyError("클립 삭제에 실패했습니다. 잠시 후 다시 시도해주세요.");
       } finally {
         setIsDeletingClips(false);
         void refreshClipQueries();
+        if (isDeleted) {
+          void invalidateTrashQueries(queryClient);
+        }
       }
     },
     [isAuthenticated, isDeletingClips, queryClient, refreshClipQueries],
@@ -475,9 +481,11 @@ export const useFolderClipsPage = () => {
       setIsDeletingClips(true);
       await cancelClipQueries(queryClient);
       const rollbackDeletedClips = removeClipsFromCache(queryClient, uniqueClipIds);
+      let isDeleted = false;
 
       try {
         await removeClips({ clipIds: uniqueClipIds });
+        isDeleted = true;
         return true;
       } catch {
         rollbackDeletedClips();
@@ -486,6 +494,9 @@ export const useFolderClipsPage = () => {
       } finally {
         setIsDeletingClips(false);
         void refreshClipQueries();
+        if (isDeleted) {
+          void invalidateTrashQueries(queryClient);
+        }
       }
     },
     [isAuthenticated, isDeletingClips, queryClient, refreshClipQueries],
@@ -574,6 +585,7 @@ export const useFolderClipsPage = () => {
 
     setIsDeleteAllOpen(false);
     setIsDeletingClips(true);
+    let isDeleted = false;
 
     try {
       const clipIds = await fetchAllFolderClipIds();
@@ -590,6 +602,7 @@ export const useFolderClipsPage = () => {
 
       try {
         await removeClips({ clipIds: uniqueClipIds });
+        isDeleted = true;
         setSelectedClipIds(new Set());
         setIsDeleteMode(false);
       } catch {
@@ -603,6 +616,9 @@ export const useFolderClipsPage = () => {
     } finally {
       setIsDeletingClips(false);
       void refreshClipQueries();
+      if (isDeleted) {
+        void invalidateTrashQueries(queryClient);
+      }
     }
   }, [
     fetchAllFolderClipIds,

--- a/src/features/folder/hooks/useFolders.ts
+++ b/src/features/folder/hooks/useFolders.ts
@@ -22,6 +22,7 @@ import type {
   FolderItem,
 } from "@/features/folder/model/folder";
 import { FolderResponseDto } from "@/features/folder/model/folder.dto";
+import { invalidateTrashQueries } from "@/features/trash/service/trashQueryCache";
 import { waitForMinimumLoading } from "@/shared/lib/loading";
 
 export const FOLDER_QUERY_KEY = "folders";
@@ -188,6 +189,7 @@ export const useFolders = () => {
       setFolders((currentFolders) =>
         currentFolders.filter((folder) => folder.id !== folderId),
       );
+      void invalidateTrashQueries(queryClient);
     },
   });
 

--- a/src/features/subscription/hooks/useMySubscription.ts
+++ b/src/features/subscription/hooks/useMySubscription.ts
@@ -4,11 +4,12 @@ import { useQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { fetchMySubscription } from "@/features/subscription/api/subscriptionApi";
+import { getMySubscriptionQueryKey } from "@/features/subscription/service/subscriptionQueryCache";
 
-export const MY_SUBSCRIPTION_QUERY_KEY = "mySubscription";
-
-export const getMySubscriptionQueryKey = (userId: string | null) =>
-  [MY_SUBSCRIPTION_QUERY_KEY, userId] as const;
+export {
+  getMySubscriptionQueryKey,
+  MY_SUBSCRIPTION_QUERY_KEY,
+} from "@/features/subscription/service/subscriptionQueryCache";
 
 export const useMySubscription = () => {
   const session = useAuthSession();

--- a/src/features/subscription/service/subscriptionQueryCache.ts
+++ b/src/features/subscription/service/subscriptionQueryCache.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import { QueryClient } from "@tanstack/react-query";
+import type { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+
+export const MY_SUBSCRIPTION_QUERY_KEY = "mySubscription";
+
+export const getMySubscriptionQueryKey = (userId: string | null) =>
+  [MY_SUBSCRIPTION_QUERY_KEY, userId] as const;
+
+export const syncMySubscriptionQueryData = (
+  queryClient: QueryClient,
+  subscription: MySubscriptionResponseDto,
+  userId: string | null,
+) => {
+  queryClient.setQueriesData<MySubscriptionResponseDto>(
+    { queryKey: [MY_SUBSCRIPTION_QUERY_KEY] },
+    subscription,
+  );
+
+  if (userId) {
+    queryClient.setQueryData(getMySubscriptionQueryKey(userId), subscription);
+  }
+};
+
+export const invalidateMySubscriptionQueries = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({
+    queryKey: [MY_SUBSCRIPTION_QUERY_KEY],
+  });

--- a/src/features/subscription/ui/BillingPage.tsx
+++ b/src/features/subscription/ui/BillingPage.tsx
@@ -8,9 +8,13 @@ import {
   fetchMySubscription,
   updateMySubscription,
 } from "@/features/subscription/api/subscriptionApi";
-import { MY_SUBSCRIPTION_QUERY_KEY } from "@/features/subscription/hooks/useMySubscription";
+import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { hasRemainingCanceledProPeriod } from "@/features/subscription/model/subscription";
 import { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
+import {
+  invalidateMySubscriptionQueries,
+  syncMySubscriptionQueryData,
+} from "@/features/subscription/service/subscriptionQueryCache";
 import {
   BillingCheckoutCard,
   type BillingStep,
@@ -80,6 +84,8 @@ const mapBillingAuthMethod = (
 export function BillingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
+  const session = useAuthSession();
+  const userId = session?.user?.id ?? null;
   const [billingAuth, setBillingAuth] =
     useState<BillingAuthRequestResponseDto | null>(null);
   const [step, setStep] = useState<BillingStep>("idle");
@@ -98,9 +104,10 @@ export function BillingPage() {
 
       if (hasRemainingCanceledProPeriod(currentSubscription)) {
         const nextSubscription = await updateMySubscription({ type: "RESUME" });
-        queryClient.setQueriesData(
-          { queryKey: [MY_SUBSCRIPTION_QUERY_KEY] },
+        syncMySubscriptionQueryData(
+          queryClient,
           nextSubscription,
+          userId,
         );
         setStep("idle");
         setMessage("Pro 구독 자동갱신이 재개되었습니다.");
@@ -136,7 +143,13 @@ export function BillingPage() {
       }
 
       if (error instanceof ApiError && error.status === 409) {
-        await fetchMySubscription().catch(() => undefined);
+        const latestSubscription = await fetchMySubscription().catch(() => null);
+
+        if (latestSubscription) {
+          syncMySubscriptionQueryData(queryClient, latestSubscription, userId);
+        } else {
+          void invalidateMySubscriptionQueries(queryClient);
+        }
       }
 
       setStep("error");

--- a/src/features/subscription/ui/BillingResultPage.tsx
+++ b/src/features/subscription/ui/BillingResultPage.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import Confetti from "react-confetti";
 import { confirmBillingAuth } from "@/features/subscription/api/subscriptionApi";
 import { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+import { syncMySubscriptionQueryData } from "@/features/subscription/service/subscriptionQueryCache";
 import { BillingResultCard } from "@/features/subscription/ui/BillingResultCard";
 
 interface BillingResultPageProps {
@@ -19,6 +21,7 @@ export function BillingResultPage({
   errorMessage,
   status,
 }: BillingResultPageProps) {
+  const queryClient = useQueryClient();
   const isMissingSuccessParams =
     status === "success" && (!authKey || !customerKey);
   const [subscription, setSubscription] =
@@ -51,6 +54,7 @@ export function BillingResultPage({
     // Toss 성공 리다이렉트의 authKey/customerKey를 서버에 전달해 최종 구독 승인을 완료한다.
     confirmBillingAuth({ authKey, customerKey })
       .then((nextSubscription) => {
+        syncMySubscriptionQueryData(queryClient, nextSubscription, null);
         setSubscription(nextSubscription);
         setMessage("Pro 구독이 활성화되었습니다.");
       })
@@ -58,7 +62,7 @@ export function BillingResultPage({
         setMessage("결제 승인을 완료하지 못했습니다.");
       })
       .finally(() => setIsConfirming(false));
-  }, [authKey, customerKey, status]);
+  }, [authKey, customerKey, queryClient, status]);
 
   const isSuccess = status === "success" && subscription?.plan === "PRO";
 

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -17,14 +17,12 @@ import {
   restoreTrashItems,
 } from "@/features/trash/api/trashApi";
 import { TrashItemMutationDto } from "@/features/trash/model/trash.dto";
+import {
+  invalidateTrashQueries,
+  TRASH_QUERY_KEYS,
+} from "@/features/trash/service/trashQueryCache";
 import { ApiError } from "@/shared/lib/apiClient";
 import { waitForMinimumLoading } from "@/shared/lib/loading";
-
-const TRASH_QUERY_KEYS = {
-  all: ["trash"] as const,
-  items: (userId: string | null) =>
-    [...TRASH_QUERY_KEYS.all, "items", userId] as const,
-};
 
 type TrashPageError = "load" | "action" | "restoreConflict";
 
@@ -63,7 +61,7 @@ export const useTrashPage = () => {
 
   const refreshRelatedData = useCallback(async () => {
     await Promise.all([
-      queryClient.invalidateQueries({ queryKey: TRASH_QUERY_KEYS.all }),
+      invalidateTrashQueries(queryClient),
       queryClient.invalidateQueries({ queryKey: [FOLDER_QUERY_KEY] }),
       queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
     ]);

--- a/src/features/trash/service/trashQueryCache.ts
+++ b/src/features/trash/service/trashQueryCache.ts
@@ -1,0 +1,12 @@
+"use client";
+
+import { QueryClient } from "@tanstack/react-query";
+
+export const TRASH_QUERY_KEYS = {
+  all: ["trash"] as const,
+  items: (userId: string | null) =>
+    [...TRASH_QUERY_KEYS.all, "items", userId] as const,
+};
+
+export const invalidateTrashQueries = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({ queryKey: TRASH_QUERY_KEYS.all });


### PR DESCRIPTION
## PR 요약

- TanStack Query 캐시 최신화 누락으로 삭제/결제 상태가 늦게 반영될 수 있는 문제를 수정합니다.

## 변경 내용 상세

### 변경 사항

- 클립 단건/선택/현재 폴더 전체 삭제 성공 시 `trash` 쿼리를 무효화하도록 추가했습니다.
- 폴더 삭제 mutation 성공 시 `trash` 쿼리를 무효화하도록 추가했습니다.
- 휴지통 쿼리 키와 무효화 함수를 공용 helper로 분리했습니다.
- 내 구독 쿼리 키/캐시 갱신 helper를 분리하고, 결제 성공 및 빌링 시작 중 409 처리에서 `mySubscription` 캐시가 최신화되도록 수정했습니다.

### 변경 이유

- 전역 `staleTime: 30_000` 및 구독 쿼리 `staleTime: 5분` 설정으로 인해 mutation 이후 관련 쿼리를 명시적으로 갱신하지 않으면 이전 캐시가 화면에 노출될 수 있습니다.
- 클립/폴더 삭제는 휴지통 목록에 영향을 주고, 결제 성공/충돌 처리는 구독 상태에 영향을 주므로 각각 관련 쿼리 캐시를 갱신해야 합니다.

## 관련 이슈

- Closes #79

## 기타 참고사항

- Before/After 스크린샷: 렌더러/UI 변경 없음
- `npm run lint`: 통과
- `npm run build`: 통과
- `npm run start`: 3000/3001 포트 사용 중으로 충돌 확인 후, `npm run start -- -p 3010` 기동 성공
- `npm run package`: package 스크립트 없음
- `npm run test:e2e`: 해당 스크립트 없음