### PR TITLE
#91 / refactor(css) : 기능 UI 컴포넌트 구조 및 중복 정리

### DIFF
--- a/src/features/auth/ui/AuthBootstrap.tsx
+++ b/src/features/auth/ui/AuthBootstrap.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/features/auth/service/authService";
 import { notifyError } from "@/shared/feedback/toast";
 
+// 앱 전역의 인증 세션을 복구하고 만료 상태를 라우팅 및 캐시와 동기화합니다.
 export function AuthBootstrap() {
   const session = useAuthSession();
   const router = useRouter();

--- a/src/features/auth/ui/LoginAgreementNotice.tsx
+++ b/src/features/auth/ui/LoginAgreementNotice.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// 소셜 로그인 진행 전에 약관 및 개인정보 처리방침 동의 안내를 표시합니다.
 interface LoginAgreementNoticeProps {
   prefix: string;
   middle: string;

--- a/src/features/auth/ui/LoginBrandPanel.tsx
+++ b/src/features/auth/ui/LoginBrandPanel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// 로그인 화면의 제목과 안내 문구를 일관된 정렬로 표시합니다.
 interface LoginBrandPanelProps {
   title: string;
   subtitle: string;

--- a/src/features/auth/ui/LoginLoadingState.tsx
+++ b/src/features/auth/ui/LoginLoadingState.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// OAuth 제공자로 이동하는 동안 진행 상태와 안내 문구를 표시합니다.
 interface LoginLoadingStateProps {
   label: string;
   isVisible: boolean;
@@ -14,8 +15,16 @@ export function LoginLoadingState({
   }
 
   return (
-    <div className="mt-6 flex items-center justify-center gap-2 text-sm text-(--muted)">
-      <svg className="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
+    <div
+      className="mt-6 flex items-center justify-center gap-2 text-sm text-(--muted)"
+      role="status"
+    >
+      <svg
+        className="h-4 w-4 animate-spin"
+        fill="none"
+        viewBox="0 0 24 24"
+        aria-hidden
+      >
         <circle
           className="opacity-25"
           cx="12"

--- a/src/features/auth/ui/LoginPage.tsx
+++ b/src/features/auth/ui/LoginPage.tsx
@@ -5,6 +5,7 @@ import { useTranslations } from "next-intl";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
 import { getAuthStartPath } from "@/features/auth/api/authApi";
+import type { AuthProvider } from "@/features/auth/model/auth";
 import { restoreSessionFromRefreshCookie } from "@/features/auth/service/authService";
 import { buildApiUrl } from "@/shared/config/env";
 import { LoginAgreementNotice } from "@/features/auth/ui/LoginAgreementNotice";
@@ -12,13 +13,14 @@ import { LoginBrandPanel } from "@/features/auth/ui/LoginBrandPanel";
 import { LoginLoadingState } from "@/features/auth/ui/LoginLoadingState";
 import { LoginSocialActions } from "@/features/auth/ui/LoginSocialActions";
 
+// 세션 복구와 OAuth 진입 상태를 관리하며 로그인 UI를 조합하는 페이지입니다.
 export function LoginPage() {
   const t = useTranslations("login");
   const router = useRouter();
   const [isLoading, setIsLoading] = useState(false);
-  const [loadingProvider, setLoadingProvider] = useState<
-    "google" | "github" | null
-  >(null);
+  const [loadingProvider, setLoadingProvider] = useState<AuthProvider | null>(
+    null,
+  );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const hasTriedCookieRestoreRef = useRef(false);
 
@@ -37,7 +39,7 @@ export function LoginPage() {
       });
   }, [router]);
 
-  const handleLogin = async (provider: "google" | "github") => {
+  const handleLogin = async (provider: AuthProvider) => {
     try {
       setErrorMessage(null);
       setIsLoading(true);
@@ -63,7 +65,10 @@ export function LoginPage() {
 
         <LoginLoadingState label={t("loading")} isVisible={isLoading} />
         {errorMessage ? (
-          <p className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-200">
+          <p
+            className="mt-3 rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-200"
+            role="alert"
+          >
             {errorMessage}
           </p>
         ) : null}

--- a/src/features/auth/ui/LoginSocialActions.tsx
+++ b/src/features/auth/ui/LoginSocialActions.tsx
@@ -1,44 +1,17 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { FaGithub } from "react-icons/fa";
+import { FcGoogle } from "react-icons/fc";
+import type { AuthProvider } from "@/features/auth/model/auth";
 import { SocialLoginButton } from "@/features/auth/ui/SocialLoginButton";
 
+// 지원하는 OAuth 제공자별 로그인 액션을 동일한 버튼 구성으로 제공합니다.
 interface LoginSocialActionsProps {
   isLoading: boolean;
-  loadingProvider: "google" | "github" | null;
-  onLogin: (provider: "google" | "github") => void;
+  loadingProvider: AuthProvider | null;
+  onLogin: (provider: AuthProvider) => void;
 }
-
-const GoogleIcon = () => (
-  <svg className="h-5 w-5" viewBox="0 0 24 24">
-    <path
-      fill="#4285F4"
-      d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z"
-    />
-    <path
-      fill="#34A853"
-      d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
-    />
-    <path
-      fill="#FBBC05"
-      d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
-    />
-    <path
-      fill="#EA4335"
-      d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
-    />
-  </svg>
-);
-
-const GithubIcon = () => (
-  <svg className="h-5 w-5" fill="currentColor" viewBox="0 0 24 24">
-    <path
-      fillRule="evenodd"
-      clipRule="evenodd"
-      d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z"
-    />
-  </svg>
-);
 
 export function LoginSocialActions({
   isLoading,
@@ -51,13 +24,13 @@ export function LoginSocialActions({
     <div className="space-y-3">
       <SocialLoginButton
         label={t("continueWithGoogle")}
-        icon={<GoogleIcon />}
+        icon={<FcGoogle className="h-5 w-5" aria-hidden />}
         onClick={() => onLogin("google")}
         isLoading={isLoading && loadingProvider === "google"}
       />
       <SocialLoginButton
         label={t("continueWithGithub")}
-        icon={<GithubIcon />}
+        icon={<FaGithub className="h-5 w-5" aria-hidden />}
         onClick={() => onLogin("github")}
         isLoading={isLoading && loadingProvider === "github"}
       />

--- a/src/features/auth/ui/SocialLoginButton.tsx
+++ b/src/features/auth/ui/SocialLoginButton.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/shared/ui/button/Button";
 
+// OAuth 제공자 아이콘과 라벨을 공통 버튼 스타일로 렌더링합니다.
 interface SocialLoginButtonProps {
   label: string;
   icon: React.ReactNode;

--- a/src/features/clip/ui/ClipCollectionPage.tsx
+++ b/src/features/clip/ui/ClipCollectionPage.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { Clip } from "@/features/clip/model/clip";
+import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
+import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
+import { FilterBar, type FilterType } from "@/features/clip/ui/FilterBar";
+
+// 필터, 조회 상태, 클립 목록과 복사 알림을 공통 컬렉션 화면으로 조합합니다.
+interface ClipCollectionPageProps {
+  activeFilter: FilterType;
+  clips: Clip[];
+  copyToastPosition: { x: number; y: number } | null;
+  hasNextPage?: boolean;
+  isError?: boolean;
+  isFetchingNextPage?: boolean;
+  isLoading?: boolean;
+  onCopy: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
+  onFetchNextPage: () => void;
+  onFilterChange: (filter: FilterType) => void;
+  onRetry: () => void;
+  onSearchChange: (value: string) => void;
+  onToggleFavorite?: (clip: Clip) => void;
+  searchQuery: string;
+}
+
+export function ClipCollectionPage({
+  activeFilter,
+  clips,
+  copyToastPosition,
+  hasNextPage,
+  isError,
+  isFetchingNextPage,
+  isLoading,
+  onCopy,
+  onFetchNextPage,
+  onFilterChange,
+  onRetry,
+  onSearchChange,
+  onToggleFavorite,
+  searchQuery,
+}: ClipCollectionPageProps) {
+  const t = useTranslations("clips");
+  const hasClipLoadError = isError && clips.length === 0;
+
+  return (
+    <div className="bg-background relative flex h-full flex-col">
+      {!hasClipLoadError ? (
+        <FilterBar
+          activeFilter={activeFilter}
+          onFilterChange={onFilterChange}
+          searchQuery={searchQuery}
+          onSearchChange={onSearchChange}
+          showStatus={false}
+          countLabel={t("count", { count: clips.length })}
+        />
+      ) : null}
+      <ClipResultsSection
+        clips={clips}
+        hasNextPage={hasNextPage}
+        isError={isError}
+        isFetchingNextPage={isFetchingNextPage}
+        isLoading={isLoading}
+        onFetchNextPage={onFetchNextPage}
+        onRetry={onRetry}
+        onCopy={onCopy}
+        onToggleFavorite={onToggleFavorite}
+      />
+      <ClipCopyToast label={t("copyToast")} position={copyToastPosition} />
+    </div>
+  );
+}

--- a/src/features/clip/ui/ClipContextMenu.tsx
+++ b/src/features/clip/ui/ClipContextMenu.tsx
@@ -1,9 +1,14 @@
 "use client";
 
-import { Clip } from "@/features/clip/model/clip";
+import {
+  HiOutlineClipboardCopy,
+  HiOutlinePencil,
+  HiOutlineTrash,
+} from "react-icons/hi";
+import type { Clip } from "@/features/clip/model/clip";
 import { ActionMenu } from "@/shared/ui/menu/ActionMenu";
-import { HiOutlineClipboardCopy, HiOutlinePencil, HiOutlineTrash } from "react-icons/hi";
 
+// 선택한 클립 위치에 복사, 이름 변경, 삭제 액션 메뉴를 표시합니다.
 interface ClipContextMenuProps {
   clips: Clip[];
   contextMenu: {

--- a/src/features/clip/ui/ClipCopyToast.tsx
+++ b/src/features/clip/ui/ClipCopyToast.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+// 복사가 발생한 포인터 위치 근처에 짧은 성공 알림을 표시합니다.
 interface ClipCopyToastProps {
   label: string;
   position: {
@@ -15,8 +16,9 @@ export function ClipCopyToast({ label, position }: ClipCopyToastProps) {
 
   return (
     <div
-      className="fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
+      className="pointer-events-none fixed z-50 rounded-full bg-(--chip-bg) px-3 py-1.5 text-xs font-semibold text-(--chip-text) shadow-md"
       style={{ left: position.x + 12, top: position.y + 12 }}
+      role="status"
     >
       {label}
     </div>

--- a/src/features/clip/ui/ClipDeleteActionBar.tsx
+++ b/src/features/clip/ui/ClipDeleteActionBar.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from "next-intl";
 import { HiOutlineTrash, HiX } from "react-icons/hi";
 import { Button } from "@/shared/ui/button/Button";
 
+// 삭제 모드에서 선택 개수와 취소, 선택 삭제, 전체 삭제 액션을 제공합니다.
 interface ClipDeleteActionBarProps {
   selectedCount: number;
   totalCount: number;

--- a/src/features/clip/ui/ClipDeleteModeButton.tsx
+++ b/src/features/clip/ui/ClipDeleteModeButton.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import { HiOutlineTrash } from "react-icons/hi";
 import { Button } from "@/shared/ui/button/Button";
 
+// 폴더 화면에서 클립 선택 삭제 모드로 진입하는 고정 액션을 제공합니다.
 interface ClipDeleteModeButtonProps {
   disabled?: boolean;
   label?: string;
@@ -23,6 +25,7 @@ export function ClipDeleteModeButton({
       size="sm"
       className="absolute right-4 bottom-4 rounded-full font-semibold shadow-lg disabled:cursor-not-allowed md:right-6 md:bottom-6"
     >
+      <HiOutlineTrash className="h-4 w-4" aria-hidden />
       {label ?? t("deleteClips")}
     </Button>
   );

--- a/src/features/clip/ui/ClipEntryPage.tsx
+++ b/src/features/clip/ui/ClipEntryPage.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
+import { useFolders } from "@/features/folder/hooks/useFolders";
+
+// 기본 컬렉션 경로를 첫 폴더 경로로 연결하고 폴더가 없으면 대체 화면을 표시합니다.
+interface ClipEntryPageProps {
+  fallback: ReactNode;
+  section: "favorites" | "recent";
+}
+
+export function ClipEntryPage({ fallback, section }: ClipEntryPageProps) {
+  const router = useRouter();
+  const { folders, isLoading } = useFolders();
+
+  useEffect(() => {
+    if (!folders.length) {
+      return;
+    }
+
+    router.replace(`/${folders[0].id}/${section}`);
+  }, [folders, router, section]);
+
+  if (isLoading) {
+    return <ClipListSkeleton />;
+  }
+
+  if (!folders.length) {
+    return fallback;
+  }
+
+  return null;
+}

--- a/src/features/clip/ui/ClipErrorState.tsx
+++ b/src/features/clip/ui/ClipErrorState.tsx
@@ -3,6 +3,7 @@
 import { useTranslations } from "next-intl";
 import { HiOutlineRefresh } from "react-icons/hi";
 
+// 클립 조회 실패 원인을 안내하고 선택적으로 재시도 액션을 제공합니다.
 interface ClipErrorStateProps {
   onRetry?: () => void;
 }

--- a/src/features/clip/ui/ClipItem.tsx
+++ b/src/features/clip/ui/ClipItem.tsx
@@ -10,8 +10,9 @@ import {
   HiOutlineStar,
   HiStar,
 } from "react-icons/hi";
-import { Clip } from "@/features/clip/model/clip";
+import type { Clip } from "@/features/clip/model/clip";
 
+// 클립 하나의 미리보기, 유형 정보, 복사, 즐겨찾기와 삭제 선택 상태를 표시합니다.
 interface ClipItemProps {
   clip: Clip;
   onCopy?: (clip: Clip, event: React.MouseEvent<HTMLDivElement>) => void;
@@ -21,6 +22,71 @@ interface ClipItemProps {
   isInteractionDisabled?: boolean;
   isSelected?: boolean;
   onToggleSelected?: (clipId: string) => void;
+}
+
+function ClipTypeIcon({ type }: { type: Clip["type"] }) {
+  switch (type) {
+    case "text":
+      return <HiOutlineDocumentText className="h-5 w-5" aria-hidden />;
+    case "color":
+      return <HiOutlineColorSwatch className="h-5 w-5" aria-hidden />;
+    case "image":
+      return <HiOutlinePhotograph className="h-5 w-5" aria-hidden />;
+    default:
+      return null;
+  }
+}
+
+function ClipContentPreview({
+  clip,
+  isOptimistic,
+}: {
+  clip: Clip;
+  isOptimistic: boolean;
+}) {
+  if (clip.type === "color") {
+    return (
+      <div
+        className="h-full w-full rounded-xl border border-(--border)"
+        style={{ backgroundColor: clip.content }}
+        aria-hidden
+      />
+    );
+  }
+
+  if (clip.type === "image") {
+    return (
+      <div
+        className="relative h-full w-full rounded-xl bg-(--surface-muted)"
+        style={
+          isOptimistic && clip.content
+            ? {
+                backgroundImage: `url(${clip.content})`,
+                backgroundPosition: "center",
+                backgroundRepeat: "no-repeat",
+                backgroundSize: "contain",
+              }
+            : undefined
+        }
+      >
+        {isOptimistic ? null : (
+          <Image
+            src={clip.content}
+            alt={clip.name}
+            fill
+            sizes="(min-width: 1200px) 18vw, (min-width: 1024px) 22vw, (min-width: 768px) 28vw, 90vw"
+            className="rounded-xl object-contain"
+          />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-foreground line-clamp-4 text-sm leading-relaxed">
+      {clip.content}
+    </p>
+  );
 }
 
 export function ClipItem({
@@ -37,68 +103,9 @@ export function ClipItem({
   const isOptimistic = Boolean(clip.isOptimistic);
   const isDisabled = isOptimistic || isInteractionDisabled;
 
-  const getIcon = () => {
-    switch (clip.type) {
-      case "text":
-        return <HiOutlineDocumentText className="h-5 w-5" aria-hidden />;
-      case "color":
-        return <HiOutlineColorSwatch className="h-5 w-5" aria-hidden />;
-      case "image":
-        return <HiOutlinePhotograph className="h-5 w-5" aria-hidden />;
-      default:
-        return null;
-    }
-  };
-
-  const renderContent = () => {
-    if (clip.type === "color") {
-      return (
-        <div
-          className="h-full w-full rounded-xl border border-(--border)"
-          style={{ backgroundColor: clip.content }}
-          aria-hidden
-        />
-      );
-    }
-
-    if (clip.type === "image") {
-      return (
-        <div
-          className="relative h-full w-full rounded-xl bg-(--surface-muted)"
-          style={
-            isOptimistic && clip.content
-              ? {
-                  backgroundImage: `url(${clip.content})`,
-                  backgroundPosition: "center",
-                  backgroundRepeat: "no-repeat",
-                  backgroundSize: "contain",
-                }
-              : undefined
-          }
-        >
-          {isOptimistic ? null : (
-            <Image
-              src={clip.content}
-              alt={clip.name}
-              fill
-              sizes="(min-width: 1200px) 18vw, (min-width: 1024px) 22vw, (min-width: 768px) 28vw, 90vw"
-              className="rounded-xl object-contain"
-            />
-          )}
-        </div>
-      );
-    }
-
-    return (
-      <p className="text-foreground line-clamp-4 text-sm leading-relaxed">
-        {clip.content}
-      </p>
-    );
-  };
-
   return (
     <div
-      className="group relative flex h-52 w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-(--border) bg-(--surface) shadow-sm transition-shadow hover:shadow-md data-[disabled=true]:cursor-wait data-[disabled=true]:opacity-75 data-[delete-mode=true]:cursor-pointer data-[selected=true]:border-(--danger) data-[selected=true]:ring-2 data-[selected=true]:ring-(--danger-border)"
+      className="group relative flex h-52 w-full cursor-pointer flex-col overflow-hidden rounded-2xl border border-(--border) bg-(--surface) shadow-sm transition-shadow hover:shadow-md data-[delete-mode=true]:cursor-pointer data-[disabled=true]:cursor-wait data-[disabled=true]:opacity-75 data-[selected=true]:border-(--danger) data-[selected=true]:ring-2 data-[selected=true]:ring-(--danger-border)"
       data-optimistic={isOptimistic}
       data-disabled={isDisabled}
       data-delete-mode={isDeleteMode}
@@ -139,7 +146,7 @@ export function ClipItem({
             }}
             className={`flex h-8 w-8 cursor-pointer items-center justify-center rounded-full border shadow-sm backdrop-blur-sm transition-all duration-150 ease-out disabled:cursor-default disabled:opacity-50 ${
               isSelected
-                ? "border-(--danger) bg-(--danger) text-danger-foreground"
+                ? "text-danger-foreground border-(--danger) bg-(--danger)"
                 : "border-(--border) bg-(--surface-elevated) text-transparent hover:border-(--danger-border) hover:text-(--danger)"
             }`}
             aria-pressed={isSelected}
@@ -178,10 +185,12 @@ export function ClipItem({
           />
         )}
       </button>
-      <div className="flex-1 overflow-hidden px-4 py-3">{renderContent()}</div>
+      <div className="flex-1 overflow-hidden px-4 py-3">
+        <ClipContentPreview clip={clip} isOptimistic={isOptimistic} />
+      </div>
       <div className="flex items-center gap-2 border-t border-(--border) px-4 py-2.5 text-xs text-(--muted)">
         <span className="flex h-6 w-6 items-center justify-center rounded-md bg-(--icon-chip) text-(--icon-chip-text)">
-          {getIcon()}
+          <ClipTypeIcon type={clip.type} />
         </span>
         <span className="text-foreground truncate font-medium">
           {clip.type === "color" ? clip.content : clip.name}

--- a/src/features/clip/ui/ClipList.tsx
+++ b/src/features/clip/ui/ClipList.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { ClipItem } from "@/features/clip/ui/ClipItem";
-import { Clip } from "@/features/clip/model/clip";
+import type { Clip } from "@/features/clip/model/clip";
 
+const EMPTY_SELECTED_CLIP_IDS = new Set<string>();
+
+// 클립 카드를 반응형 그리드로 렌더링하고 무한 스크롤 감지 영역을 제공합니다.
 interface ClipListProps {
   clips: Clip[];
   loadMoreRef?: React.Ref<HTMLDivElement>;
@@ -25,7 +28,7 @@ export function ClipList({
   onContextMenu,
   isDeleteMode = false,
   isInteractionDisabled = false,
-  selectedClipIds = new Set(),
+  selectedClipIds = EMPTY_SELECTED_CLIP_IDS,
   onToggleSelected,
 }: ClipListProps) {
   if (clips.length === 0) {

--- a/src/features/clip/ui/ClipListSkeleton.tsx
+++ b/src/features/clip/ui/ClipListSkeleton.tsx
@@ -2,6 +2,7 @@
 
 const SKELETON_CARD_COUNT = 8;
 
+// 클립 목록을 불러오는 동안 실제 그리드와 같은 형태의 로딩 카드를 표시합니다.
 export function ClipListSkeleton() {
   return (
     <div className="clip-scrollbar flex-1 overflow-auto px-4 py-4 md:px-6">

--- a/src/features/clip/ui/ClipResultsSection.tsx
+++ b/src/features/clip/ui/ClipResultsSection.tsx
@@ -2,12 +2,15 @@
 
 import { useEffect, useRef } from "react";
 import { useInView } from "react-intersection-observer";
-import { Clip } from "@/features/clip/model/clip";
+import type { Clip } from "@/features/clip/model/clip";
 import { ClipErrorState } from "@/features/clip/ui/ClipErrorState";
 import { ClipList } from "@/features/clip/ui/ClipList";
 import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 import { EmptyState } from "@/features/clip/ui/EmptyState";
 
+const EMPTY_SELECTED_CLIP_IDS = new Set<string>();
+
+// 클립 조회 상태에 따라 로딩, 오류, 빈 상태 또는 페이지네이션 목록을 표시합니다.
 interface ClipResultsSectionProps {
   clips: Clip[];
   isError?: boolean;
@@ -38,7 +41,7 @@ export function ClipResultsSection({
   onContextMenu,
   isDeleteMode = false,
   isInteractionDisabled = false,
-  selectedClipIds = new Set(),
+  selectedClipIds = EMPTY_SELECTED_CLIP_IDS,
   onToggleSelected,
 }: ClipResultsSectionProps) {
   const hasTriggeredInViewRef = useRef(false);

--- a/src/features/clip/ui/DeleteAllClipsModal.tsx
+++ b/src/features/clip/ui/DeleteAllClipsModal.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/shared/ui/button/Button";
 import { Modal } from "@/shared/ui/overlay/Modal";
 
+// 현재 폴더의 모든 클립 삭제를 확인하고 요청 진행 중 액션을 잠급니다.
 interface DeleteAllClipsModalProps {
   isOpen: boolean;
   title: string;

--- a/src/features/clip/ui/FavoriteClipsPage.tsx
+++ b/src/features/clip/ui/FavoriteClipsPage.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
-import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { useFavoriteClipsPage } from "@/features/clip/hooks/useFavoriteClipsPage";
-import { FilterBar } from "@/features/clip/ui/FilterBar";
+import { ClipCollectionPage } from "@/features/clip/ui/ClipCollectionPage";
 
+// 즐겨찾기 클립 데이터와 즐겨찾기 해제 액션을 공통 컬렉션 화면에 연결합니다.
 export function FavoriteClipsPage() {
-  const t = useTranslations("clips");
   const {
     activeFilter,
     copyToast,
@@ -24,36 +21,27 @@ export function FavoriteClipsPage() {
     setActiveFilter,
     setSearchQuery,
   } = useFavoriteClipsPage();
-  const hasClipLoadError = isError && filteredClips.length === 0;
 
   return (
-    <div className="bg-background relative flex h-full flex-col">
-      {!hasClipLoadError ? (
-        <FilterBar
-          activeFilter={activeFilter}
-          onFilterChange={setActiveFilter}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          showStatus={false}
-          countLabel={t("count", { count: filteredClips.length })}
-        />
-      ) : null}
-      <ClipResultsSection
-        clips={filteredClips}
-        hasNextPage={hasNextPage}
-        isError={isError}
-        isFetchingNextPage={isFetchingNextPage}
-        isLoading={isLoading}
-        onFetchNextPage={() => {
-          void fetchNextPage();
-        }}
-        onRetry={() => {
-          void refetchClips();
-        }}
-        onCopy={handleCopy}
-        onToggleFavorite={handleToggleFavorite}
-      />
-      <ClipCopyToast label={t("copyToast")} position={copyToast} />
-    </div>
+    <ClipCollectionPage
+      activeFilter={activeFilter}
+      clips={filteredClips}
+      copyToastPosition={copyToast}
+      hasNextPage={hasNextPage}
+      isError={isError}
+      isFetchingNextPage={isFetchingNextPage}
+      isLoading={isLoading}
+      onCopy={handleCopy}
+      onFetchNextPage={() => {
+        void fetchNextPage();
+      }}
+      onFilterChange={setActiveFilter}
+      onRetry={() => {
+        void refetchClips();
+      }}
+      onSearchChange={setSearchQuery}
+      onToggleFavorite={handleToggleFavorite}
+      searchQuery={searchQuery}
+    />
   );
 }

--- a/src/features/clip/ui/FavoritesEntryPage.tsx
+++ b/src/features/clip/ui/FavoritesEntryPage.tsx
@@ -1,30 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useFolders } from "@/features/folder/hooks/useFolders";
+import { ClipEntryPage } from "@/features/clip/ui/ClipEntryPage";
 import { FavoriteClipsPage } from "@/features/clip/ui/FavoriteClipsPage";
-import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 
+// 즐겨찾기 기본 경로를 폴더 기준 경로 또는 빈 폴더 대체 화면으로 연결합니다.
 export function FavoritesEntryPage() {
-  const router = useRouter();
-  const { folders, isLoading } = useFolders();
-
-  useEffect(() => {
-    if (!folders.length) {
-      return;
-    }
-
-    router.replace(`/${folders[0].id}/favorites`);
-  }, [folders, router]);
-
-  if (isLoading) {
-    return <ClipListSkeleton />;
-  }
-
-  if (!folders.length) {
-    return <FavoriteClipsPage />;
-  }
-
-  return null;
+  return <ClipEntryPage section="favorites" fallback={<FavoriteClipsPage />} />;
 }

--- a/src/features/clip/ui/FilterBar.tsx
+++ b/src/features/clip/ui/FilterBar.tsx
@@ -7,7 +7,7 @@ import {
   HiOutlinePhotograph,
   HiOutlineSearch,
 } from "react-icons/hi";
-import { ClipType } from "@/features/clip/model/clip";
+import type { ClipType } from "@/features/clip/model/clip";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 import { Select } from "@/shared/ui/input/Select";
@@ -15,6 +15,7 @@ import { TextInput } from "@/shared/ui/input/TextInput";
 
 export type FilterType = ClipType | "all";
 
+// 클립 유형 필터, 검색, 수집 상태와 결과 개수를 반응형으로 표시합니다.
 interface FilterBarProps {
   activeFilter: FilterType;
   onFilterChange: (filter: FilterType) => void;
@@ -78,9 +79,7 @@ export function FilterBar({
           <span>{isActive ? t("readyToPaste") : t("notActive")}</span>
         </div>
       ) : null}
-      {countLabel ? (
-        <Badge variant="chip">{countLabel}</Badge>
-      ) : null}
+      {countLabel ? <Badge variant="chip">{countLabel}</Badge> : null}
     </div>
   );
 

--- a/src/features/clip/ui/FolderClipCaptureHint.tsx
+++ b/src/features/clip/ui/FolderClipCaptureHint.tsx
@@ -1,12 +1,11 @@
 "use client";
 
+// 클립 수집이 비활성화된 폴더 화면에 활성화 방법을 안내합니다.
 interface FolderClipCaptureHintProps {
   message: string;
 }
 
-export function FolderClipCaptureHint({
-  message,
-}: FolderClipCaptureHintProps) {
+export function FolderClipCaptureHint({ message }: FolderClipCaptureHintProps) {
   return (
     <div className="px-4 pt-4 md:px-6">
       <div className="rounded-2xl border border-(--border) bg-(--surface) px-4 py-3 text-center text-xs text-(--muted)">

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -11,6 +11,7 @@ import { DeleteAllClipsModal } from "@/features/clip/ui/DeleteAllClipsModal";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 import { FolderClipCaptureHint } from "@/features/clip/ui/FolderClipCaptureHint";
 
+// 폴더 클립의 조회, 복사, 즐겨찾기, 컨텍스트 메뉴와 삭제 UI를 조합합니다.
 export function FolderClipsPage() {
   const t = useTranslations("clips");
   const {

--- a/src/features/clip/ui/RecentClipsPage.tsx
+++ b/src/features/clip/ui/RecentClipsPage.tsx
@@ -1,13 +1,10 @@
 "use client";
 
-import { useTranslations } from "next-intl";
-import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
-import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { useRecentClipsPage } from "@/features/clip/hooks/useRecentClipsPage";
-import { FilterBar } from "@/features/clip/ui/FilterBar";
+import { ClipCollectionPage } from "@/features/clip/ui/ClipCollectionPage";
 
+// 최근 사용한 클립 데이터를 공통 컬렉션 화면에 연결합니다.
 export function RecentClipsPage() {
-  const t = useTranslations("clips");
   const {
     activeFilter,
     copyToast,
@@ -23,35 +20,26 @@ export function RecentClipsPage() {
     setActiveFilter,
     setSearchQuery,
   } = useRecentClipsPage();
-  const hasClipLoadError = isError && filteredClips.length === 0;
 
   return (
-    <div className="bg-background relative flex h-full flex-col">
-      {!hasClipLoadError ? (
-        <FilterBar
-          activeFilter={activeFilter}
-          onFilterChange={setActiveFilter}
-          searchQuery={searchQuery}
-          onSearchChange={setSearchQuery}
-          showStatus={false}
-          countLabel={t("count", { count: filteredClips.length })}
-        />
-      ) : null}
-      <ClipResultsSection
-        clips={filteredClips}
-        hasNextPage={hasNextPage}
-        isError={isError}
-        isFetchingNextPage={isFetchingNextPage}
-        isLoading={isLoading}
-        onFetchNextPage={() => {
-          void fetchNextPage();
-        }}
-        onRetry={() => {
-          void refetchClips();
-        }}
-        onCopy={handleCopy}
-      />
-      <ClipCopyToast label={t("copyToast")} position={copyToast} />
-    </div>
+    <ClipCollectionPage
+      activeFilter={activeFilter}
+      clips={filteredClips}
+      copyToastPosition={copyToast}
+      hasNextPage={hasNextPage}
+      isError={isError}
+      isFetchingNextPage={isFetchingNextPage}
+      isLoading={isLoading}
+      onCopy={handleCopy}
+      onFetchNextPage={() => {
+        void fetchNextPage();
+      }}
+      onFilterChange={setActiveFilter}
+      onRetry={() => {
+        void refetchClips();
+      }}
+      onSearchChange={setSearchQuery}
+      searchQuery={searchQuery}
+    />
   );
 }

--- a/src/features/clip/ui/RecentEntryPage.tsx
+++ b/src/features/clip/ui/RecentEntryPage.tsx
@@ -1,30 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
-import { useRouter } from "next/navigation";
-import { useFolders } from "@/features/folder/hooks/useFolders";
+import { ClipEntryPage } from "@/features/clip/ui/ClipEntryPage";
 import { RecentClipsPage } from "@/features/clip/ui/RecentClipsPage";
-import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
 
+// 최근 클립 기본 경로를 폴더 기준 경로 또는 빈 폴더 대체 화면으로 연결합니다.
 export function RecentEntryPage() {
-  const router = useRouter();
-  const { folders, isLoading } = useFolders();
-
-  useEffect(() => {
-    if (!folders.length) {
-      return;
-    }
-
-    router.replace(`/${folders[0].id}/recent`);
-  }, [folders, router]);
-
-  if (isLoading) {
-    return <ClipListSkeleton />;
-  }
-
-  if (!folders.length) {
-    return <RecentClipsPage />;
-  }
-
-  return null;
+  return <ClipEntryPage section="recent" fallback={<RecentClipsPage />} />;
 }

--- a/src/features/folder/ui/FolderNameModal.tsx
+++ b/src/features/folder/ui/FolderNameModal.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/shared/ui/button/Button";
 import { TextInput } from "@/shared/ui/input/TextInput";
 import { Modal } from "@/shared/ui/overlay/Modal";
 
+// 폴더 생성과 이름 변경에 공통으로 사용하는 입력 및 확인 모달입니다.
 interface FolderNameModalProps {
   title: string;
   closeLabel: string;

--- a/src/features/folder/ui/FolderOptionsMenu.tsx
+++ b/src/features/folder/ui/FolderOptionsMenu.tsx
@@ -3,6 +3,7 @@
 import { HiOutlinePencil, HiOutlineTrash } from "react-icons/hi";
 import { ActionMenu } from "@/shared/ui/menu/ActionMenu";
 
+// 폴더 이름 변경과 삭제 액션을 컨텍스트 메뉴로 제공합니다.
 interface FolderOptionsMenuProps {
   renameLabel: string;
   deleteLabel: string;

--- a/src/features/folder/ui/FolderSidebarFooter.tsx
+++ b/src/features/folder/ui/FolderSidebarFooter.tsx
@@ -9,6 +9,7 @@ import {
 } from "react-icons/hi";
 import { ActionMenu } from "@/shared/ui/menu/ActionMenu";
 
+// 사용자 식별 정보와 설정, 요금제, 로그아웃 액션 메뉴를 제공합니다.
 interface FolderSidebarFooterProps {
   userLabel: string;
   settingsLabel: string;
@@ -112,6 +113,7 @@ export function FolderSidebarFooter({
           onClick={() => setIsMenuOpen((previous) => !previous)}
           className="flex w-full cursor-pointer items-center justify-between rounded-lg bg-(--surface) px-3 py-2 transition-colors hover:bg-(--surface-elevated)"
           aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
         >
           <span className="flex min-w-0 items-center gap-2">
             <span className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full bg-(--icon-chip) text-[10px] font-semibold text-(--icon-chip-text)">

--- a/src/features/folder/ui/FolderSidebarHeader.tsx
+++ b/src/features/folder/ui/FolderSidebarHeader.tsx
@@ -2,6 +2,7 @@
 
 import { HiOutlinePaperClip, HiX } from "react-icons/hi";
 
+// 사이드바 상단에 브랜드와 모바일 닫기 액션을 표시합니다.
 interface FolderSidebarHeaderProps {
   onCloseMobile?: () => void;
 }

--- a/src/features/folder/ui/FolderSidebarItem.tsx
+++ b/src/features/folder/ui/FolderSidebarItem.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import Link from "next/link";
+import {
+  HiOutlineDotsVertical,
+  HiOutlineFolder,
+  HiOutlineMenuAlt4,
+} from "react-icons/hi";
+import type { FolderItem } from "@/features/folder/model/folder";
+import { FolderOptionsMenu } from "@/features/folder/ui/FolderOptionsMenu";
+
+// 폴더 하나의 탐색, 순서 변경, 옵션 메뉴와 드롭 위치를 렌더링합니다.
+interface FolderSidebarItemProps {
+  deleteLabel: string;
+  draggingFolderId: string | null;
+  dropIndicatorEdge: "top" | "bottom" | null;
+  folder: FolderItem;
+  isOptionsOpen: boolean;
+  onDelete: () => void;
+  onDragEnd: () => void;
+  onDragOver: (event: React.DragEvent<HTMLLIElement>) => void;
+  onDragStart: (event: React.DragEvent<HTMLButtonElement>) => void;
+  onDrop: (event: React.DragEvent<HTMLLIElement>) => void;
+  onNavigate?: () => void;
+  onRename: () => void;
+  onToggleOptions: () => void;
+  openFolderOptionsLabel: string;
+  pathname: string;
+  renameLabel: string;
+  reorderFolderLabel: string;
+}
+
+export function FolderSidebarItem({
+  deleteLabel,
+  draggingFolderId,
+  dropIndicatorEdge,
+  folder,
+  isOptionsOpen,
+  onDelete,
+  onDragEnd,
+  onDragOver,
+  onDragStart,
+  onDrop,
+  onNavigate,
+  onRename,
+  onToggleOptions,
+  openFolderOptionsLabel,
+  pathname,
+  renameLabel,
+  reorderFolderLabel,
+}: FolderSidebarItemProps) {
+  const isDragging = Boolean(draggingFolderId);
+  const isDraggedItem = draggingFolderId === folder.id;
+  const isActiveFolder = pathname === `/${folder.id}`;
+  const isDropTarget = dropIndicatorEdge !== null;
+
+  return (
+    <li
+      onDragOver={onDragOver}
+      onDrop={onDrop}
+      className={`relative rounded-lg ${isDraggedItem ? "opacity-50" : ""}`}
+    >
+      {dropIndicatorEdge ? (
+        <span
+          className={`pointer-events-none absolute right-2 left-2 z-10 h-0.5 rounded-full bg-(--focus-ring) opacity-100 shadow-[0_0_0_1px_var(--surface-muted)] transition-[opacity,transform] duration-150 ${
+            dropIndicatorEdge === "top"
+              ? "top-0 -translate-y-1/2"
+              : "bottom-0 translate-y-1/2"
+          }`}
+          aria-hidden
+        />
+      ) : null}
+
+      <div
+        className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium ${
+          isDragging ? "transition-colors duration-150" : "transition-colors"
+        } ${
+          isDropTarget
+            ? "text-foreground bg-(--surface-elevated)"
+            : isActiveFolder
+              ? "text-foreground bg-(--surface)"
+              : isDragging
+                ? "text-muted"
+                : "text-muted hover:text-foreground hover:bg-(--surface)"
+        }`}
+      >
+        <button
+          type="button"
+          draggable
+          onDragStart={onDragStart}
+          onDragEnd={onDragEnd}
+          className={`text-muted cursor-grab rounded p-1 ${
+            isDragging ? "" : "hover:text-foreground"
+          }`}
+          aria-label={reorderFolderLabel}
+        >
+          <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
+        </button>
+
+        <Link
+          href={`/${folder.id}`}
+          onClick={onNavigate}
+          className="flex flex-1 items-center gap-2 truncate"
+          aria-current={isActiveFolder ? "page" : undefined}
+        >
+          <HiOutlineFolder className="h-5 w-5" aria-hidden />
+          <span className="truncate">{folder.name}</span>
+        </Link>
+
+        <button
+          type="button"
+          onClick={onToggleOptions}
+          className={`text-muted cursor-pointer rounded p-1 ${
+            isDragging ? "" : "hover:text-foreground transition"
+          }`}
+          aria-label={openFolderOptionsLabel}
+          aria-expanded={isOptionsOpen}
+          aria-haspopup="menu"
+          data-folder-options
+        >
+          <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
+        </button>
+      </div>
+
+      {isOptionsOpen ? (
+        <FolderOptionsMenu
+          renameLabel={renameLabel}
+          deleteLabel={deleteLabel}
+          onRename={onRename}
+          onDelete={onDelete}
+        />
+      ) : null}
+    </li>
+  );
+}

--- a/src/features/folder/ui/FolderSidebarSection.tsx
+++ b/src/features/folder/ui/FolderSidebarSection.tsx
@@ -1,15 +1,10 @@
 "use client";
 
-import Link from "next/link";
 import type { FolderItem } from "@/features/folder/model/folder";
-import {
-  HiOutlineDotsVertical,
-  HiOutlineFolder,
-  HiOutlineMenuAlt4,
-  HiOutlinePlus,
-} from "react-icons/hi";
-import { FolderOptionsMenu } from "@/features/folder/ui/FolderOptionsMenu";
+import { HiOutlinePlus } from "react-icons/hi";
+import { FolderSidebarItem } from "@/features/folder/ui/FolderSidebarItem";
 
+// 폴더 추가 액션과 로딩 또는 폴더 목록 상태를 사이드바 섹션으로 조합합니다.
 interface FolderSidebarSectionProps {
   folders: FolderItem[];
   isLoading?: boolean;
@@ -77,92 +72,32 @@ export function FolderSidebarSection({
       <ul className="space-y-1 px-2">
         {isLoading
           ? skeletonRows.map((row) => <FolderSidebarSkeletonRow key={row} />)
-          : folders.map((folder) => {
-              const isDragging = Boolean(draggingFolderId);
-              const isActiveFolder = pathname === `/${folder.id}`;
-              const isDropTarget = dropIndicator?.folderId === folder.id;
-
-              return (
-                <li
-                  key={folder.id}
-                  onDragOver={(event) => onDragOver(folder.id, event)}
-                  onDrop={(event) => onDrop(folder.id, event)}
-                  className={`relative rounded-lg ${
-                    draggingFolderId === folder.id ? "opacity-50" : ""
-                  }`}
-                >
-                  {isDropTarget ? (
-                    <span
-                      className={`pointer-events-none absolute right-2 left-2 z-10 h-0.5 rounded-full bg-(--focus-ring) opacity-100 shadow-[0_0_0_1px_var(--surface-muted)] transition-[opacity,transform] duration-150 ${
-                        dropIndicator.edge === "top"
-                          ? "top-0 -translate-y-1/2"
-                          : "bottom-0 translate-y-1/2"
-                      }`}
-                      aria-hidden
-                    />
-                  ) : null}
-
-                  <div
-                    className={`flex items-center gap-2 rounded-lg px-2 py-2 text-sm font-medium ${
-                      isDragging
-                        ? "transition-colors duration-150"
-                        : "transition-colors"
-                    } ${
-                      isDropTarget
-                        ? "text-foreground bg-(--surface-elevated)"
-                        : isActiveFolder
-                        ? "text-foreground bg-(--surface)"
-                        : isDragging
-                          ? "text-muted"
-                          : "text-muted hover:text-foreground hover:bg-(--surface)"
-                    }`}
-                  >
-                    <button
-                      type="button"
-                      draggable
-                      onDragStart={(event) => onDragStart(folder.id, event)}
-                      onDragEnd={onDragEnd}
-                      className={`text-muted cursor-grab rounded p-1 ${
-                        isDragging ? "" : "hover:text-foreground"
-                      }`}
-                      aria-label={reorderFolderLabel}
-                    >
-                      <HiOutlineMenuAlt4 className="h-4 w-4" aria-hidden />
-                    </button>
-
-                    <Link
-                      href={`/${folder.id}`}
-                      onClick={onNavigate}
-                      className="flex flex-1 items-center gap-2 truncate"
-                    >
-                      <HiOutlineFolder className="h-5 w-5" aria-hidden />
-                      <span className="truncate">{folder.name}</span>
-                    </Link>
-
-                    <button
-                      type="button"
-                      onClick={() => onToggleOptions(folder.id)}
-                      className={`text-muted cursor-pointer rounded p-1 ${
-                        isDragging ? "" : "transition hover:text-foreground"
-                      }`}
-                      aria-label={openFolderOptionsLabel}
-                      data-folder-options
-                    >
-                      <HiOutlineDotsVertical className="h-4 w-4" aria-hidden />
-                    </button>
-                  </div>
-
-                  {openOptionsFolderId === folder.id ? (
-                    <FolderOptionsMenu
-                      renameLabel={renameLabel}
-                      deleteLabel={deleteLabel}
-                      onRename={() => onRenameFolder(folder.id)}
-                      onDelete={() => onDeleteFolder(folder.id)}
-                    />
-                  ) : null}
-                </li>
-              );
-            })}
+          : folders.map((folder) => (
+              <FolderSidebarItem
+                key={folder.id}
+                folder={folder}
+                pathname={pathname}
+                reorderFolderLabel={reorderFolderLabel}
+                openFolderOptionsLabel={openFolderOptionsLabel}
+                renameLabel={renameLabel}
+                deleteLabel={deleteLabel}
+                draggingFolderId={draggingFolderId}
+                dropIndicatorEdge={
+                  dropIndicator?.folderId === folder.id
+                    ? dropIndicator.edge
+                    : null
+                }
+                isOptionsOpen={openOptionsFolderId === folder.id}
+                onNavigate={onNavigate}
+                onDragStart={(event) => onDragStart(folder.id, event)}
+                onDragEnd={onDragEnd}
+                onDragOver={(event) => onDragOver(folder.id, event)}
+                onDrop={(event) => onDrop(folder.id, event)}
+                onToggleOptions={() => onToggleOptions(folder.id)}
+                onRename={() => onRenameFolder(folder.id)}
+                onDelete={() => onDeleteFolder(folder.id)}
+              />
+            ))}
       </ul>
     </div>
   );

--- a/src/features/folder/ui/Sidebar.tsx
+++ b/src/features/folder/ui/Sidebar.tsx
@@ -18,7 +18,13 @@ import { FolderSidebarHeader } from "@/features/folder/ui/FolderSidebarHeader";
 import { FolderSidebarSection } from "@/features/folder/ui/FolderSidebarSection";
 import { SidebarPrimaryNav } from "@/features/folder/ui/SidebarPrimaryNav";
 
-//TODO : 클립 도메인으로 합병
+const RESERVED_PATHNAMES = new Set([
+  "favorites",
+  "recent",
+  "trash",
+  "login",
+  "pricing",
+]);
 
 interface SidebarProps {
   onOpenSettings: () => void;
@@ -33,6 +39,11 @@ type FolderDropTarget = {
   indicatorEdge: "top" | "bottom";
 };
 
+type FolderNameModalState =
+  | { mode: "create"; value: string }
+  | { mode: "rename"; folderId: string; value: string };
+
+// 앱 탐색과 폴더 생성, 이름 변경, 삭제, 순서 변경 흐름을 조합합니다.
 export function Sidebar({
   onOpenSettings,
   isMobileOpen = false,
@@ -52,30 +63,20 @@ export function Sidebar({
     renameFolder,
     saveFolderOrder,
   } = useFolders();
-  const [isCreateFolderModalOpen, setIsCreateFolderModalOpen] = useState(false);
-  const [newFolderName, setNewFolderName] = useState("");
+  const [folderNameModal, setFolderNameModal] =
+    useState<FolderNameModalState | null>(null);
   const [openOptionsFolderId, setOpenOptionsFolderId] = useState<string | null>(
     null,
   );
-  const [isRenameFolderModalOpen, setIsRenameFolderModalOpen] = useState(false);
-  const [renameFolderId, setRenameFolderId] = useState<string | null>(null);
-  const [renameFolderName, setRenameFolderName] = useState("");
   const [draggingFolderId, setDraggingFolderId] = useState<string | null>(null);
   const [folderDropTarget, setFolderDropTarget] =
     useState<FolderDropTarget | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const renameInputRef = useRef<HTMLInputElement>(null);
+  const folderNameInputRef = useRef<HTMLInputElement>(null);
+  const folderNameModalMode = folderNameModal?.mode ?? null;
   const pathSegments = pathname.split("/").filter(Boolean);
   const pathnameFolderId = pathSegments[0] ?? null;
-  const reservedPathnames = new Set([
-    "favorites",
-    "recent",
-    "trash",
-    "login",
-    "pricing",
-  ]);
   const currentFolderId =
-    pathnameFolderId && !reservedPathnames.has(pathnameFolderId)
+    pathnameFolderId && !RESERVED_PATHNAMES.has(pathnameFolderId)
       ? pathnameFolderId
       : (folders[0]?.id ?? null);
 
@@ -98,16 +99,10 @@ export function Sidebar({
   ];
 
   useEffect(() => {
-    if (isCreateFolderModalOpen && inputRef.current) {
-      inputRef.current.focus();
+    if (folderNameModalMode && folderNameInputRef.current) {
+      folderNameInputRef.current.focus();
     }
-  }, [isCreateFolderModalOpen]);
-
-  useEffect(() => {
-    if (isRenameFolderModalOpen && renameInputRef.current) {
-      renameInputRef.current.focus();
-    }
-  }, [isRenameFolderModalOpen]);
+  }, [folderNameModalMode]);
 
   useEffect(() => {
     if (!openOptionsFolderId) {
@@ -157,7 +152,9 @@ export function Sidebar({
       }
 
       const sourceIndex = folders.findIndex((folder) => folder.id === sourceId);
-      const hoveredIndex = folders.findIndex((folder) => folder.id === folderId);
+      const hoveredIndex = folders.findIndex(
+        (folder) => folder.id === folderId,
+      );
 
       if (sourceIndex === -1 || hoveredIndex === -1) {
         return null;
@@ -227,19 +224,14 @@ export function Sidebar({
     [clearFolderDragState, ensureAuthenticated, saveFolderOrder],
   );
 
-  const closeCreateModal = () => {
-    setIsCreateFolderModalOpen(false);
-    setNewFolderName("");
-  };
+  const closeFolderNameModal = () => setFolderNameModal(null);
 
-  const closeRenameModal = () => {
-    setIsRenameFolderModalOpen(false);
-    setRenameFolderId(null);
-    setRenameFolderName("");
-  };
+  const handleSubmitFolderName = useCallback(() => {
+    if (!folderNameModal) {
+      return;
+    }
 
-  const handleCreateFolder = useCallback(() => {
-    const trimmedName = newFolderName.trim();
+    const trimmedName = folderNameModal.value.trim();
     if (!trimmedName) {
       return;
     }
@@ -248,33 +240,15 @@ export function Sidebar({
       return;
     }
 
-    void createFolder(trimmedName)
-      .then(() => closeCreateModal())
-      .catch(() => {
-        // keep the modal open when the request fails
-      });
-  }, [createFolder, ensureAuthenticated, newFolderName]);
+    const request =
+      folderNameModal.mode === "create"
+        ? createFolder(trimmedName)
+        : renameFolder(folderNameModal.folderId, trimmedName);
 
-  const handleRenameFolder = useCallback(() => {
-    if (!renameFolderId) {
-      return;
-    }
-
-    const trimmedName = renameFolderName.trim();
-    if (!trimmedName) {
-      return;
-    }
-
-    if (!ensureAuthenticated()) {
-      return;
-    }
-
-    void renameFolder(renameFolderId, trimmedName)
-      .then(() => closeRenameModal())
-      .catch(() => {
-        // keep the modal open when the request fails
-      });
-  }, [ensureAuthenticated, renameFolder, renameFolderId, renameFolderName]);
+    void request.then(closeFolderNameModal).catch(() => {
+      // keep the modal open when the request fails
+    });
+  }, [createFolder, ensureAuthenticated, folderNameModal, renameFolder]);
 
   const getRedirectPathAfterFolderDelete = useCallback(
     (deletedFolderId: string) => {
@@ -302,6 +276,106 @@ export function Sidebar({
     },
     [folders, pathname],
   );
+
+  const handleFolderDragStart = (
+    folderId: string,
+    event: React.DragEvent<HTMLButtonElement>,
+  ) => {
+    setDraggingFolderId(folderId);
+    setFolderDropTarget(null);
+    event.dataTransfer.effectAllowed = "move";
+    event.dataTransfer.setData("text/plain", folderId);
+  };
+
+  const handleFolderDragOver = (
+    folderId: string,
+    event: React.DragEvent<HTMLLIElement>,
+  ) => {
+    event.preventDefault();
+    event.dataTransfer.dropEffect = "move";
+
+    if (!draggingFolderId || draggingFolderId === folderId) {
+      setFolderDropTarget(null);
+      return;
+    }
+
+    const nextDropTarget = getFolderDropTarget(
+      draggingFolderId,
+      folderId,
+      event,
+    );
+
+    setFolderDropTarget((currentTarget) =>
+      currentTarget?.targetId === nextDropTarget?.targetId &&
+      currentTarget?.position === nextDropTarget?.position &&
+      currentTarget?.indicatorFolderId === nextDropTarget?.indicatorFolderId &&
+      currentTarget?.indicatorEdge === nextDropTarget?.indicatorEdge
+        ? currentTarget
+        : nextDropTarget,
+    );
+  };
+
+  const handleFolderDrop = (
+    folderId: string,
+    event: React.DragEvent<HTMLLIElement>,
+  ) => {
+    event.preventDefault();
+    const dropTarget = getFolderDropTarget(draggingFolderId, folderId, event);
+
+    if (!dropTarget) {
+      clearFolderDragState();
+      return;
+    }
+
+    handleDropFolder(
+      draggingFolderId,
+      dropTarget.targetId,
+      dropTarget.position,
+    );
+  };
+
+  const handleToggleFolderOptions = (folderId: string) => {
+    setOpenOptionsFolderId((previous) =>
+      previous === folderId ? null : folderId,
+    );
+  };
+
+  const handleOpenRenameFolder = (folderId: string) => {
+    const targetFolder = folders.find((folder) => folder.id === folderId);
+    if (!targetFolder) {
+      return;
+    }
+
+    setOpenOptionsFolderId(null);
+    setFolderNameModal({
+      mode: "rename",
+      folderId,
+      value: targetFolder.name,
+    });
+  };
+
+  const handleDeleteFolder = (folderId: string) => {
+    if (!ensureAuthenticated()) {
+      return;
+    }
+
+    const isDeletingCurrentFolder = pathnameFolderId === folderId;
+    const redirectPath = getRedirectPathAfterFolderDelete(folderId);
+
+    void removeFolder(folderId)
+      .then(() => {
+        setOpenOptionsFolderId(null);
+        void invalidateClipQueries(queryClient);
+
+        if (isDeletingCurrentFolder) {
+          onCloseMobile?.();
+          router.replace(redirectPath);
+        }
+      })
+      .catch(() => {
+        // keep the menu open when the request fails
+      });
+  };
 
   const userLabel =
     session?.user?.authAccounts?.[0]?.email ??
@@ -371,102 +445,16 @@ export function Sidebar({
                   : null
               }
               onAddFolder={() => {
-                setNewFolderName("");
-                setIsCreateFolderModalOpen(true);
+                setFolderNameModal({ mode: "create", value: "" });
               }}
               onNavigate={onCloseMobile}
-              onDragStart={(folderId, event) => {
-                setDraggingFolderId(folderId);
-                setFolderDropTarget(null);
-                event.dataTransfer.effectAllowed = "move";
-                event.dataTransfer.setData("text/plain", folderId);
-              }}
+              onDragStart={handleFolderDragStart}
               onDragEnd={clearFolderDragState}
-              onDragOver={(folderId, event) => {
-                event.preventDefault();
-                event.dataTransfer.dropEffect = "move";
-
-                if (!draggingFolderId || draggingFolderId === folderId) {
-                  setFolderDropTarget(null);
-                  return;
-                }
-
-                const nextDropTarget = getFolderDropTarget(
-                  draggingFolderId,
-                  folderId,
-                  event,
-                );
-
-                setFolderDropTarget((currentTarget) =>
-                  currentTarget?.targetId === nextDropTarget?.targetId &&
-                  currentTarget?.position === nextDropTarget?.position &&
-                  currentTarget?.indicatorFolderId ===
-                    nextDropTarget?.indicatorFolderId &&
-                  currentTarget?.indicatorEdge === nextDropTarget?.indicatorEdge
-                    ? currentTarget
-                    : nextDropTarget,
-                );
-              }}
-              onDrop={(folderId, event) => {
-                event.preventDefault();
-                const dropTarget = getFolderDropTarget(
-                  draggingFolderId,
-                  folderId,
-                  event,
-                );
-
-                if (!dropTarget) {
-                  clearFolderDragState();
-                  return;
-                }
-
-                handleDropFolder(
-                  draggingFolderId,
-                  dropTarget.targetId,
-                  dropTarget.position,
-                );
-              }}
-              onToggleOptions={(folderId) =>
-                setOpenOptionsFolderId((previous) =>
-                  previous === folderId ? null : folderId,
-                )
-              }
-              onRenameFolder={(folderId) => {
-                const targetFolder = folders.find(
-                  (folder) => folder.id === folderId,
-                );
-                if (!targetFolder) {
-                  return;
-                }
-
-                setOpenOptionsFolderId(null);
-                setRenameFolderId(folderId);
-                setRenameFolderName(targetFolder.name);
-                setIsRenameFolderModalOpen(true);
-              }}
-              onDeleteFolder={(folderId) => {
-                if (!ensureAuthenticated()) {
-                  return;
-                }
-
-                const isDeletingCurrentFolder = pathnameFolderId === folderId;
-                const redirectPath =
-                  getRedirectPathAfterFolderDelete(folderId);
-
-                void removeFolder(folderId)
-                  .then(() => {
-                    setOpenOptionsFolderId(null);
-                    void invalidateClipQueries(queryClient);
-
-                    if (isDeletingCurrentFolder) {
-                      onCloseMobile?.();
-                      router.replace(redirectPath);
-                    }
-                  })
-                  .catch(() => {
-                    // keep the menu open when the request fails
-                  });
-              }}
+              onDragOver={handleFolderDragOver}
+              onDrop={handleFolderDrop}
+              onToggleOptions={handleToggleFolderOptions}
+              onRenameFolder={handleOpenRenameFolder}
+              onDeleteFolder={handleDeleteFolder}
             />
           </div>
         </nav>
@@ -488,35 +476,31 @@ export function Sidebar({
         />
       </aside>
 
-      {isCreateFolderModalOpen ? (
+      {folderNameModal ? (
         <FolderNameModal
-          title={t("createFolder")}
-          closeLabel={t("closeCreateFolder")}
+          title={t(
+            folderNameModal.mode === "create" ? "createFolder" : "renameFolder",
+          )}
+          closeLabel={t(
+            folderNameModal.mode === "create"
+              ? "closeCreateFolder"
+              : "closeRenameFolder",
+          )}
           fieldLabel={t("folderName")}
           placeholder={t("folderNamePlaceholder")}
-          confirmLabel={t("create")}
+          confirmLabel={t(
+            folderNameModal.mode === "create" ? "create" : "change",
+          )}
           cancelLabel={t("cancel")}
-          value={newFolderName}
-          inputRef={inputRef}
-          onChange={setNewFolderName}
-          onClose={closeCreateModal}
-          onConfirm={handleCreateFolder}
-        />
-      ) : null}
-
-      {isRenameFolderModalOpen ? (
-        <FolderNameModal
-          title={t("renameFolder")}
-          closeLabel={t("closeRenameFolder")}
-          fieldLabel={t("folderName")}
-          placeholder={t("folderNamePlaceholder")}
-          confirmLabel={t("change")}
-          cancelLabel={t("cancel")}
-          value={renameFolderName}
-          inputRef={renameInputRef}
-          onChange={setRenameFolderName}
-          onClose={closeRenameModal}
-          onConfirm={handleRenameFolder}
+          value={folderNameModal.value}
+          inputRef={folderNameInputRef}
+          onChange={(value) =>
+            setFolderNameModal((current) =>
+              current ? { ...current, value } : current,
+            )
+          }
+          onClose={closeFolderNameModal}
+          onConfirm={handleSubmitFolderName}
         />
       ) : null}
     </>

--- a/src/features/folder/ui/SidebarPrimaryNav.tsx
+++ b/src/features/folder/ui/SidebarPrimaryNav.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 
+// 즐겨찾기, 최근 항목, 휴지통으로 이동하는 주요 탐색 링크를 표시합니다.
 interface SidebarNavItem {
   href: string;
   label: string;
@@ -26,6 +27,7 @@ export function SidebarPrimaryNav({
           <Link
             href={item.href}
             onClick={onNavigate}
+            aria-current={pathname === item.href ? "page" : undefined}
             className={`flex items-center gap-3 rounded-lg px-2 py-2 text-sm font-medium transition-colors ${
               pathname === item.href
                 ? "text-foreground bg-(--surface)"

--- a/src/features/landing/ui/LandingFeaturesSection.tsx
+++ b/src/features/landing/ui/LandingFeaturesSection.tsx
@@ -1,5 +1,6 @@
 import type { IconType } from "react-icons";
 
+// 랜딩 페이지에서 제품의 핵심 기능을 반복 가능한 카드 목록으로 소개합니다.
 interface LandingFeature {
   key: string;
   title: string;
@@ -9,6 +10,22 @@ interface LandingFeature {
 
 interface LandingFeaturesSectionProps {
   features: readonly LandingFeature[];
+}
+
+function LandingFeatureCard({ feature }: { feature: LandingFeature }) {
+  const Icon = feature.icon;
+
+  return (
+    <article className="rounded-2xl border border-(--border) bg-(--surface-muted) p-6 transition-transform hover:-translate-y-1">
+      <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--landing-brand-bg)] text-[var(--landing-brand-fg)]">
+        <Icon className="h-6 w-6" aria-hidden />
+      </div>
+      <h3 className="text-lg font-semibold">{feature.title}</h3>
+      <p className="mt-2 text-sm leading-relaxed text-(--muted)">
+        {feature.description}
+      </p>
+    </article>
+  );
 }
 
 export function LandingFeaturesSection({
@@ -27,24 +44,9 @@ export function LandingFeaturesSection({
         </div>
 
         <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
-          {features.map((feature) => {
-            const Icon = feature.icon;
-
-            return (
-              <div
-                key={feature.key}
-                className="rounded-2xl border border-(--border) bg-(--surface-muted) p-6 transition-transform hover:-translate-y-1"
-              >
-                <div className="mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--landing-brand-bg)] text-[var(--landing-brand-fg)]">
-                  <Icon className="h-6 w-6" />
-                </div>
-                <h3 className="text-lg font-semibold">{feature.title}</h3>
-                <p className="mt-2 text-sm leading-relaxed text-(--muted)">
-                  {feature.description}
-                </p>
-              </div>
-            );
-          })}
+          {features.map((feature) => (
+            <LandingFeatureCard key={feature.key} feature={feature} />
+          ))}
         </div>
       </div>
     </section>

--- a/src/features/landing/ui/LandingFinalCtaSection.tsx
+++ b/src/features/landing/ui/LandingFinalCtaSection.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+// 랜딩 페이지 마지막에서 로그인과 데모로 이어지는 핵심 액션을 강조합니다.
 export function LandingFinalCtaSection() {
   return (
     <section className="border-t border-(--border) bg-[var(--landing-brand-bg)] py-24 text-[color:var(--landing-brand-fg)]">

--- a/src/features/landing/ui/LandingFooter.tsx
+++ b/src/features/landing/ui/LandingFooter.tsx
@@ -1,6 +1,7 @@
 import { FaGithub } from "react-icons/fa";
 import { HiOutlineMail } from "react-icons/hi";
 
+// 저작권 정보와 프로젝트 및 문의 링크를 제공하는 마케팅 푸터입니다.
 interface LandingFooterProps {
   currentYear: number;
 }
@@ -19,7 +20,7 @@ export function LandingFooter({ currentYear }: LandingFooterProps) {
             className="flex items-center gap-2 transition-colors hover:text-(--foreground)"
             aria-label="EasyClip GitHub 저장소"
           >
-            <FaGithub className="h-4 w-4" />
+            <FaGithub className="h-4 w-4" aria-hidden />
             <span>GitHub</span>
           </a>
 
@@ -27,7 +28,7 @@ export function LandingFooter({ currentYear }: LandingFooterProps) {
             href="mailto:medic6655@gmail.com"
             className="flex items-center gap-2 transition-colors hover:text-(--foreground)"
           >
-            <HiOutlineMail className="h-4 w-4" />
+            <HiOutlineMail className="h-4 w-4" aria-hidden />
             <span>medic6655@gmail.com</span>
           </a>
         </div>

--- a/src/features/landing/ui/LandingHeader.tsx
+++ b/src/features/landing/ui/LandingHeader.tsx
@@ -7,6 +7,7 @@ import {
 
 export type LandingHeaderTab = "home" | "pricing";
 
+// 마케팅 페이지의 브랜드 탐색, 요금제 이동, 테마 전환 액션을 제공합니다.
 interface LandingHeaderProps {
   activeTab?: LandingHeaderTab;
   isDarkMode: boolean;
@@ -34,7 +35,8 @@ export function LandingHeader({
         >
           <Link
             href="/pricing"
-            className={`inline-flex items-center px-1 py-2 text-sm font-medium transition-colors`}
+            className="inline-flex items-center px-1 py-2 text-sm font-medium transition-colors"
+            aria-current={activeTab === "pricing" ? "page" : undefined}
           >
             <span
               className={`${
@@ -50,14 +52,15 @@ export function LandingHeader({
 
         <div className="order-2 flex items-center gap-3 md:order-3">
           <button
+            type="button"
             onClick={onToggleTheme}
             className="flex h-10 w-10 cursor-pointer items-center justify-center rounded-full text-(--muted) transition-colors hover:bg-(--surface-muted) hover:text-(--foreground)"
             aria-label="다크 모드 전환"
           >
             {isDarkMode ? (
-              <HiOutlineSun className="h-5 w-5" />
+              <HiOutlineSun className="h-5 w-5" aria-hidden />
             ) : (
-              <HiOutlineMoon className="h-5 w-5" />
+              <HiOutlineMoon className="h-5 w-5" aria-hidden />
             )}
           </button>
 

--- a/src/features/landing/ui/LandingHeroSection.tsx
+++ b/src/features/landing/ui/LandingHeroSection.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
+import { HiOutlinePlay, HiOutlineSwitchHorizontal } from "react-icons/hi";
 
+// 핵심 가치와 진입 액션, 기기 간 동기화 데모를 첫 화면에 표시합니다.
 interface LandingHeroSectionProps {
   demoItems: readonly string[];
   mobileDemoItems: readonly string[];
@@ -34,7 +36,7 @@ export function LandingHeroSection({
             href="/favorites"
             className="flex items-center gap-2 rounded-xl border border-(--border) px-7 py-3.5 text-sm font-semibold transition-colors hover:bg-(--surface-muted)"
           >
-            <span aria-hidden>▷</span>
+            <HiOutlinePlay className="h-4 w-4" aria-hidden />
             <span className="text-(--foreground)">데모 보기</span>
           </Link>
         </div>
@@ -72,19 +74,10 @@ export function LandingHeroSection({
         </div>
 
         <div className="absolute top-1/2 left-1/2 z-10 flex h-14 w-14 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-[var(--landing-brand-bg)] shadow-[var(--landing-shadow)] md:static md:translate-x-0 md:translate-y-0">
-          <svg
+          <HiOutlineSwitchHorizontal
             className="h-6 w-6 text-[var(--landing-brand-fg)]"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4"
-            />
-          </svg>
+            aria-hidden
+          />
         </div>
 
         <div className="hidden h-72 w-40 overflow-hidden rounded-3xl border border-(--border) bg-[var(--landing-demo-surface)] shadow-[var(--landing-shadow)] md:block">

--- a/src/features/landing/ui/LandingPage.tsx
+++ b/src/features/landing/ui/LandingPage.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { LandingFeaturesSection } from "@/features/landing/ui/LandingFeaturesSection";
 import { LandingFinalCtaSection } from "@/features/landing/ui/LandingFinalCtaSection";
 import { LandingHeroSection } from "@/features/landing/ui/LandingHeroSection";
@@ -14,6 +12,7 @@ import {
   LANDING_WORKFLOW_STEPS,
 } from "../const/landingContent";
 
+// 랜딩 화면의 마케팅 섹션을 사용자 흐름 순서대로 조합합니다.
 export function LandingPage() {
   return (
     <MarketingShell activeTab="home">

--- a/src/features/landing/ui/LandingReviewsBanner.tsx
+++ b/src/features/landing/ui/LandingReviewsBanner.tsx
@@ -1,3 +1,4 @@
+// 사용자 후기를 연속 배너 형태로 반복 노출합니다.
 interface LandingReview {
   quote: string;
   name: string;
@@ -7,6 +8,28 @@ interface LandingReview {
 
 interface LandingReviewsBannerProps {
   reviews: readonly LandingReview[];
+}
+
+function LandingReviewCard({ review }: { review: LandingReview }) {
+  return (
+    <article className="flex min-h-52 w-[20rem] shrink-0 flex-col justify-between rounded-[1.75rem] border border-(--border) bg-(--surface) p-6 md:w-[22rem]">
+      <p className="text-base leading-8 font-medium tracking-[-0.01em] text-(--foreground)">
+        &ldquo;{review.quote}&rdquo;
+      </p>
+
+      <div className="mt-6 flex items-center gap-4">
+        <div className="flex h-11 w-11 items-center justify-center rounded-full bg-(--surface-muted) text-sm font-semibold text-(--foreground)">
+          {review.avatar}
+        </div>
+        <div>
+          <p className="text-sm font-semibold text-(--foreground)">
+            {review.name}
+          </p>
+          <p className="mt-1 text-xs text-(--muted)">{review.role}</p>
+        </div>
+      </div>
+    </article>
+  );
 }
 
 export function LandingReviewsBanner({ reviews }: LandingReviewsBannerProps) {
@@ -35,28 +58,10 @@ export function LandingReviewsBanner({ reviews }: LandingReviewsBannerProps) {
                 className="flex shrink-0 gap-[var(--marquee-gap)]"
               >
                 {reviews.map((review, reviewIndex) => (
-                  <article
+                  <LandingReviewCard
                     key={`${groupIndex}-${review.name}-${reviewIndex}`}
-                    className="flex min-h-52 w-[20rem] shrink-0 flex-col justify-between rounded-[1.75rem] border border-(--border) bg-(--surface) p-6 md:w-[22rem]"
-                  >
-                    <p className="text-base leading-8 font-medium tracking-[-0.01em] text-(--foreground)">
-                      &ldquo;{review.quote}&rdquo;
-                    </p>
-
-                    <div className="mt-6 flex items-center gap-4">
-                      <div className="flex h-11 w-11 items-center justify-center rounded-full bg-(--surface-muted) text-sm font-semibold text-(--foreground)">
-                        {review.avatar}
-                      </div>
-                      <div>
-                        <p className="text-sm font-semibold text-(--foreground)">
-                          {review.name}
-                        </p>
-                        <p className="mt-1 text-xs text-(--muted)">
-                          {review.role}
-                        </p>
-                      </div>
-                    </div>
-                  </article>
+                    review={review}
+                  />
                 ))}
               </div>
             ))}

--- a/src/features/landing/ui/LandingWorkflowSection.tsx
+++ b/src/features/landing/ui/LandingWorkflowSection.tsx
@@ -1,3 +1,4 @@
+// 클립 저장부터 재사용까지의 제품 흐름을 단계별 카드로 설명합니다.
 interface LandingWorkflowStep {
   step: string;
   title: string;
@@ -6,6 +7,37 @@ interface LandingWorkflowStep {
 
 interface LandingWorkflowSectionProps {
   steps: readonly LandingWorkflowStep[];
+}
+
+function LandingWorkflowStepCard({
+  index,
+  step,
+}: {
+  index: number;
+  step: LandingWorkflowStep;
+}) {
+  return (
+    <article className="relative overflow-hidden rounded-[2rem] border border-(--border) bg-(--background) p-7">
+      <div className="absolute top-0 right-0 h-28 w-28 rounded-full bg-(--surface-muted) blur-2xl" />
+      <div className="relative">
+        <div className="flex items-center justify-between">
+          <span className="rounded-full bg-(--surface-muted) px-3 py-1 text-xs font-semibold tracking-[0.16em] text-(--muted) uppercase">
+            {step.step}
+          </span>
+          <span className="text-4xl font-semibold tracking-tight text-(--border)">
+            0{index + 1}
+          </span>
+        </div>
+
+        <h3 className="mt-10 text-2xl font-semibold tracking-tight">
+          {step.title}
+        </h3>
+        <p className="mt-4 text-sm leading-7 text-(--muted) md:text-base">
+          {step.description}
+        </p>
+      </div>
+    </article>
+  );
 }
 
 export function LandingWorkflowSection({ steps }: LandingWorkflowSectionProps) {
@@ -24,29 +56,11 @@ export function LandingWorkflowSection({ steps }: LandingWorkflowSectionProps) {
 
         <div className="mt-14 grid gap-6 lg:grid-cols-3">
           {steps.map((step, index) => (
-            <article
+            <LandingWorkflowStepCard
               key={step.step}
-              className="relative overflow-hidden rounded-[2rem] border border-(--border) bg-(--background) p-7"
-            >
-              <div className="absolute top-0 right-0 h-28 w-28 rounded-full bg-(--surface-muted) blur-2xl" />
-              <div className="relative">
-                <div className="flex items-center justify-between">
-                  <span className="rounded-full bg-(--surface-muted) px-3 py-1 text-xs font-semibold tracking-[0.16em] text-(--muted) uppercase">
-                    {step.step}
-                  </span>
-                  <span className="text-4xl font-semibold tracking-tight text-(--border)">
-                    0{index + 1}
-                  </span>
-                </div>
-
-                <h3 className="mt-10 text-2xl font-semibold tracking-tight">
-                  {step.title}
-                </h3>
-                <p className="mt-4 text-sm leading-7 text-(--muted) md:text-base">
-                  {step.description}
-                </p>
-              </div>
-            </article>
+              index={index}
+              step={step}
+            />
           ))}
         </div>
       </div>

--- a/src/features/landing/ui/MarketingShell.tsx
+++ b/src/features/landing/ui/MarketingShell.tsx
@@ -7,6 +7,7 @@ import {
 } from "@/features/landing/ui/LandingHeader";
 import { useSettingsStore } from "@/shared/store/settingsStore";
 
+// 마케팅 페이지에 공통 헤더, 테마 제어, 푸터를 제공하는 레이아웃입니다.
 interface MarketingShellProps {
   activeTab?: LandingHeaderTab;
   children: React.ReactNode;

--- a/src/features/pricing/ui/PricingCancelModal.tsx
+++ b/src/features/pricing/ui/PricingCancelModal.tsx
@@ -1,0 +1,47 @@
+import { Button } from "@/shared/ui/button/Button";
+import { Modal } from "@/shared/ui/overlay/Modal";
+
+// Pro 구독 취소 의사를 확인하고 진행 상태에 따라 액션을 제어합니다.
+interface PricingCancelModalProps {
+  isCanceling: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function PricingCancelModal({
+  isCanceling,
+  onCancel,
+  onConfirm,
+}: PricingCancelModalProps) {
+  return (
+    <Modal overlay="strong" contentClassName="w-full max-w-sm">
+      <div className="rounded-2xl border border-(--border) bg-(--surface-elevated) p-5 shadow-xl">
+        <h2 className="text-lg font-semibold">Pro 구독을 취소할까요?</h2>
+        <p className="mt-3 text-sm leading-6 text-(--muted)">
+          확인을 누르면 Pro 구독의 자동 갱신이 중지되고 Free 플랜으로
+          전환됩니다.
+        </p>
+        <div className="mt-6 flex gap-2">
+          <Button
+            onClick={onCancel}
+            disabled={isCanceling}
+            variant="secondary"
+            size="lg"
+            className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            아니오
+          </Button>
+          <Button
+            onClick={onConfirm}
+            disabled={isCanceling}
+            variant="primary"
+            size="lg"
+            className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isCanceling ? "변경 중" : "예"}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/features/pricing/ui/PricingComparisonSection.tsx
+++ b/src/features/pricing/ui/PricingComparisonSection.tsx
@@ -1,5 +1,6 @@
 import { PRICING_COMPARISON_POINTS } from "@/features/pricing/const/pricingContent";
 
+// Free와 Pro 플랜의 핵심 차이를 접근 가능한 표로 비교합니다.
 export function PricingComparisonSection() {
   return (
     <section
@@ -35,7 +36,11 @@ export function PricingComparisonSection() {
               {PRICING_COMPARISON_POINTS.map((point, index) => (
                 <tr
                   key={point.label}
-                  className={index % 2 === 0 ? "bg-(--surface)" : "bg-[var(--landing-demo-surface)]"}
+                  className={
+                    index % 2 === 0
+                      ? "bg-(--surface)"
+                      : "bg-[var(--landing-demo-surface)]"
+                  }
                 >
                   <th className="border-t border-(--border) px-5 py-4 text-left text-sm font-medium text-(--foreground)">
                     {point.label}

--- a/src/features/pricing/ui/PricingHeroSection.tsx
+++ b/src/features/pricing/ui/PricingHeroSection.tsx
@@ -1,5 +1,6 @@
 import { HiOutlineSparkles } from "react-icons/hi";
 
+// 요금제 페이지의 목적과 선택 안내를 첫 영역에 표시합니다.
 export function PricingHeroSection() {
   return (
     <div className="mx-auto max-w-3xl text-center">
@@ -10,7 +11,7 @@ export function PricingHeroSection() {
           border: "1px solid var(--pricing-chip-border)",
         }}
       >
-        <HiOutlineSparkles className="h-4 w-4" />
+        <HiOutlineSparkles className="h-4 w-4" aria-hidden />
         <span>Simple plans for focused users</span>
       </div>
 

--- a/src/features/pricing/ui/PricingPage.tsx
+++ b/src/features/pricing/ui/PricingPage.tsx
@@ -3,6 +3,7 @@ import { PricingComparisonSection } from "@/features/pricing/ui/PricingCompariso
 import { PricingHeroSection } from "@/features/pricing/ui/PricingHeroSection";
 import { PricingPlansSection } from "@/features/pricing/ui/PricingPlansSection";
 
+// 인증 상태를 준비하고 요금제 소개, 플랜 선택, 비교 섹션을 조합합니다.
 export function PricingPage() {
   return (
     <section className="relative overflow-hidden">

--- a/src/features/pricing/ui/PricingPlanCard.tsx
+++ b/src/features/pricing/ui/PricingPlanCard.tsx
@@ -1,0 +1,130 @@
+import type { ReactNode } from "react";
+import { HiCheck } from "react-icons/hi";
+import type { PricingPlan } from "@/features/pricing/const/pricingContent";
+import { Badge } from "@/shared/ui/badge/Badge";
+
+// 요금제의 가격, 기능 목록, 현재 상태와 액션을 하나의 비교 카드로 표시합니다.
+interface PricingPlanCardProps {
+  action: ReactNode;
+  plan: PricingPlan;
+  status?: ReactNode;
+}
+
+export function PricingPlanCard({
+  action,
+  plan,
+  status,
+}: PricingPlanCardProps) {
+  return (
+    <article
+      className={`relative overflow-hidden rounded-2xl border px-5 py-6 transition-transform duration-300 hover:-translate-y-1 sm:rounded-[2rem] sm:px-8 sm:py-8 ${
+        plan.highlight
+          ? "border-transparent text-white"
+          : "border-(--border) bg-(--surface)"
+      }`}
+      style={{
+        boxShadow: "var(--pricing-card-shadow)",
+        background: plan.highlight ? "var(--pricing-featured-bg)" : undefined,
+      }}
+    >
+      {plan.highlight ? (
+        <div className="absolute inset-x-8 top-0 h-px bg-[linear-gradient(90deg,rgba(255,255,255,0),rgba(255,255,255,0.92),rgba(255,255,255,0))]" />
+      ) : null}
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <p
+            className={`text-sm font-medium ${
+              plan.highlight
+                ? "text-[var(--pricing-featured-muted)]"
+                : "text-(--muted)"
+            }`}
+          >
+            {plan.badge}
+          </p>
+          <h2 className="mt-3 text-2xl font-semibold sm:text-3xl">
+            {plan.name}
+          </h2>
+        </div>
+        {plan.highlight ? (
+          <Badge
+            variant="featured"
+            size="sm"
+            style={{ backgroundColor: "var(--pricing-featured-badge)" }}
+          >
+            Recommended
+          </Badge>
+        ) : null}
+      </div>
+
+      <p
+        className={`mt-5 text-sm leading-6 sm:text-base sm:leading-7 ${
+          plan.highlight
+            ? "text-[var(--pricing-featured-text)]"
+            : "text-(--muted)"
+        }`}
+      >
+        {plan.description}
+      </p>
+
+      <div className="mt-8 flex items-end gap-2">
+        <span className="text-4xl font-semibold tracking-tight sm:text-5xl">
+          {plan.price}
+        </span>
+        {plan.priceSuffix ? (
+          <span
+            className={`pb-1 text-sm ${
+              plan.highlight
+                ? "text-[var(--pricing-featured-text)]"
+                : "text-(--muted)"
+            }`}
+          >
+            {plan.priceSuffix}
+          </span>
+        ) : null}
+      </div>
+
+      <p
+        className={`mt-2 text-sm ${
+          plan.highlight
+            ? "text-[var(--pricing-featured-text)]"
+            : "text-(--muted)"
+        }`}
+      >
+        {plan.billingNote}
+      </p>
+
+      {action}
+      {status}
+
+      <ul className="mt-8 space-y-4">
+        {plan.features.map((feature) => (
+          <li key={feature} className="flex items-start gap-3">
+            <span
+              className={`mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
+                plan.highlight ? "bg-white/12 text-white" : ""
+              }`}
+              style={
+                plan.highlight
+                  ? { backgroundColor: "var(--pricing-featured-badge)" }
+                  : {
+                      backgroundColor: "var(--pricing-check-bg)",
+                      color: "var(--pricing-check-fg)",
+                    }
+              }
+            >
+              <HiCheck className="h-4 w-4" aria-hidden />
+            </span>
+            <span
+              className={`text-sm leading-6 ${
+                plan.highlight ? "text-white" : "text-(--foreground)"
+              }`}
+            >
+              {feature}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </article>
+  );
+}

--- a/src/features/pricing/ui/PricingPlansSection.tsx
+++ b/src/features/pricing/ui/PricingPlansSection.tsx
@@ -4,8 +4,12 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
-import { HiCheck } from "react-icons/hi";
-import { PRICING_PLANS } from "@/features/pricing/const/pricingContent";
+import {
+  PRICING_PLANS,
+  type PricingPlan,
+} from "@/features/pricing/const/pricingContent";
+import { PricingCancelModal } from "@/features/pricing/ui/PricingCancelModal";
+import { PricingPlanCard } from "@/features/pricing/ui/PricingPlanCard";
 import {
   fetchMySubscription,
   updateMySubscription,
@@ -16,11 +20,21 @@ import {
   isActiveProSubscription,
 } from "@/features/subscription/model/subscription";
 import { notifyError, notifySuccess } from "@/shared/feedback/toast";
-import { Badge } from "@/shared/ui/badge/Badge";
-import { Button } from "@/shared/ui/button/Button";
-import { Modal } from "@/shared/ui/overlay/Modal";
 import { ApiError } from "@/shared/lib/apiClient";
+import { Button } from "@/shared/ui/button/Button";
 
+const formatSubscriptionDate = (value: string | null) => {
+  if (!value) {
+    return "-";
+  }
+
+  return new Intl.DateTimeFormat("ko-KR", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+};
+
+// 구독 상태에 맞는 요금제 카드 액션과 취소 흐름을 조합합니다.
 export function PricingPlansSection() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -34,17 +48,6 @@ export function PricingPlansSection() {
   const [isResumingSubscription, setIsResumingSubscription] = useState(false);
   const isCurrentProPlan = isActiveProSubscription(subscription);
   const isResumableProPlan = hasRemainingCanceledProPeriod(subscription);
-
-  const formatSubscriptionDate = (value: string | null) => {
-    if (!value) {
-      return "-";
-    }
-
-    return new Intl.DateTimeFormat("ko-KR", {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  };
 
   const handleCancelSubscription = async () => {
     if (isCancelingSubscription) {
@@ -99,248 +102,123 @@ export function PricingPlansSection() {
     }
   };
 
+  const renderPlanAction = (plan: PricingPlan) => {
+    const isFreePlan = !plan.highlight;
+    const isCurrentFreePlan =
+      isAuthenticated && isFreePlan && subscription?.plan === "FREE";
+    const isCurrentProPlanCard =
+      isAuthenticated && plan.highlight && isCurrentProPlan;
+    const isResumeTargetPlan =
+      isAuthenticated && plan.highlight && isResumableProPlan;
+
+    if (isCurrentFreePlan || isCurrentProPlanCard) {
+      return (
+        <Button
+          disabled
+          variant="secondaryMuted"
+          size="lg"
+          fullWidth
+          className="mt-8 cursor-not-allowed rounded-2xl font-semibold text-(--muted) disabled:cursor-not-allowed disabled:opacity-100"
+        >
+          현재 플랜
+        </Button>
+      );
+    }
+
+    if (isResumeTargetPlan) {
+      return (
+        <Button
+          onClick={() => {
+            void handleResumeSubscription();
+          }}
+          disabled={isResumingSubscription}
+          variant="pricingFeatured"
+          size="lg"
+          fullWidth
+          className="mt-8 rounded-2xl font-semibold transition-[opacity,transform] duration-200 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {isResumingSubscription ? "재개 중" : "구독 재개"}
+        </Button>
+      );
+    }
+
+    if (isAuthenticated && isFreePlan && isCurrentProPlan) {
+      return (
+        <Button
+          onClick={() => setIsCancelModalOpen(true)}
+          variant="secondaryMuted"
+          size="lg"
+          fullWidth
+          className="mt-8 rounded-2xl font-semibold"
+        >
+          Free로 전환하기
+        </Button>
+      );
+    }
+
+    return (
+      <Link
+        href={plan.ctaHref}
+        className={`mt-8 inline-flex w-full cursor-pointer items-center justify-center rounded-2xl px-5 py-3 text-sm font-semibold transition-[background-color,opacity,transform] duration-200 hover:opacity-90 ${
+          plan.highlight
+            ? "bg-(--pricing-button-featured-bg) text-(--pricing-button-featured-fg) hover:bg-(--pricing-button-featured-bg-hover)"
+            : "bg-(--pricing-button-bg) text-(--pricing-button-fg) hover:bg-(--pricing-button-bg-hover)"
+        }`}
+      >
+        <span>{plan.ctaLabel}</span>
+      </Link>
+    );
+  };
+
+  const renderPlanStatus = (plan: PricingPlan) => {
+    if (!plan.highlight || (!isCurrentProPlan && !isResumableProPlan)) {
+      return null;
+    }
+
+    const renewalLabel = isCurrentProPlan
+      ? subscription?.autoRenew
+        ? "자동갱신 활성화됨"
+        : "자동갱신 비활성화됨"
+      : "자동갱신 중지됨";
+    const billingDateLabel = isCurrentProPlan ? "다음 결제일" : "이용 종료일";
+    const billingDateValue = isCurrentProPlan
+      ? subscription?.nextBillingAt
+      : subscription?.currentPeriodEnd;
+
+    return (
+      <div className="mt-4 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm text-white">
+        <p className="font-semibold">현재 PRO 이용 중</p>
+        <p className="mt-1 text-[var(--pricing-featured-text)]">
+          {renewalLabel}
+        </p>
+        <p className="mt-1 text-[var(--pricing-featured-text)]">
+          {billingDateLabel}: {formatSubscriptionDate(billingDateValue ?? null)}
+        </p>
+      </div>
+    );
+  };
+
   return (
     <>
       <div className="mt-10 grid gap-4 sm:mt-12 sm:gap-6 lg:mt-16 lg:grid-cols-[0.95fr_1.05fr]">
-        {PRICING_PLANS.map((plan) => {
-          const isFreePlan = !plan.highlight;
-          const isCurrentFreePlan =
-            isAuthenticated && isFreePlan && subscription?.plan === "FREE";
-          const isCurrentProPlanCard =
-            isAuthenticated && plan.highlight && isCurrentProPlan;
-          const isResumeTargetPlan =
-            isAuthenticated && plan.highlight && isResumableProPlan;
-          const proStatusLabel = isCurrentProPlan
-            ? "현재 PRO 이용 중"
-            : isResumableProPlan
-              ? "현재 PRO 이용 중"
-              : null;
-          const proRenewalLabel = isCurrentProPlan
-            ? subscription?.autoRenew
-              ? "자동갱신 활성화됨"
-              : "자동갱신 비활성화됨"
-            : isResumableProPlan
-              ? "자동갱신 중지됨"
-              : null;
-          const proBillingDateLabel = isCurrentProPlan
-            ? "다음 결제일"
-            : isResumableProPlan
-              ? "이용 종료일"
-              : null;
-          const proBillingDateValue = isCurrentProPlan
-            ? subscription?.nextBillingAt
-            : isResumableProPlan
-              ? subscription?.currentPeriodEnd
-              : null;
-
-          return (
-            <article
-              key={plan.name}
-              className={`relative overflow-hidden rounded-2xl border px-5 py-6 transition-transform duration-300 hover:-translate-y-1 sm:rounded-[2rem] sm:px-8 sm:py-8 ${
-                plan.highlight
-                  ? "border-transparent text-white"
-                  : "border-(--border) bg-(--surface)"
-              }`}
-              style={{
-                boxShadow: "var(--pricing-card-shadow)",
-                background: plan.highlight
-                  ? "var(--pricing-featured-bg)"
-                  : undefined,
-              }}
-            >
-              {plan.highlight ? (
-                <div className="absolute inset-x-8 top-0 h-px bg-[linear-gradient(90deg,rgba(255,255,255,0),rgba(255,255,255,0.92),rgba(255,255,255,0))]" />
-              ) : null}
-
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p
-                    className={`text-sm font-medium ${
-                      plan.highlight
-                        ? "text-[var(--pricing-featured-muted)]"
-                        : "text-(--muted)"
-                    }`}
-                  >
-                    {plan.badge}
-                  </p>
-                  <h2 className="mt-3 text-2xl font-semibold sm:text-3xl">
-                    {plan.name}
-                  </h2>
-                </div>
-                {plan.highlight ? (
-                  <Badge
-                    variant="featured"
-                    size="sm"
-                    style={{ backgroundColor: "var(--pricing-featured-badge)" }}
-                  >
-                    Recommended
-                  </Badge>
-                ) : null}
-              </div>
-
-              <p
-                className={`mt-5 text-sm leading-6 sm:text-base sm:leading-7 ${
-                  plan.highlight
-                    ? "text-[var(--pricing-featured-text)]"
-                    : "text-(--muted)"
-                }`}
-              >
-                {plan.description}
-              </p>
-
-              <div className="mt-8 flex items-end gap-2">
-                <span className="text-4xl font-semibold tracking-tight sm:text-5xl">
-                  {plan.price}
-                </span>
-                {plan.priceSuffix ? (
-                  <span
-                    className={`pb-1 text-sm ${
-                      plan.highlight
-                        ? "text-[var(--pricing-featured-text)]"
-                        : "text-(--muted)"
-                    }`}
-                  >
-                    {plan.priceSuffix}
-                  </span>
-                ) : null}
-              </div>
-
-              <p
-                className={`mt-2 text-sm ${
-                  plan.highlight
-                    ? "text-[var(--pricing-featured-text)]"
-                    : "text-(--muted)"
-                }`}
-              >
-                {plan.billingNote}
-              </p>
-
-              {isCurrentFreePlan || isCurrentProPlanCard ? (
-                <Button
-                  disabled
-                  variant="secondaryMuted"
-                  size="lg"
-                  fullWidth
-                  className="mt-8 cursor-not-allowed rounded-2xl font-semibold text-(--muted) disabled:cursor-not-allowed disabled:opacity-100"
-                >
-                  현재 플랜
-                </Button>
-              ) : isResumeTargetPlan ? (
-                <Button
-                  onClick={() => {
-                    void handleResumeSubscription();
-                  }}
-                  disabled={isResumingSubscription}
-                  variant="pricingFeatured"
-                  size="lg"
-                  fullWidth
-                  className="mt-8 rounded-2xl font-semibold transition-[opacity,transform] duration-200 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
-                >
-                  {isResumingSubscription ? "재개 중" : "구독 재개"}
-                </Button>
-              ) : isAuthenticated && isFreePlan && isCurrentProPlan ? (
-                <Button
-                  onClick={() => setIsCancelModalOpen(true)}
-                  variant="secondaryMuted"
-                  size="lg"
-                  fullWidth
-                  className="mt-8 rounded-2xl font-semibold"
-                >
-                  Free로 전환하기
-                </Button>
-              ) : (
-                <Link
-                  href={plan.ctaHref}
-                  className={`mt-8 inline-flex w-full cursor-pointer items-center justify-center rounded-2xl px-5 py-3 text-sm font-semibold transition-[background-color,opacity,transform] duration-200 hover:opacity-90 ${
-                    plan.highlight
-                      ? "bg-(--pricing-button-featured-bg) text-(--pricing-button-featured-fg) hover:bg-(--pricing-button-featured-bg-hover)"
-                      : "bg-(--pricing-button-bg) text-(--pricing-button-fg) hover:bg-(--pricing-button-bg-hover)"
-                  }`}
-                >
-                  <span>{plan.ctaLabel}</span>
-                </Link>
-              )}
-
-              {plan.highlight && proStatusLabel ? (
-                <div className="mt-4 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm text-white">
-                  <p className="font-semibold">{proStatusLabel}</p>
-                  <p className="mt-1 text-[var(--pricing-featured-text)]">
-                    {proRenewalLabel}
-                  </p>
-                  {proBillingDateLabel ? (
-                    <p className="mt-1 text-[var(--pricing-featured-text)]">
-                      {proBillingDateLabel}:{" "}
-                      {formatSubscriptionDate(proBillingDateValue ?? null)}
-                    </p>
-                  ) : null}
-                </div>
-              ) : null}
-
-              <ul className="mt-8 space-y-4">
-                {plan.features.map((feature) => (
-                  <li key={feature} className="flex items-start gap-3">
-                    <span
-                      className={`mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${
-                        plan.highlight ? "bg-white/12 text-white" : ""
-                      }`}
-                      style={
-                        plan.highlight
-                          ? { backgroundColor: "var(--pricing-featured-badge)" }
-                          : {
-                              backgroundColor: "var(--pricing-check-bg)",
-                              color: "var(--pricing-check-fg)",
-                            }
-                      }
-                    >
-                      <HiCheck className="h-4 w-4" />
-                    </span>
-                    <span
-                      className={`text-sm leading-6 ${
-                        plan.highlight ? "text-white" : "text-(--foreground)"
-                      }`}
-                    >
-                      {feature}
-                    </span>
-                  </li>
-                ))}
-              </ul>
-            </article>
-          );
-        })}
+        {PRICING_PLANS.map((plan) => (
+          <PricingPlanCard
+            key={plan.name}
+            plan={plan}
+            action={renderPlanAction(plan)}
+            status={renderPlanStatus(plan)}
+          />
+        ))}
       </div>
 
       {isCancelModalOpen ? (
-        <Modal overlay="strong" contentClassName="w-full max-w-sm">
-          <div className="rounded-2xl border border-(--border) bg-(--surface-elevated) p-5 shadow-xl">
-            <h2 className="text-lg font-semibold">Pro 구독을 취소할까요?</h2>
-            <p className="mt-3 text-sm leading-6 text-(--muted)">
-              확인을 누르면 Pro 구독의 자동 갱신이 중지되고 Free 플랜으로
-              전환됩니다.
-            </p>
-            <div className="mt-6 flex gap-2">
-              <Button
-                onClick={() => setIsCancelModalOpen(false)}
-                disabled={isCancelingSubscription}
-                variant="secondary"
-                size="lg"
-                className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                아니오
-              </Button>
-              <Button
-                onClick={() => {
-                  void handleCancelSubscription();
-                }}
-                disabled={isCancelingSubscription}
-                variant="primary"
-                size="lg"
-                className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {isCancelingSubscription ? "변경 중" : "예"}
-              </Button>
-            </div>
-          </div>
-        </Modal>
+        <PricingCancelModal
+          isCanceling={isCancelingSubscription}
+          onCancel={() => setIsCancelModalOpen(false)}
+          onConfirm={() => {
+            void handleCancelSubscription();
+          }}
+        />
       ) : null}
     </>
   );

--- a/src/features/settings/ui/SettingsAboutSection.tsx
+++ b/src/features/settings/ui/SettingsAboutSection.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { HiOutlineCreditCard } from "react-icons/hi";
+import type { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+import type { AppLocale } from "@/shared/config/locale";
+import { Text } from "@/shared/ui/typography/Text";
+
+// 앱 소개와 현재 구독의 플랜, 상태, 결제 예정 정보를 함께 표시합니다.
+interface SettingsAboutSectionProps {
+  errorMessage: string | null;
+  isLoading: boolean;
+  language: AppLocale;
+  subscription: MySubscriptionResponseDto | null | undefined;
+}
+
+export function SettingsAboutSection({
+  errorMessage,
+  isLoading,
+  language,
+  subscription,
+}: SettingsAboutSectionProps) {
+  const t = useTranslations("settings");
+
+  const formatNullableDate = (value: string | null) => {
+    if (!value) {
+      return t("subscriptionEmptyValue");
+    }
+
+    return new Intl.DateTimeFormat(language, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(value));
+  };
+
+  const formatSubscriptionStatus = (
+    status: MySubscriptionResponseDto["status"] | null | undefined,
+  ) => {
+    if (!status) {
+      return t("subscriptionEmptyValue");
+    }
+
+    return t(`subscriptionStatusValues.${status}`);
+  };
+
+  return (
+    <section>
+      <Text variant="sectionLabel">{t("about")}</Text>
+      <div className="mt-3 rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
+        <Text variant="itemTitle">{t("aboutTitle")}</Text>
+        <Text variant="caption">{t("aboutDescription")}</Text>
+      </div>
+      <div className="mt-3 rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
+            <HiOutlineCreditCard className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <Text variant="itemTitle" className="text-left">
+              {t("subscriptionTitle")}
+            </Text>
+            <dl className="mt-4 grid grid-cols-2 gap-3 text-left text-sm">
+              <div>
+                <Text as="dt" variant="caption">
+                  {t("subscriptionPlan")}
+                </Text>
+                <dd className="mt-1 font-semibold">
+                  {isLoading
+                    ? t("subscriptionLoading")
+                    : (subscription?.plan ?? t("subscriptionEmptyValue"))}
+                </dd>
+              </div>
+              <div>
+                <Text as="dt" variant="caption">
+                  {t("subscriptionStatus")}
+                </Text>
+                <dd className="mt-1 font-semibold">
+                  {isLoading
+                    ? t("subscriptionLoading")
+                    : formatSubscriptionStatus(subscription?.status)}
+                </dd>
+              </div>
+              <div>
+                <Text as="dt" variant="caption">
+                  {t("subscriptionNextBillingAt")}
+                </Text>
+                <dd className="mt-1 font-semibold">
+                  {formatNullableDate(subscription?.nextBillingAt ?? null)}
+                </dd>
+              </div>
+            </dl>
+            {errorMessage ? (
+              <Text variant="caption" className="mt-3">
+                {errorMessage}
+              </Text>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/features/settings/ui/SettingsModal.tsx
+++ b/src/features/settings/ui/SettingsModal.tsx
@@ -1,27 +1,19 @@
 "use client";
 
-// 사용자 설정 변경과 구독 정보를 표시하는 설정 도메인 모달입니다.
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import {
-  HiOutlineCog,
-  HiOutlineCreditCard,
-  HiOutlineMoon,
-  HiOutlineTranslate,
-  HiOutlineX,
-} from "react-icons/hi";
+import { HiOutlineCog, HiOutlineX } from "react-icons/hi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { persistUserSettings } from "@/features/settings/service/settingsService";
+import { SettingsAboutSection } from "@/features/settings/ui/SettingsAboutSection";
+import { SettingsPreferencesSection } from "@/features/settings/ui/SettingsPreferencesSection";
 import { useMySubscription } from "@/features/subscription/hooks/useMySubscription";
-import { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
-import { LOCALE_LABELS, type AppLocale } from "@/shared/config/locale";
+import type { AppLocale } from "@/shared/config/locale";
 import { useSettingsStore } from "@/shared/store/settingsStore";
 import { Button } from "@/shared/ui/button/Button";
-import { Select } from "@/shared/ui/input/Select";
-import { Switch } from "@/shared/ui/input/Switch";
 import { Modal } from "@/shared/ui/overlay/Modal";
-import { Text } from "@/shared/ui/typography/Text";
 
+// 사용자 설정 저장 상태를 관리하고 환경 설정과 구독 정보 섹션을 조합합니다.
 interface SettingsModalProps {
   onClose: () => void;
 }
@@ -35,7 +27,6 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
     null,
   );
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const subscription = subscriptionQuery.subscription;
   const isDark = theme === "dark";
   const isSubscriptionLoading = Boolean(
     session?.user && subscriptionQuery.isPending,
@@ -43,27 +34,6 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
   const subscriptionError = subscriptionQuery.isError
     ? t("subscriptionLoadError")
     : null;
-
-  const formatNullableDate = (value: string | null) => {
-    if (!value) {
-      return t("subscriptionEmptyValue");
-    }
-
-    return new Intl.DateTimeFormat(language, {
-      dateStyle: "medium",
-      timeStyle: "short",
-    }).format(new Date(value));
-  };
-
-  const formatSubscriptionStatus = (
-    status: MySubscriptionResponseDto["status"] | null | undefined,
-  ) => {
-    if (!status) {
-      return t("subscriptionEmptyValue");
-    }
-
-    return t(`subscriptionStatusValues.${status}`);
-  };
 
   const handleThemeToggle = async () => {
     const previousTheme = theme;
@@ -136,128 +106,33 @@ export function SettingsModal({ onClose }: SettingsModalProps) {
         </div>
 
         <div className="space-y-6 overflow-y-auto px-6 py-6">
-          <div>
-            <Text variant="sectionLabel">
-              {t("appearance")}
-            </Text>
-            <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
-              <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
-                  <HiOutlineMoon className="h-5 w-5" aria-hidden />
-                </div>
-                <div>
-                  <Text variant="itemTitle">{t("darkMode")}</Text>
-                  <Text variant="caption">
-                    {t("darkModeDescription")}
-                  </Text>
-                </div>
-              </div>
-              <Switch
-                checked={isDark}
-                onClick={() => {
-                  void handleThemeToggle();
-                }}
-                disabled={savingField === "theme"}
-                aria-label={t("toggleDarkMode")}
-              />
-            </div>
-          </div>
-
-          <div>
-            <Text variant="sectionLabel">
-              {t("general")}
-            </Text>
-            <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
-              <div className="flex items-center gap-3">
-                <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
-                  <HiOutlineTranslate className="h-5 w-5" aria-hidden />
-                </div>
-                <div>
-                  <Text variant="itemTitle">{t("language")}</Text>
-                  <Text variant="caption">
-                    {t("languageDescription")}
-                  </Text>
-                </div>
-              </div>
-              <Select
-                value={language}
-                onChange={(value) => {
-                  void handleLanguageChange(value as AppLocale);
-                }}
-                disabled={savingField === "language"}
-                options={Object.entries(LOCALE_LABELS).map(
-                  ([value, label]) => ({
-                    value,
-                    label,
-                  }),
-                )}
-                className="min-w-36"
-              />
-            </div>
-          </div>
+          <SettingsPreferencesSection
+            isDark={isDark}
+            language={language}
+            savingField={savingField}
+            onThemeToggle={() => {
+              void handleThemeToggle();
+            }}
+            onLanguageChange={(nextLanguage) => {
+              void handleLanguageChange(nextLanguage);
+            }}
+          />
 
           {errorMessage ? (
-            <p className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200">
+            <p
+              className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-200"
+              role="alert"
+            >
               {errorMessage}
             </p>
           ) : null}
 
-          <div>
-            <Text variant="sectionLabel">{t("about")}</Text>
-            <div className="mt-3 rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
-              <Text variant="itemTitle">{t("aboutTitle")}</Text>
-              <Text variant="caption">{t("aboutDescription")}</Text>
-            </div>
-            <div className="mt-3 rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
-              <div className="flex items-start gap-3">
-                <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
-                  <HiOutlineCreditCard className="h-5 w-5" aria-hidden />
-                </div>
-                <div className="min-w-0 flex-1">
-                  <Text variant="itemTitle" className="text-left">
-                    {t("subscriptionTitle")}
-                  </Text>
-                  <dl className="mt-4 grid grid-cols-2 gap-3 text-left text-sm">
-                    <div>
-                      <Text as="dt" variant="caption">
-                        {t("subscriptionPlan")}
-                      </Text>
-                      <dd className="mt-1 font-semibold">
-                        {isSubscriptionLoading
-                          ? t("subscriptionLoading")
-                          : (subscription?.plan ?? t("subscriptionEmptyValue"))}
-                      </dd>
-                    </div>
-                    <div>
-                      <Text as="dt" variant="caption">
-                        {t("subscriptionStatus")}
-                      </Text>
-                      <dd className="mt-1 font-semibold">
-                        {isSubscriptionLoading
-                          ? t("subscriptionLoading")
-                          : formatSubscriptionStatus(subscription?.status)}
-                      </dd>
-                    </div>
-                    <div>
-                      <Text as="dt" variant="caption">
-                        {t("subscriptionNextBillingAt")}
-                      </Text>
-                      <dd className="mt-1 font-semibold">
-                        {formatNullableDate(
-                          subscription?.nextBillingAt ?? null,
-                        )}
-                      </dd>
-                    </div>
-                  </dl>
-                  {subscriptionError ? (
-                    <Text variant="caption" className="mt-3">
-                      {subscriptionError}
-                    </Text>
-                  ) : null}
-                </div>
-              </div>
-            </div>
-          </div>
+          <SettingsAboutSection
+            subscription={subscriptionQuery.subscription}
+            isLoading={isSubscriptionLoading}
+            errorMessage={subscriptionError}
+            language={language}
+          />
         </div>
 
         <div className="flex items-center justify-end border-t border-(--border) px-6 py-4">

--- a/src/features/settings/ui/SettingsPreferencesSection.tsx
+++ b/src/features/settings/ui/SettingsPreferencesSection.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { HiOutlineMoon, HiOutlineTranslate } from "react-icons/hi";
+import { LOCALE_LABELS, type AppLocale } from "@/shared/config/locale";
+import { Select } from "@/shared/ui/input/Select";
+import { Switch } from "@/shared/ui/input/Switch";
+import { Text } from "@/shared/ui/typography/Text";
+
+// 테마와 언어 설정을 각각의 입력 컨트롤과 저장 상태로 표시합니다.
+interface SettingsPreferencesSectionProps {
+  isDark: boolean;
+  language: AppLocale;
+  onLanguageChange: (language: AppLocale) => void;
+  onThemeToggle: () => void;
+  savingField: "language" | "theme" | null;
+}
+
+export function SettingsPreferencesSection({
+  isDark,
+  language,
+  onLanguageChange,
+  onThemeToggle,
+  savingField,
+}: SettingsPreferencesSectionProps) {
+  const t = useTranslations("settings");
+
+  return (
+    <>
+      <section>
+        <Text variant="sectionLabel">{t("appearance")}</Text>
+        <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
+              <HiOutlineMoon className="h-5 w-5" aria-hidden />
+            </div>
+            <div>
+              <Text variant="itemTitle">{t("darkMode")}</Text>
+              <Text variant="caption">{t("darkModeDescription")}</Text>
+            </div>
+          </div>
+          <Switch
+            checked={isDark}
+            onClick={onThemeToggle}
+            disabled={savingField === "theme"}
+            aria-label={t("toggleDarkMode")}
+          />
+        </div>
+      </section>
+
+      <section>
+        <Text variant="sectionLabel">{t("general")}</Text>
+        <div className="mt-3 flex items-center justify-between rounded-xl border border-(--border) bg-(--modal-section-bg) px-4 py-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-(--modal-icon-bg) text-(--modal-icon-fg)">
+              <HiOutlineTranslate className="h-5 w-5" aria-hidden />
+            </div>
+            <div>
+              <Text variant="itemTitle">{t("language")}</Text>
+              <Text variant="caption">{t("languageDescription")}</Text>
+            </div>
+          </div>
+          <Select
+            value={language}
+            onChange={(value) => onLanguageChange(value as AppLocale)}
+            disabled={savingField === "language"}
+            options={Object.entries(LOCALE_LABELS).map(([value, label]) => ({
+              value,
+              label,
+            }))}
+            className="min-w-36"
+          />
+        </div>
+      </section>
+    </>
+  );
+}

--- a/src/features/subscription/ui/BillingCheckoutCard.tsx
+++ b/src/features/subscription/ui/BillingCheckoutCard.tsx
@@ -1,11 +1,12 @@
 import { HiOutlineRefresh } from "react-icons/hi";
-import { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
+import type { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
 import { BillingUnlockedFeatureList } from "@/features/subscription/ui/BillingUnlockedFeatureList";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 
 export type BillingStep = "idle" | "loading" | "redirecting" | "error";
 
+// Pro 요금과 제공 기능, 인증 정보, 결제 시작 상태를 하나의 카드로 표시합니다.
 interface BillingCheckoutCardProps {
   actionLabel: string;
   billingAuth: BillingAuthRequestResponseDto | null;
@@ -24,52 +25,53 @@ export function BillingCheckoutCard({
   const isProcessing = step === "loading" || step === "redirecting";
 
   return (
-    <div className="flex items-center">
-      <div className="w-full rounded-2xl border border-(--border) bg-(--surface-elevated) p-4 shadow-xl">
-        <div className="flex items-start justify-between gap-4 border-b border-(--border) pb-5">
-          <div>
-            <p className="text-sm font-medium text-(--muted)">EasyClip Pro</p>
-            <div className="mt-3 flex items-end gap-2">
-              <span className="text-3xl font-semibold">₩3,900</span>
-              <span className="pb-1 text-sm text-(--muted)">/ month</span>
-            </div>
+    <div className="w-full rounded-2xl border border-(--border) bg-(--surface-elevated) p-4 shadow-xl">
+      <div className="flex items-start justify-between gap-4 border-b border-(--border) pb-5">
+        <div>
+          <p className="text-sm font-medium text-(--muted)">EasyClip Pro</p>
+          <div className="mt-3 flex items-end gap-2">
+            <span className="text-3xl font-semibold">₩3,900</span>
+            <span className="pb-1 text-sm text-(--muted)">/ month</span>
           </div>
-          <Badge variant="muted" size="sm">월간</Badge>
         </div>
-
-        <BillingUnlockedFeatureList />
-
-        {billingAuth ? (
-          <div className="mt-4 rounded-xl border border-(--border) px-4 py-3 text-sm text-(--muted)">
-            <p className="font-medium text-(--foreground)">결제 인증 정보</p>
-            <p className="mt-1 break-all">
-              customerKey: {billingAuth.customerKey}
-            </p>
-          </div>
-        ) : null}
-
-        {message ? (
-          <p className="mt-4 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
-            {message}
-          </p>
-        ) : null}
-
-        <Button
-          onClick={() => {
-            onStartBilling();
-          }}
-          disabled={isProcessing}
-          variant="primary"
-          size="lg"
-          fullWidth
-          className="mt-5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          {isProcessing ? (
-            <HiOutlineRefresh className="h-4 w-4 animate-spin" aria-hidden />
-          ) : null}
-          {actionLabel}
-        </Button>
+        <Badge variant="muted" size="sm">
+          월간
+        </Badge>
       </div>
+
+      <BillingUnlockedFeatureList />
+
+      {billingAuth ? (
+        <div className="mt-4 rounded-xl border border-(--border) px-4 py-3 text-sm text-(--muted)">
+          <p className="font-medium text-(--foreground)">결제 인증 정보</p>
+          <p className="mt-1 break-all">
+            customerKey: {billingAuth.customerKey}
+          </p>
+        </div>
+      ) : null}
+
+      {message ? (
+        <p
+          className="mt-4 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300"
+          role="alert"
+        >
+          {message}
+        </p>
+      ) : null}
+
+      <Button
+        onClick={onStartBilling}
+        disabled={isProcessing}
+        variant="primary"
+        size="lg"
+        fullWidth
+        className="mt-5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isProcessing ? (
+          <HiOutlineRefresh className="h-4 w-4 animate-spin" aria-hidden />
+        ) : null}
+        {actionLabel}
+      </Button>
     </div>
   );
 }

--- a/src/features/subscription/ui/BillingHeroSection.tsx
+++ b/src/features/subscription/ui/BillingHeroSection.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { HiArrowLeft, HiOutlineCreditCard } from "react-icons/hi";
 
+// 요금제 복귀 링크와 Pro 업그레이드 목적을 결제 화면 상단에 안내합니다.
 export function BillingHeroSection() {
   return (
     <div className="flex flex-col justify-center">

--- a/src/features/subscription/ui/BillingPage.tsx
+++ b/src/features/subscription/ui/BillingPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/features/subscription/api/subscriptionApi";
 import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
 import { hasRemainingCanceledProPeriod } from "@/features/subscription/model/subscription";
-import { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
+import type { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
 import {
   invalidateMySubscriptionQueries,
   syncMySubscriptionQueryData,
@@ -81,6 +81,7 @@ const mapBillingAuthMethod = (
   method: BillingAuthRequestResponseDto["method"],
 ) => (method === "CARD" ? "카드" : method);
 
+// 구독 상태를 확인하고 Toss 카드 인증 진입과 오류 복구 UI를 조합합니다.
 export function BillingPage() {
   const router = useRouter();
   const queryClient = useQueryClient();
@@ -104,11 +105,7 @@ export function BillingPage() {
 
       if (hasRemainingCanceledProPeriod(currentSubscription)) {
         const nextSubscription = await updateMySubscription({ type: "RESUME" });
-        syncMySubscriptionQueryData(
-          queryClient,
-          nextSubscription,
-          userId,
-        );
+        syncMySubscriptionQueryData(queryClient, nextSubscription, userId);
         setStep("idle");
         setMessage("Pro 구독 자동갱신이 재개되었습니다.");
         router.push("/pricing");
@@ -143,7 +140,9 @@ export function BillingPage() {
       }
 
       if (error instanceof ApiError && error.status === 409) {
-        const latestSubscription = await fetchMySubscription().catch(() => null);
+        const latestSubscription = await fetchMySubscription().catch(
+          () => null,
+        );
 
         if (latestSubscription) {
           syncMySubscriptionQueryData(queryClient, latestSubscription, userId);

--- a/src/features/subscription/ui/BillingResultCard.tsx
+++ b/src/features/subscription/ui/BillingResultCard.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { HiCheckCircle, HiExclamationCircle } from "react-icons/hi";
 
+// 결제 승인 진행, 성공 또는 실패 상태와 다음 이동 액션을 표시합니다.
 interface BillingResultCardProps {
   isConfirming: boolean;
   isMissingSuccessParams: boolean;
@@ -40,18 +41,16 @@ export function BillingResultCard({
               : "결제 페이지에서 다시 시도해 주세요."))}
       </p>
 
-      <div className="mt-6 flex flex-col gap-2">
-        <Link
-          href={isSuccess ? "/recent" : "/billing"}
-          className="flex flex-1 cursor-pointer items-center justify-center rounded-xl bg-(--primary) px-4 py-3 text-sm font-semibold transition hover:bg-(--primary-hover)"
-        >
-          {isSuccess ? (
-            <span className="text-primary-foreground">앱으로 이동</span>
-          ) : (
-            <span className="text-primary-foreground">결제 다시 시도</span>
-          )}
-        </Link>
-      </div>
+      <Link
+        href={isSuccess ? "/recent" : "/billing"}
+        className="mt-6 flex cursor-pointer items-center justify-center rounded-xl bg-(--primary) px-4 py-3 text-sm font-semibold transition hover:bg-(--primary-hover)"
+      >
+        {isSuccess ? (
+          <span className="text-primary-foreground">앱으로 이동</span>
+        ) : (
+          <span className="text-primary-foreground">결제 다시 시도</span>
+        )}
+      </Link>
     </section>
   );
 }

--- a/src/features/subscription/ui/BillingResultPage.tsx
+++ b/src/features/subscription/ui/BillingResultPage.tsx
@@ -4,10 +4,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import Confetti from "react-confetti";
 import { confirmBillingAuth } from "@/features/subscription/api/subscriptionApi";
-import { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+import type { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
 import { syncMySubscriptionQueryData } from "@/features/subscription/service/subscriptionQueryCache";
 import { BillingResultCard } from "@/features/subscription/ui/BillingResultCard";
 
+// 결제 리다이렉트 결과를 서버에서 확정하고 성공 또는 실패 화면을 표시합니다.
 interface BillingResultPageProps {
   authKey?: string;
   customerKey?: string;

--- a/src/features/subscription/ui/BillingUnlockedFeatureList.tsx
+++ b/src/features/subscription/ui/BillingUnlockedFeatureList.tsx
@@ -8,9 +8,10 @@ const PRO_UNLOCKED_FEATURES = [
   "AI 기능 우선 제공 예정",
 ] as const;
 
+// Pro 구독으로 사용할 수 있는 기능을 체크 목록으로 안내합니다.
 export function BillingUnlockedFeatureList() {
   return (
-    <div className="mt-5 rounded-xl border border-(--border) bg-(--surface-muted) p-4">
+    <section className="mt-5 rounded-xl border border-(--border) bg-(--surface-muted) p-4">
       <p className="text-sm font-semibold">Pro 구독 시 해금되는 기능</p>
       <ul className="mt-4 space-y-3">
         {PRO_UNLOCKED_FEATURES.map((feature) => (
@@ -22,6 +23,6 @@ export function BillingUnlockedFeatureList() {
           </li>
         ))}
       </ul>
-    </div>
+    </section>
   );
 }

--- a/src/features/trash/ui/TrashListRow.tsx
+++ b/src/features/trash/ui/TrashListRow.tsx
@@ -7,7 +7,10 @@ import {
   HiOutlineFolder,
   HiOutlinePhotograph,
 } from "react-icons/hi";
-import { formatDeletedAt, TrashItemRow } from "@/features/trash/ui/trashRow";
+import {
+  formatDeletedAt,
+  type TrashItemRow,
+} from "@/features/trash/ui/trashRow";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 import { Checkbox } from "@/shared/ui/input/Checkbox";
@@ -22,6 +25,22 @@ interface TrashListRowProps {
   onDeleteFolder: (folderId: string) => void;
   onRestoreClip: (clipId: string) => void;
   onDeleteClip: (clipId: string) => void;
+}
+
+function TrashRowIcon({ row }: { row: TrashItemRow }) {
+  if (row.kind === "folder") {
+    return <HiOutlineFolder className="h-5 w-5" aria-hidden />;
+  }
+
+  if (row.clipType === "IMAGE") {
+    return <HiOutlinePhotograph className="h-5 w-5" aria-hidden />;
+  }
+
+  if (row.clipType === "COLOR") {
+    return <HiOutlineColorSwatch className="h-5 w-5" aria-hidden />;
+  }
+
+  return <HiOutlineDocumentText className="h-5 w-5" aria-hidden />;
 }
 
 // 휴지통 항목 하나를 파일/폴더 유형과 액션까지 포함해 한 줄로 렌더링하는 컴포넌트입니다.
@@ -57,15 +76,7 @@ export function TrashListRow({
         </div>
         <div className="flex min-w-0 items-center gap-3">
           <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-(--icon-chip) text-(--icon-chip-text)">
-            {row.kind === "folder" ? (
-              <HiOutlineFolder className="h-5 w-5" aria-hidden />
-            ) : row.clipType === "IMAGE" ? (
-              <HiOutlinePhotograph className="h-5 w-5" aria-hidden />
-            ) : row.clipType === "COLOR" ? (
-              <HiOutlineColorSwatch className="h-5 w-5" aria-hidden />
-            ) : (
-              <HiOutlineDocumentText className="h-5 w-5" aria-hidden />
-            )}
+            <TrashRowIcon row={row} />
           </div>
 
           <div className="min-w-0">

--- a/src/features/trash/ui/TrashListSection.tsx
+++ b/src/features/trash/ui/TrashListSection.tsx
@@ -4,8 +4,10 @@ import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useInView } from "react-intersection-observer";
 import { TrashListRow } from "@/features/trash/ui/TrashListRow";
-import { TrashItemRow } from "@/features/trash/ui/trashRow";
+import type { TrashItemRow } from "@/features/trash/ui/trashRow";
 import { Checkbox } from "@/shared/ui/input/Checkbox";
+
+const SKELETON_ROWS = Array.from({ length: 6 }, (_, index) => index);
 
 interface TrashListSectionProps {
   rows: TrashItemRow[];
@@ -40,7 +42,6 @@ export function TrashListSection({
   onDeleteClip,
 }: TrashListSectionProps) {
   const t = useTranslations("trash");
-  const skeletonRows = Array.from({ length: 6 }, (_, index) => index);
   const hasTriggeredInViewRef = useRef(false);
   const { ref: loadMoreRef, inView } = useInView({
     rootMargin: "240px 0px",
@@ -95,7 +96,7 @@ export function TrashListSection({
 
       <div className="clip-scrollbar min-h-0 flex-1 divide-y divide-(--border) overflow-y-auto">
         {isLoading
-          ? skeletonRows.map((row) => <TrashListSkeletonRow key={row} />)
+          ? SKELETON_ROWS.map((row) => <TrashListSkeletonRow key={row} />)
           : rows.map((row) => (
               <TrashListRow
                 key={`${row.kind}-${row.id}`}

--- a/src/features/trash/ui/TrashPage.tsx
+++ b/src/features/trash/ui/TrashPage.tsx
@@ -7,7 +7,7 @@ import { useTrashPage } from "@/features/trash/hooks/useTrashPage";
 import { TrashListSection } from "@/features/trash/ui/TrashListSection";
 import { TrashPageEmptyState } from "@/features/trash/ui/TrashPageEmptyState";
 import { TrashPageHeader } from "@/features/trash/ui/TrashPageHeader";
-import { TrashItemRow } from "@/features/trash/ui/trashRow";
+import type { TrashItemRow } from "@/features/trash/ui/trashRow";
 
 const getClipTypeLabel = (
   clipType: "TEXT" | "COLOR" | "IMAGE",
@@ -27,9 +27,9 @@ const getClipTypeLabel = (
 // 휴지통 페이지의 상태에 따라 안내, 빈 상태, 리스트 섹션을 조합하는 루트 컴포넌트입니다.
 export function TrashPage() {
   const t = useTranslations("trash");
-  const [isClearAllModalOpen, setIsClearAllModalOpen] = useState(false);
-  const [isDeleteSelectedModalOpen, setIsDeleteSelectedModalOpen] =
-    useState(false);
+  const [deleteModal, setDeleteModal] = useState<
+    "clearAll" | "selected" | null
+  >(null);
   const [selectedRowKeys, setSelectedRowKeys] = useState<Set<string>>(
     () => new Set(),
   );
@@ -179,16 +179,19 @@ export function TrashPage() {
         onReload={() => {
           void reload();
         }}
-        onRequestClearAll={() => setIsClearAllModalOpen(true)}
+        onRequestClearAll={() => setDeleteModal("clearAll")}
         onRestoreSelected={() => {
           void handleRestoreSelected();
         }}
-        onRequestDeleteSelected={() => setIsDeleteSelectedModalOpen(true)}
+        onRequestDeleteSelected={() => setDeleteModal("selected")}
       />
 
       {error ? (
         <div className="p-6 pt-6">
-          <p className="rounded-xl border border-(--danger-border) bg-(--danger-surface) px-4 py-3 text-sm text-(--danger-text)">
+          <p
+            className="rounded-xl border border-(--danger-border) bg-(--danger-surface) px-4 py-3 text-sm text-(--danger-text)"
+            role="alert"
+          >
             {errorMessage}
           </p>
         </div>
@@ -197,60 +200,61 @@ export function TrashPage() {
       {!isLoading && !hasRows ? <TrashPageEmptyState /> : null}
 
       {isLoading || hasRows ? (
-        <div className="flex min-h-0 flex-1 flex-col">
-          <TrashListSection
-            rows={rows}
-            isLoading={isLoading}
-            hasNextPage={hasNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-            pendingActionKey={pendingActionKey}
-            selectedRowKeys={selectedRowKeys}
-            onFetchNextPage={() => {
-              void fetchNextPage();
-            }}
-            onToggleRow={handleToggleRow}
-            onToggleAllRows={handleToggleAllRows}
-            onRestoreFolder={(folderId) => {
-              void handleRestoreFolder(folderId);
-            }}
-            onDeleteFolder={(folderId) => {
-              void handleDeleteFolder(folderId);
-            }}
-            onRestoreClip={(clipId) => {
-              void handleRestoreClip(clipId);
-            }}
-            onDeleteClip={(clipId) => {
-              void handleDeleteClip(clipId);
-            }}
-          />
-        </div>
+        <TrashListSection
+          rows={rows}
+          isLoading={isLoading}
+          hasNextPage={hasNextPage}
+          isFetchingNextPage={isFetchingNextPage}
+          pendingActionKey={pendingActionKey}
+          selectedRowKeys={selectedRowKeys}
+          onFetchNextPage={() => {
+            void fetchNextPage();
+          }}
+          onToggleRow={handleToggleRow}
+          onToggleAllRows={handleToggleAllRows}
+          onRestoreFolder={(folderId) => {
+            void handleRestoreFolder(folderId);
+          }}
+          onDeleteFolder={(folderId) => {
+            void handleDeleteFolder(folderId);
+          }}
+          onRestoreClip={(clipId) => {
+            void handleRestoreClip(clipId);
+          }}
+          onDeleteClip={(clipId) => {
+            void handleDeleteClip(clipId);
+          }}
+        />
       ) : null}
 
       <DeleteAllClipsModal
-        isOpen={isClearAllModalOpen}
-        title={t("clearAllModal.title")}
-        description={t("clearAllModal.description")}
+        isOpen={deleteModal !== null}
+        title={
+          deleteModal === "selected"
+            ? t("deleteSelectedModal.title", { count: selectedRows.length })
+            : t("clearAllModal.title")
+        }
+        description={
+          deleteModal === "selected"
+            ? t("deleteSelectedModal.description", {
+                count: selectedRows.length,
+              })
+            : t("clearAllModal.description")
+        }
         cancelLabel={t("cancel")}
-        confirmLabel={t("clearAll")}
-        onCancel={() => setIsClearAllModalOpen(false)}
+        confirmLabel={
+          deleteModal === "selected" ? t("deleteSelected") : t("clearAll")
+        }
+        onCancel={() => setDeleteModal(null)}
         onConfirm={() => {
-          setIsClearAllModalOpen(false);
-          void handleClearAll();
-        }}
-      />
+          const target = deleteModal;
+          setDeleteModal(null);
 
-      <DeleteAllClipsModal
-        isOpen={isDeleteSelectedModalOpen}
-        title={t("deleteSelectedModal.title", { count: selectedRows.length })}
-        description={t("deleteSelectedModal.description", {
-          count: selectedRows.length,
-        })}
-        cancelLabel={t("cancel")}
-        confirmLabel={t("deleteSelected")}
-        onCancel={() => setIsDeleteSelectedModalOpen(false)}
-        onConfirm={() => {
-          setIsDeleteSelectedModalOpen(false);
-          void handleDeleteSelected();
+          if (target === "selected") {
+            void handleDeleteSelected();
+          } else {
+            void handleClearAll();
+          }
         }}
       />
     </div>

--- a/src/features/trash/ui/TrashPageHeader.tsx
+++ b/src/features/trash/ui/TrashPageHeader.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { HiOutlineRefresh, HiOutlineReply, HiOutlineTrash } from "react-icons/hi";
+import {
+  HiOutlineRefresh,
+  HiOutlineReply,
+  HiOutlineTrash,
+} from "react-icons/hi";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 import { Text } from "@/shared/ui/typography/Text";
@@ -37,6 +41,17 @@ export function TrashPageHeader({
   const t = useTranslations("trash");
   const hasSelection = selectedCount > 0;
   const areControlsDisabled = isLoading || isActionPending;
+  const statusLabel = isLoading
+    ? t("loading")
+    : isRestoringSelected
+      ? t("restoringSelected")
+      : isDeletingSelected
+        ? t("deletingSelected")
+        : isClearingAll
+          ? t("clearing")
+          : hasSelection
+            ? t("selectedCount", { count: selectedCount })
+            : null;
 
   return (
     <div className="border-b border-(--border) px-4 py-6 min-[1200px]:px-6">
@@ -52,21 +67,9 @@ export function TrashPageHeader({
           </div>
           <div className="mt-2 flex flex-col gap-1 min-[640px]:flex-row min-[640px]:items-center min-[640px]:gap-3">
             <Text variant="bodyMuted">{t("description")}</Text>
-            {isLoading ||
-            isRestoringSelected ||
-            isDeletingSelected ||
-            isClearingAll ||
-            hasSelection ? (
+            {statusLabel ? (
               <Text as="span" variant="bodyStrong">
-                {isLoading
-                  ? t("loading")
-                  : isRestoringSelected
-                    ? t("restoringSelected")
-                    : isDeletingSelected
-                      ? t("deletingSelected")
-                      : isClearingAll
-                        ? t("clearing")
-                        : t("selectedCount", { count: selectedCount })}
+                {statusLabel}
               </Text>
             ) : null}
           </div>


### PR DESCRIPTION
## PR 요약

- `src/features/**/ui`의 중복 UI와 의미 없는 래퍼를 정리하고, 화면·섹션·반복 아이템 단위의 합성 컴포넌트 구조로 개선했습니다.

## 변경 내용 상세

### 변경 사항

- 인증, 랜딩, 요금제, 폴더, 클립, 설정, 구독, 휴지통 UI를 도메인별로 분리 리팩터링
- 최근·즐겨찾기 클립 화면과 기본 진입 리다이렉트의 중복 컴포넌트 통합
- 요금제 카드, 폴더 행, 설정 섹션 등 반복되거나 책임이 혼합된 UI 분리
- 폴더 이름 모달과 휴지통 삭제 확인 모달의 중복 상태 통합
- 의미 없는 단일 자식 래퍼 제거 및 조건부 렌더링을 명명된 컴포넌트·변수로 정리
- 모든 `src/features/**/ui/*.tsx` 파일에 대표 컴포넌트 역할 주석 추가
- 접근성 상태 속성, 아이콘 라이브러리 사용, type-only import와 포맷 정리
- `api`, `hooks`, `service`, `model` 및 비즈니스 로직은 변경하지 않음

### 변경 이유

- feature UI가 도메인별 화면 흐름을 조합하는 역할에 집중하도록 책임 경계를 명확히 하기 위함
- 중복 마크업과 상태를 줄이고 반복 UI를 명명된 합성 단위로 만들어 유지보수성과 리뷰 가능성을 높이기 위함

## 관련 이슈

- Closes #91

## 기타 참고사항

- 도메인별 8개 커밋으로 분리했습니다.
- `npx prettier --check "src/features/**/ui/*.tsx"`: 통과
- `npm run lint`: 통과
- `npx tsc --noEmit`: 통과
- `npm run build`: 통과
- `npm run start -- -p 3011`: 실행 후 `/`, `/pricing`, `/login` 200 응답 확인
- 인증 필요 경로 `/billing`, `/favorites`, `/recent`, `/trash`가 비로그인 상태에서 `/login`으로 정상 이동하는 것을 확인
- `npm run package`와 `npm run test:e2e`는 package script가 없어 실행하지 못했습니다.
- 의도적인 시각 디자인 변경은 없습니다. 자동 브라우저 도구가 `Target closed` 오류로 연결되지 않아 Before/After 스크린샷은 첨부하지 못했습니다.