### PR TITLE
#105 / refactor(sidebar) : 앱 셸과 사이드바 조합 책임을 app 레이어로 이동

### DIFF
--- a/src/app/(app)/_components/AppShell.tsx
+++ b/src/app/(app)/_components/AppShell.tsx
@@ -1,17 +1,17 @@
 "use client";
 
-// 앱 내부 화면의 공통 레이아웃과 사이드바/설정 모달 진입점을 구성합니다.
 import { useCallback, useState } from "react";
+import { HiOutlineMenuAlt4, HiOutlinePaperClip } from "react-icons/hi";
+import { AppSidebar } from "@/app/(app)/_components/sidebar/AppSidebar";
 import { AuthBootstrap } from "@/features/auth/ui/AuthBootstrap";
 import { SettingsModal } from "@/features/settings/ui/SettingsModal";
-import { HiOutlineMenuAlt4, HiOutlinePaperClip } from "react-icons/hi";
-import { Sidebar } from "@/features/folder/ui/Sidebar";
 import { Button } from "@/shared/ui/button/Button";
 
 interface AppShellProps {
   children: React.ReactNode;
 }
 
+// 인증된 앱 화면의 전역 탐색과 설정 진입점을 조합합니다.
 export function AppShell({ children }: AppShellProps) {
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
@@ -45,7 +45,7 @@ export function AppShell({ children }: AppShellProps) {
       </header>
 
       <div className="flex flex-1 overflow-hidden">
-        <Sidebar
+        <AppSidebar
           onOpenSettings={openSettings}
           isMobileOpen={isSidebarOpen}
           onCloseMobile={closeSidebar}
@@ -54,9 +54,7 @@ export function AppShell({ children }: AppShellProps) {
           {children}
         </main>
       </div>
-      {isSettingsOpen ? (
-        <SettingsModal onClose={closeSettings} />
-      ) : null}
+      {isSettingsOpen ? <SettingsModal onClose={closeSettings} /> : null}
     </div>
   );
 }

--- a/src/app/(app)/_components/sidebar/AppSidebar.tsx
+++ b/src/app/(app)/_components/sidebar/AppSidebar.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslations } from "next-intl";
+import { usePathname, useRouter } from "next/navigation";
+import { useCallback, useEffect } from "react";
+import { HiOutlineClock, HiOutlineStar, HiOutlineTrash } from "react-icons/hi";
+import { AppSidebarFooter } from "@/app/(app)/_components/sidebar/AppSidebarFooter";
+import { AppSidebarHeader } from "@/app/(app)/_components/sidebar/AppSidebarHeader";
+import { AppSidebarNav } from "@/app/(app)/_components/sidebar/AppSidebarNav";
+import { logout } from "@/features/auth/api/authApi";
+import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { clearAuthSession } from "@/features/auth/service/authSession";
+import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
+import { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
+import { FolderSidebarContent } from "@/features/folder/ui/FolderSidebarContent";
+
+const RESERVED_PATHNAMES = new Set([
+  "favorites",
+  "recent",
+  "trash",
+  "login",
+  "pricing",
+]);
+
+interface AppSidebarProps {
+  onOpenSettings: () => void;
+  isMobileOpen?: boolean;
+  onCloseMobile?: () => void;
+}
+
+// 여러 기능의 탐색, 사용자 메뉴와 폴더 섹션을 앱 사이드바로 조합합니다.
+export function AppSidebar({
+  onOpenSettings,
+  isMobileOpen = false,
+  onCloseMobile,
+}: AppSidebarProps) {
+  const t = useTranslations("sidebar");
+  const pathname = usePathname();
+  const router = useRouter();
+  const queryClient = useQueryClient();
+  const session = useAuthSession();
+  const isAuthenticated = Boolean(session?.user);
+  const { folders, isLoading: isFoldersLoading } = useFoldersQuery();
+  const pathnameFolderId = pathname.split("/").filter(Boolean)[0] ?? null;
+  const currentFolderId =
+    pathnameFolderId && !RESERVED_PATHNAMES.has(pathnameFolderId)
+      ? pathnameFolderId
+      : (folders[0]?.id ?? null);
+  const topNavs = [
+    {
+      href: currentFolderId ? `/${currentFolderId}/favorites` : "/favorites",
+      label: t("favorites"),
+      icon: <HiOutlineStar className="h-5 w-5" aria-hidden />,
+    },
+    {
+      href: currentFolderId ? `/${currentFolderId}/recent` : "/recent",
+      label: t("recent"),
+      icon: <HiOutlineClock className="h-5 w-5" aria-hidden />,
+    },
+    {
+      href: "/trash",
+      label: t("trash"),
+      icon: <HiOutlineTrash className="h-5 w-5" aria-hidden />,
+    },
+  ];
+  const userLabel =
+    session?.user?.authAccounts?.[0]?.email ??
+    session?.user?.displayName ??
+    t("guest");
+
+  useEffect(() => {
+    onCloseMobile?.();
+  }, [onCloseMobile, pathname]);
+
+  const requireAuthentication = useCallback(() => {
+    onCloseMobile?.();
+    router.push("/login");
+  }, [onCloseMobile, router]);
+
+  const handleFolderDeleted = useCallback(
+    (redirectPath: string | null) => {
+      void invalidateClipQueries(queryClient);
+
+      if (redirectPath) {
+        onCloseMobile?.();
+        router.replace(redirectPath);
+      }
+    },
+    [onCloseMobile, queryClient, router],
+  );
+
+  const handleLogout = useCallback(async () => {
+    onCloseMobile?.();
+
+    try {
+      if (isAuthenticated) {
+        await logout();
+      }
+    } catch {
+      // 서버 세션이 이미 만료된 경우에도 로컬 인증 상태는 정리합니다.
+    } finally {
+      clearAuthSession();
+      queryClient.clear();
+      router.push("/login");
+      router.refresh();
+    }
+  }, [isAuthenticated, onCloseMobile, queryClient, router]);
+
+  return (
+    <>
+      {isMobileOpen ? (
+        <button
+          type="button"
+          onClick={onCloseMobile}
+          className="fixed inset-0 z-30 cursor-pointer bg-(--overlay) md:hidden"
+          aria-label="사이드바 닫기"
+        />
+      ) : null}
+
+      <aside
+        className={`fixed inset-y-0 left-0 z-40 flex h-screen w-72 max-w-[86vw] flex-col border-r border-(--border) bg-(--surface-muted) transition-transform duration-300 md:static md:z-auto md:w-64 md:max-w-none ${
+          isMobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
+        }`}
+      >
+        <AppSidebarHeader onCloseMobile={onCloseMobile} />
+
+        <nav className="flex-1 overflow-y-auto py-4">
+          <div className="space-y-6">
+            <AppSidebarNav
+              items={topNavs}
+              pathname={pathname}
+              onNavigate={onCloseMobile}
+            />
+            <FolderSidebarContent
+              folders={folders}
+              isLoading={isFoldersLoading}
+              pathname={pathname}
+              isAuthenticated={isAuthenticated}
+              onNavigate={onCloseMobile}
+              onAuthenticationRequired={requireAuthentication}
+              onFolderDeleted={handleFolderDeleted}
+            />
+          </div>
+        </nav>
+
+        <AppSidebarFooter
+          userLabel={userLabel}
+          settingsLabel={t("settings")}
+          logoutLabel={t("logout")}
+          upgradePlanLabel={t("upgradePlan")}
+          onOpenSettings={() => {
+            onCloseMobile?.();
+            onOpenSettings();
+          }}
+          onUpgradePlan={() => {
+            onCloseMobile?.();
+            router.push("/pricing");
+          }}
+          onLogout={handleLogout}
+        />
+      </aside>
+    </>
+  );
+}

--- a/src/app/(app)/_components/sidebar/AppSidebarFooter.tsx
+++ b/src/app/(app)/_components/sidebar/AppSidebarFooter.tsx
@@ -9,8 +9,7 @@ import {
 } from "react-icons/hi";
 import { ActionMenu } from "@/shared/ui/menu/ActionMenu";
 
-// 사용자 식별 정보와 설정, 요금제, 로그아웃 액션 메뉴를 제공합니다.
-interface FolderSidebarFooterProps {
+interface AppSidebarFooterProps {
   userLabel: string;
   settingsLabel: string;
   logoutLabel: string;
@@ -20,7 +19,7 @@ interface FolderSidebarFooterProps {
   onLogout: () => void;
 }
 
-export function FolderSidebarFooter({
+export function AppSidebarFooter({
   userLabel,
   settingsLabel,
   logoutLabel,
@@ -28,7 +27,7 @@ export function FolderSidebarFooter({
   onOpenSettings,
   onUpgradePlan,
   onLogout,
-}: FolderSidebarFooterProps) {
+}: AppSidebarFooterProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const initials = userLabel.slice(0, 2).toUpperCase();

--- a/src/app/(app)/_components/sidebar/AppSidebarHeader.tsx
+++ b/src/app/(app)/_components/sidebar/AppSidebarHeader.tsx
@@ -2,14 +2,11 @@
 
 import { HiOutlinePaperClip, HiX } from "react-icons/hi";
 
-// 사이드바 상단에 브랜드와 모바일 닫기 액션을 표시합니다.
-interface FolderSidebarHeaderProps {
+interface AppSidebarHeaderProps {
   onCloseMobile?: () => void;
 }
 
-export function FolderSidebarHeader({
-  onCloseMobile,
-}: FolderSidebarHeaderProps) {
+export function AppSidebarHeader({ onCloseMobile }: AppSidebarHeaderProps) {
   return (
     <div className="border-b border-(--border) px-4 py-5">
       <div className="flex items-center justify-between gap-2">

--- a/src/app/(app)/_components/sidebar/AppSidebarNav.tsx
+++ b/src/app/(app)/_components/sidebar/AppSidebarNav.tsx
@@ -2,24 +2,23 @@
 
 import Link from "next/link";
 
-// 즐겨찾기, 최근 항목, 휴지통으로 이동하는 주요 탐색 링크를 표시합니다.
-interface SidebarNavItem {
+interface AppSidebarNavItem {
   href: string;
   label: string;
   icon: React.ReactNode;
 }
 
-interface SidebarPrimaryNavProps {
-  items: SidebarNavItem[];
+interface AppSidebarNavProps {
+  items: AppSidebarNavItem[];
   pathname: string;
   onNavigate?: () => void;
 }
 
-export function SidebarPrimaryNav({
+export function AppSidebarNav({
   items,
   pathname,
   onNavigate,
-}: SidebarPrimaryNavProps) {
+}: AppSidebarNavProps) {
   return (
     <ul className="space-y-2 px-2">
       {items.map((item) => (

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,4 +1,4 @@
-import { AppShell } from "@/shared/layout/AppShell";
+import { AppShell } from "@/app/(app)/_components/AppShell";
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return <AppShell>{children}</AppShell>;

--- a/src/features/folder/ui/FolderSidebarContent.tsx
+++ b/src/features/folder/ui/FolderSidebarContent.tsx
@@ -1,36 +1,23 @@
 "use client";
 
 import { useTranslations } from "next-intl";
-import { usePathname } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { HiOutlineClock, HiOutlineStar, HiOutlineTrash } from "react-icons/hi";
-import { useRouter } from "next/navigation";
-import { useQueryClient } from "@tanstack/react-query";
-import { logout } from "@/features/auth/api/authApi";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import { clearAuthSession } from "@/features/auth/service/authSession";
-import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
 import { useFolderActions } from "@/features/folder/hooks/useFolderActions";
-import { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
-import type { FolderDropPosition } from "@/features/folder/model/folder";
+import type {
+  FolderDropPosition,
+  FolderItem,
+} from "@/features/folder/model/folder";
 import { FolderNameModal } from "@/features/folder/ui/FolderNameModal";
-import { FolderSidebarFooter } from "@/features/folder/ui/FolderSidebarFooter";
-import { FolderSidebarHeader } from "@/features/folder/ui/FolderSidebarHeader";
 import { FolderSidebarSection } from "@/features/folder/ui/FolderSidebarSection";
-import { SidebarPrimaryNav } from "@/features/folder/ui/SidebarPrimaryNav";
 
-const RESERVED_PATHNAMES = new Set([
-  "favorites",
-  "recent",
-  "trash",
-  "login",
-  "pricing",
-]);
-
-interface SidebarProps {
-  onOpenSettings: () => void;
-  isMobileOpen?: boolean;
-  onCloseMobile?: () => void;
+interface FolderSidebarContentProps {
+  folders: FolderItem[];
+  isLoading?: boolean;
+  pathname: string;
+  isAuthenticated: boolean;
+  onNavigate?: () => void;
+  onAuthenticationRequired: () => void;
+  onFolderDeleted: (redirectPath: string | null) => void;
 }
 
 type FolderDropTarget = {
@@ -44,19 +31,17 @@ type FolderNameModalState =
   | { mode: "create"; value: string }
   | { mode: "rename"; folderId: string; value: string };
 
-// 앱 탐색과 폴더 생성, 이름 변경, 삭제, 순서 변경 흐름을 조합합니다.
-export function Sidebar({
-  onOpenSettings,
-  isMobileOpen = false,
-  onCloseMobile,
-}: SidebarProps) {
+// 폴더 생성, 이름 변경, 삭제와 정렬 상호작용만 관리합니다.
+export function FolderSidebarContent({
+  folders,
+  isLoading = false,
+  pathname,
+  isAuthenticated,
+  onNavigate,
+  onAuthenticationRequired,
+  onFolderDeleted,
+}: FolderSidebarContentProps) {
   const t = useTranslations("sidebar");
-  const pathname = usePathname();
-  const router = useRouter();
-  const queryClient = useQueryClient();
-  const session = useAuthSession();
-  const isAuthenticated = Boolean(session?.user);
-  const { folders, isLoading: isFoldersLoading } = useFoldersQuery();
   const { createFolder, removeFolder, renameFolder, saveFolderOrder } =
     useFolderActions();
   const [folderNameModal, setFolderNameModal] =
@@ -69,30 +54,7 @@ export function Sidebar({
     useState<FolderDropTarget | null>(null);
   const folderNameInputRef = useRef<HTMLInputElement>(null);
   const folderNameModalMode = folderNameModal?.mode ?? null;
-  const pathSegments = pathname.split("/").filter(Boolean);
-  const pathnameFolderId = pathSegments[0] ?? null;
-  const currentFolderId =
-    pathnameFolderId && !RESERVED_PATHNAMES.has(pathnameFolderId)
-      ? pathnameFolderId
-      : (folders[0]?.id ?? null);
-
-  const topNavs = [
-    {
-      href: currentFolderId ? `/${currentFolderId}/favorites` : "/favorites",
-      label: t("favorites"),
-      icon: <HiOutlineStar className="h-5 w-5" aria-hidden />,
-    },
-    {
-      href: currentFolderId ? `/${currentFolderId}/recent` : "/recent",
-      label: t("recent"),
-      icon: <HiOutlineClock className="h-5 w-5" aria-hidden />,
-    },
-    {
-      href: "/trash",
-      label: t("trash"),
-      icon: <HiOutlineTrash className="h-5 w-5" aria-hidden />,
-    },
-  ];
+  const pathnameFolderId = pathname.split("/").filter(Boolean)[0] ?? null;
 
   useEffect(() => {
     if (folderNameModalMode && folderNameInputRef.current) {
@@ -118,19 +80,14 @@ export function Sidebar({
     return () => window.removeEventListener("pointerdown", handlePointerDown);
   }, [openOptionsFolderId]);
 
-  useEffect(() => {
-    onCloseMobile?.();
-  }, [onCloseMobile, pathname]);
-
   const ensureAuthenticated = useCallback(() => {
     if (isAuthenticated) {
       return true;
     }
 
-    onCloseMobile?.();
-    router.push("/login");
+    onAuthenticationRequired();
     return false;
-  }, [isAuthenticated, onCloseMobile, router]);
+  }, [isAuthenticated, onAuthenticationRequired]);
 
   const clearFolderDragState = useCallback(() => {
     setDraggingFolderId(null);
@@ -214,7 +171,7 @@ export function Sidebar({
       }
 
       void saveFolderOrder(sourceId, targetId, position).catch(() => {
-        // refresh from the server when the final order cannot be saved
+        // 최종 순서 저장 실패 시 query가 서버 순서로 다시 동기화됩니다.
       });
     },
     [clearFolderDragState, ensureAuthenticated, saveFolderOrder],
@@ -228,11 +185,7 @@ export function Sidebar({
     }
 
     const trimmedName = folderNameModal.value.trim();
-    if (!trimmedName) {
-      return;
-    }
-
-    if (!ensureAuthenticated()) {
+    if (!trimmedName || !ensureAuthenticated()) {
       return;
     }
 
@@ -242,7 +195,7 @@ export function Sidebar({
         : renameFolder(folderNameModal.folderId, trimmedName);
 
     void request.then(closeFolderNameModal).catch(() => {
-      // keep the modal open when the request fails
+      // 실패 내용을 확인하고 재시도할 수 있도록 모달을 유지합니다.
     });
   }, [createFolder, ensureAuthenticated, folderNameModal, renameFolder]);
 
@@ -355,122 +308,54 @@ export function Sidebar({
       return;
     }
 
-    const isDeletingCurrentFolder = pathnameFolderId === folderId;
-    const redirectPath = getRedirectPathAfterFolderDelete(folderId);
+    const redirectPath =
+      pathnameFolderId === folderId
+        ? getRedirectPathAfterFolderDelete(folderId)
+        : null;
 
     void removeFolder(folderId)
       .then(() => {
         setOpenOptionsFolderId(null);
-        void invalidateClipQueries(queryClient);
-
-        if (isDeletingCurrentFolder) {
-          onCloseMobile?.();
-          router.replace(redirectPath);
-        }
+        onFolderDeleted(redirectPath);
       })
       .catch(() => {
-        // keep the menu open when the request fails
+        // 실패 내용을 확인하고 재시도할 수 있도록 옵션 메뉴를 유지합니다.
       });
   };
 
-  const userLabel =
-    session?.user?.authAccounts?.[0]?.email ??
-    session?.user?.displayName ??
-    t("guest");
-
-  const handleLogout = useCallback(async () => {
-    onCloseMobile?.();
-
-    try {
-      if (isAuthenticated) {
-        await logout();
-      }
-    } catch {
-      // clear client session even when the server session is already invalid
-    } finally {
-      clearAuthSession();
-      queryClient.clear();
-      router.push("/login");
-      router.refresh();
-    }
-  }, [isAuthenticated, onCloseMobile, queryClient, router]);
-
   return (
     <>
-      {isMobileOpen ? (
-        <button
-          type="button"
-          onClick={onCloseMobile}
-          className="fixed inset-0 z-30 cursor-pointer bg-(--overlay) md:hidden"
-          aria-label="사이드바 닫기"
-        />
-      ) : null}
-
-      <aside
-        className={`fixed inset-y-0 left-0 z-40 flex h-screen w-72 max-w-[86vw] flex-col border-r border-(--border) bg-(--surface-muted) transition-transform duration-300 md:static md:z-auto md:w-64 md:max-w-none ${
-          isMobileOpen ? "translate-x-0" : "-translate-x-full md:translate-x-0"
-        }`}
-      >
-        <FolderSidebarHeader onCloseMobile={onCloseMobile} />
-
-        <nav className="flex-1 py-4">
-          <div className="space-y-6">
-            <SidebarPrimaryNav
-              items={topNavs}
-              pathname={pathname}
-              onNavigate={onCloseMobile}
-            />
-
-            <FolderSidebarSection
-              folders={folders}
-              isLoading={isFoldersLoading}
-              pathname={pathname}
-              addFolderLabel={t("addFolder")}
-              reorderFolderLabel={t("reorderFolder")}
-              openFolderOptionsLabel={t("openFolderOptions")}
-              renameLabel={t("rename")}
-              deleteLabel={t("delete")}
-              openOptionsFolderId={openOptionsFolderId}
-              draggingFolderId={draggingFolderId}
-              dropIndicator={
-                folderDropTarget
-                  ? {
-                      folderId: folderDropTarget.indicatorFolderId,
-                      edge: folderDropTarget.indicatorEdge,
-                    }
-                  : null
+      <FolderSidebarSection
+        folders={folders}
+        isLoading={isLoading}
+        pathname={pathname}
+        addFolderLabel={t("addFolder")}
+        reorderFolderLabel={t("reorderFolder")}
+        openFolderOptionsLabel={t("openFolderOptions")}
+        renameLabel={t("rename")}
+        deleteLabel={t("delete")}
+        openOptionsFolderId={openOptionsFolderId}
+        draggingFolderId={draggingFolderId}
+        dropIndicator={
+          folderDropTarget
+            ? {
+                folderId: folderDropTarget.indicatorFolderId,
+                edge: folderDropTarget.indicatorEdge,
               }
-              onAddFolder={() => {
-                setFolderNameModal({ mode: "create", value: "" });
-              }}
-              onNavigate={onCloseMobile}
-              onDragStart={handleFolderDragStart}
-              onDragEnd={clearFolderDragState}
-              onDragOver={handleFolderDragOver}
-              onDrop={handleFolderDrop}
-              onToggleOptions={handleToggleFolderOptions}
-              onRenameFolder={handleOpenRenameFolder}
-              onDeleteFolder={handleDeleteFolder}
-            />
-          </div>
-        </nav>
-
-        <FolderSidebarFooter
-          userLabel={userLabel}
-          settingsLabel={t("settings")}
-          logoutLabel={t("logout")}
-          upgradePlanLabel={t("upgradePlan")}
-          onOpenSettings={() => {
-            onCloseMobile?.();
-            onOpenSettings();
-          }}
-          onUpgradePlan={() => {
-            onCloseMobile?.();
-            router.push("/pricing");
-          }}
-          onLogout={handleLogout}
-        />
-      </aside>
+            : null
+        }
+        onAddFolder={() => {
+          setFolderNameModal({ mode: "create", value: "" });
+        }}
+        onNavigate={onNavigate}
+        onDragStart={handleFolderDragStart}
+        onDragEnd={clearFolderDragState}
+        onDragOver={handleFolderDragOver}
+        onDrop={handleFolderDrop}
+        onToggleOptions={handleToggleFolderOptions}
+        onRenameFolder={handleOpenRenameFolder}
+        onDeleteFolder={handleDeleteFolder}
+      />
 
       {folderNameModal ? (
         <FolderNameModal


### PR DESCRIPTION
## PR 요약

- 앱 셸과 전역 사이드바 조합 책임을 `app` 레이어로 이동하고 folder feature를 폴더 기능에 집중하도록 정리했습니다.

## 변경 내용 상세

### 변경 사항

- `AppShell`을 `src/shared/layout`에서 `src/app/(app)/_components`로 이동했습니다.
- 전역 탐색, 사용자 메뉴, 설정·요금제 진입, 로그아웃과 모바일 사이드바 조합을 `AppSidebar`가 담당하도록 분리했습니다.
- folder feature의 사이드바 UI를 `FolderSidebarContent`로 축소해 폴더 조회, 생성, 이름 변경, 삭제와 정렬만 담당하도록 변경했습니다.
- 폴더 삭제 후 clip 캐시 무효화와 화면 이동처럼 feature 간 조합이 필요한 처리를 app 레이어로 이동했습니다.
- `src/shared`에서 `src/features`와 `src/app`을 참조하던 역방향 의존성을 제거했습니다.

### 변경 이유

- 목표 의존성 방향인 `app -> features -> shared`를 지키고, 전역 앱 조합 책임이 folder 또는 shared 레이어에 섞이지 않도록 하기 위함입니다.

## 관련 이슈

- Closes #105

## 검증 결과

- `npm run lint` 통과
- `npm run build` 통과
- `git diff --check` 통과
- Prettier 검사 통과
- 프로덕션 서버에서 `/login`, `/pricing` 200 응답 확인
- 미인증 상태에서 `/favorites`, `/recent`, `/trash`가 `/login`으로 307 이동하는 것 확인

## 기타 참고사항

- 렌더링 결과를 변경하지 않는 구조 리팩터링이므로 Before/After 스크린샷은 첨부하지 않았습니다.
- 실제 로그인 세션이 필요한 설정 모달, 로그아웃과 폴더 조작은 코드 흐름을 검토했으며 인증 브라우저 조작 검증은 수행하지 않았습니다.
- 작업 트리의 `FEATURES_ARCHITECTURE_REVIEW.md`는 이번 PR에 포함하지 않았습니다.