### PR TITLE
#88 / feat(settings) : 일본어 및 중국어 설정 수정 연동

### DIFF
--- a/src/features/settings/model/settings.dto.ts
+++ b/src/features/settings/model/settings.dto.ts
@@ -1,7 +1,8 @@
-export const SERVER_SUPPORTED_LANGUAGES = ["ko", "en"] as const;
+import { APP_LOCALES, type AppLocale } from "@/shared/config/locale";
 
-export type ServerSupportedLanguage =
-  (typeof SERVER_SUPPORTED_LANGUAGES)[number];
+export const SERVER_SUPPORTED_LANGUAGES = APP_LOCALES;
+
+export type ServerSupportedLanguage = AppLocale;
 
 export type UserSettingsThemeDto = "LIGHT" | "DARK" | "SYSTEM";
 


### PR DESCRIPTION
## PR 요약

- 사용자 설정 수정 API의 지원 언어 범위를 일본어·중국어까지 확장한 백엔드 변경에 맞춰 프론트엔드 설정 수정 타입을 동기화했습니다.

## 변경 내용 상세

### 변경 사항

- 사용자 설정 DTO의 서버 지원 언어 목록을 앱 공통 로케일(`ko`, `en`, `ja`, `zh`)과 공유하도록 변경
- 설정 저장 로직에서 `ja`, `zh` 선택 시 PATCH payload에 언어 코드가 포함될 수 있도록 타입 제한 정리

### 변경 이유

- 기존 프론트 DTO가 서버 지원 언어를 `ko`, `en`으로만 제한해 일본어·중국어 선택 시 설정 수정 요청에 language 값이 포함되지 않았습니다.
- 백엔드의 다국어 설정 수정 지원 범위와 프론트엔드 요청 모델을 일치시켜야 합니다.

## 관련 이슈

- Closes #88

## 기타 참고사항

- UI 렌더러 변경은 아니어서 Before/After 스크린샷은 생략했습니다.
- 로컬 검증: `npm run lint` 통과
- 로컬 검증: `npm run build` 통과
- `npm run start`: 미실행
- `npm run package`: package.json에 스크립트가 없어 미실행
- `npm run test:e2e`: 해당 스크립트가 없어 미실행