### PR TITLE
#85 / fix(settings) : 배포 API 환경변수 수정 사항을 main에 반영

### DIFF
--- a/src/shared/config/env.ts
+++ b/src/shared/config/env.ts
@@ -1,7 +1,9 @@
-const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
+const trimTrailingSlash = (value: string) => value.trim().replace(/\/+$/, "");
 
-const getRequiredPublicEnv = (name: "NEXT_PUBLIC_API_BASE_URL") => {
-  const value = process.env[name];
+const getRequiredPublicEnv = (
+  name: "NEXT_PUBLIC_API_BASE_URL",
+  value: string | undefined,
+) => {
   if (!value && process.env.NODE_ENV !== "production") {
     return "http://localhost:3000";
   }
@@ -14,7 +16,10 @@ const getRequiredPublicEnv = (name: "NEXT_PUBLIC_API_BASE_URL") => {
 };
 
 export const getApiBaseUrl = () =>
-  getRequiredPublicEnv("NEXT_PUBLIC_API_BASE_URL");
+  getRequiredPublicEnv(
+    "NEXT_PUBLIC_API_BASE_URL",
+    process.env.NEXT_PUBLIC_API_BASE_URL,
+  );
 
 export const isLocalApiBaseUrl = () => {
   const apiBaseUrl = getApiBaseUrl();


### PR DESCRIPTION
## PR 요약

dev 브랜치에 반영된 배포 로그인 API 환경변수 참조 수정 사항을 main 브랜치로 병합합니다.

## 변경 내용 상세

### 변경 사항

- NEXT_PUBLIC_API_BASE_URL을 클라이언트 번들에서 정적으로 참조하도록 수정한 변경을 main에 반영합니다.
- API base URL 값의 앞뒤 공백과 trailing slash를 정리하는 보완 사항을 포함합니다.

### 변경 이유

- 배포 로그인 화면에서 소셜 로그인 버튼 클릭 시 API 요청 전에 base URL 생성이 실패하는 문제를 운영 브랜치에 반영하기 위함입니다.

## 관련 이슈

- Closes #85

## 기타 참고사항

- 포함 PR: #86
- Vercel Production Environment Variables에 NEXT_PUBLIC_API_BASE_URL=https://api.easy-clip.app 설정이 필요합니다.
- 설정 변경 후 Production 재배포가 필요합니다.
- 로컬 검증: npm run lint 통과 (#86)
- 로컬 검증: npm run build 통과 (#86)
- npm run start: 미실행
- npm run package: 스크립트 없음
- npm run test:e2e: 해당 없음
