### PR TITLE
#85 / fix(settings) : 배포 API 환경변수 참조 방식 수정

### DIFF
--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,7 +1,9 @@
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+const trimTrailingSlash = (value: string) => value.trim().replace(/\/+$/, "");
 
-const getRequiredPublicEnv = (name: "NEXT_PUBLIC_API_BASE_URL") => {
-  const value = process.env[name];
+const getRequiredPublicEnv = (
+  name: "NEXT_PUBLIC_API_BASE_URL",
+  value: string | undefined,
+) => {
   if (!value && process.env.NODE_ENV !== "production") {
     return "http://localhost:3000";
   }
@@ -14,7 +16,10 @@ const getRequiredPublicEnv = (name: "NEXT_PUBLIC_API_BASE_URL") => {
 };
 
 export const getApiBaseUrl = () =>
-  getRequiredPublicEnv("NEXT_PUBLIC_API_BASE_URL");
+  getRequiredPublicEnv(
+    "NEXT_PUBLIC_API_BASE_URL",
+    process.env.NEXT_PUBLIC_API_BASE_URL,
+  );
 
 export const isLocalApiBaseUrl = () => {
   const apiBaseUrl = getApiBaseUrl();


### PR DESCRIPTION
## PR 요약

배포 환경에서 로그인 API base URL을 클라이언트 번들에 정상 반영하도록 환경변수 참조 방식을 수정했습니다.

## 변경 내용 상세

### 변경 사항

- NEXT_PUBLIC_API_BASE_URL을 동적 키 접근 대신 정적 참조로 읽도록 변경했습니다.
- 환경변수 값의 앞뒤 공백과 trailing slash를 정리한 뒤 API URL을 생성하도록 보완했습니다.

### 변경 이유

- 배포 로그인 화면에서 소셜 로그인 버튼 클릭 시 API 요청 전에 base URL 생성이 실패했습니다.
- Next.js 클라이언트 번들은 NEXT_PUBLIC 환경변수를 빌드 시점에 인라인하므로 정적 참조가 필요합니다.

## 관련 이슈

- Closes #85

## 기타 참고사항

- Vercel Production Environment Variables에 NEXT_PUBLIC_API_BASE_URL=https://api.easy-clip.app 설정이 필요합니다.
- 설정 변경 후 재배포해야 클라이언트 번들에 반영됩니다.
- 로컬 검증: npm run lint 통과
- 로컬 검증: npm run build 통과
- npm run start: 미실행
- npm run package: 스크립트 없음
- npm run test:e2e: 해당 없음
