### PR TITLE
#108 / refactor(shared) : 기능 도메인 공개 API를 정의하고 순환 의존 제거

### DIFF
--- a/src/app/(app)/[id]/favorites/page.tsx
+++ b/src/app/(app)/[id]/favorites/page.tsx
@@ -1,4 +1,4 @@
-import { FavoriteClipsPage } from "@/features/clip/ui/FavoriteClipsPage";
+import { FavoriteClipsPage } from "@/features/clip";
 
 export default function FolderFavorites() {
   return <FavoriteClipsPage />;

--- a/src/app/(app)/[id]/page.tsx
+++ b/src/app/(app)/[id]/page.tsx
@@ -1,5 +1,5 @@
-import { FolderClipsPage } from "@/features/clip/ui/FolderClipsPage";
+import { FolderClipsRoute } from "@/app/(app)/_components/FolderClipsRoute";
 
 export default function Folder() {
-  return <FolderClipsPage />;
+  return <FolderClipsRoute />;
 }

--- a/src/app/(app)/[id]/recent/page.tsx
+++ b/src/app/(app)/[id]/recent/page.tsx
@@ -1,4 +1,4 @@
-import { RecentClipsPage } from "@/features/clip/ui/RecentClipsPage";
+import { RecentClipsPage } from "@/features/clip";
 
 export default function FolderRecent() {
   return <RecentClipsPage />;

--- a/src/app/(app)/_components/AppShell.tsx
+++ b/src/app/(app)/_components/AppShell.tsx
@@ -3,8 +3,9 @@
 import { useCallback, useState } from "react";
 import { HiOutlineMenuAlt4, HiOutlinePaperClip } from "react-icons/hi";
 import { AppSidebar } from "@/app/(app)/_components/sidebar/AppSidebar";
-import { AuthBootstrap } from "@/features/auth/ui/AuthBootstrap";
-import { SettingsModal } from "@/features/settings/ui/SettingsModal";
+import { UserSettingsSync } from "@/app/_components/UserSettingsSync";
+import { AuthBootstrap } from "@/features/auth";
+import { SettingsModal } from "@/features/settings";
 import { Button } from "@/shared/ui/button/Button";
 
 interface AppShellProps {
@@ -23,6 +24,7 @@ export function AppShell({ children }: AppShellProps) {
   return (
     <div className="bg-background text-foreground flex h-screen flex-col overflow-hidden">
       <AuthBootstrap />
+      <UserSettingsSync />
       <header className="bg-background border-b border-(--border) md:hidden">
         <div className="flex items-center justify-between px-4 py-3">
           <Button

--- a/src/app/(app)/_components/FolderClipsRoute.tsx
+++ b/src/app/(app)/_components/FolderClipsRoute.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { FolderClipsPage } from "@/features/clip";
+import { invalidateTrashQueries } from "@/features/trash";
+
+// 클립 삭제 결과를 휴지통 캐시 갱신과 연결합니다.
+export function FolderClipsRoute() {
+  const queryClient = useQueryClient();
+
+  return (
+    <FolderClipsPage
+      onClipsDeleted={() => invalidateTrashQueries(queryClient)}
+    />
+  );
+}

--- a/src/app/(app)/_components/TrashRoute.tsx
+++ b/src/app/(app)/_components/TrashRoute.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useQueryClient } from "@tanstack/react-query";
+import { invalidateClipQueries } from "@/features/clip";
+import { invalidateFolderQueries, useFoldersQuery } from "@/features/folder";
+import { TrashPage } from "@/features/trash";
+
+// 휴지통 변경 결과를 폴더와 클립 캐시 갱신에 연결합니다.
+export function TrashRoute() {
+  const queryClient = useQueryClient();
+  const { folders } = useFoldersQuery();
+
+  return (
+    <TrashPage
+      activeFolders={folders}
+      onItemsChanged={async () => {
+        await Promise.all([
+          invalidateClipQueries(queryClient),
+          invalidateFolderQueries(queryClient),
+        ]);
+      }}
+    />
+  );
+}

--- a/src/app/(app)/_components/sidebar/AppSidebar.tsx
+++ b/src/app/(app)/_components/sidebar/AppSidebar.tsx
@@ -8,12 +8,10 @@ import { HiOutlineClock, HiOutlineStar, HiOutlineTrash } from "react-icons/hi";
 import { AppSidebarFooter } from "@/app/(app)/_components/sidebar/AppSidebarFooter";
 import { AppSidebarHeader } from "@/app/(app)/_components/sidebar/AppSidebarHeader";
 import { AppSidebarNav } from "@/app/(app)/_components/sidebar/AppSidebarNav";
-import { logout } from "@/features/auth/api/authApi";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import { clearAuthSession } from "@/features/auth/service/authSession";
-import { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
-import { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
-import { FolderSidebarContent } from "@/features/folder/ui/FolderSidebarContent";
+import { clearAuthSession, logout, useAuthSession } from "@/features/auth";
+import { invalidateClipQueries } from "@/features/clip";
+import { FolderSidebarContent, useFoldersQuery } from "@/features/folder";
+import { invalidateTrashQueries } from "@/features/trash";
 
 const RESERVED_PATHNAMES = new Set([
   "favorites",
@@ -80,7 +78,10 @@ export function AppSidebar({
 
   const handleFolderDeleted = useCallback(
     (redirectPath: string | null) => {
-      void invalidateClipQueries(queryClient);
+      void Promise.all([
+        invalidateClipQueries(queryClient),
+        invalidateTrashQueries(queryClient),
+      ]);
 
       if (redirectPath) {
         onCloseMobile?.();

--- a/src/app/(app)/favorites/page.tsx
+++ b/src/app/(app)/favorites/page.tsx
@@ -1,4 +1,4 @@
-import { FavoritesEntryPage } from "@/features/clip/ui/FavoritesEntryPage";
+import { FavoritesEntryPage } from "@/features/clip";
 
 export default function Favorites() {
   return <FavoritesEntryPage />;

--- a/src/app/(app)/recent/page.tsx
+++ b/src/app/(app)/recent/page.tsx
@@ -1,4 +1,4 @@
-import { RecentEntryPage } from "@/features/clip/ui/RecentEntryPage";
+import { RecentEntryPage } from "@/features/clip";
 
 export default function Recent() {
   return <RecentEntryPage />;

--- a/src/app/(app)/trash/page.tsx
+++ b/src/app/(app)/trash/page.tsx
@@ -1,5 +1,5 @@
-import { TrashPage } from "@/features/trash/ui/TrashPage";
+import { TrashRoute } from "@/app/(app)/_components/TrashRoute";
 
 export default function Trash() {
-  return <TrashPage />;
+  return <TrashRoute />;
 }

--- a/src/app/_components/UserSettingsSync.tsx
+++ b/src/app/_components/UserSettingsSync.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useEffect } from "react";
+import { clearAuthSession, useAuthSession } from "@/features/auth";
+import { syncUserSettings } from "@/features/settings";
+import { ApiError } from "@/shared/lib/apiClient";
+
+// 인증 세션이 준비되면 서버 사용자 설정을 전역 설정 store에 반영합니다.
+export function UserSettingsSync() {
+  const session = useAuthSession();
+
+  useEffect(() => {
+    if (!session?.user) {
+      return;
+    }
+
+    void syncUserSettings().catch((error: unknown) => {
+      if (error instanceof ApiError && error.status === 401) {
+        clearAuthSession();
+      }
+    });
+  }, [session]);
+
+  return null;
+}

--- a/src/app/billing/fail/page.tsx
+++ b/src/app/billing/fail/page.tsx
@@ -1,4 +1,4 @@
-import { BillingResultPage } from "@/features/subscription/ui/BillingResultPage";
+import { BillingResultPage } from "@/features/subscription";
 
 interface BillingFailProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -1,4 +1,4 @@
-import { BillingPage } from "@/features/subscription/ui/BillingPage";
+import { BillingPage } from "@/features/subscription";
 
 export default function Billing() {
   return <BillingPage />;

--- a/src/app/billing/success/page.tsx
+++ b/src/app/billing/success/page.tsx
@@ -1,4 +1,4 @@
-import { BillingResultPage } from "@/features/subscription/ui/BillingResultPage";
+import { BillingResultPage } from "@/features/subscription";
 
 interface BillingSuccessProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { getInitialUserSettings } from "@/features/settings/server/getInitialUserSettings";
+import { getInitialUserSettings } from "@/features/settings/server";
 import { AppToaster } from "@/shared/feedback/AppToaster";
 import { IntlProvider } from "@/shared/providers/IntlProvider";
 import { QueryProvider } from "@/shared/providers/QueryProvider";

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,5 @@
 import { Suspense } from "react";
-import { LoginPage } from "@/features/auth/ui/LoginPage";
+import { LoginPage } from "@/features/auth";
 
 export default function Login() {
   return (

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { LandingPage } from "@/features/landing/ui/LandingPage";
+import { LandingPage } from "@/features/landing";
 
 export default function Home() {
   return <LandingPage />;

--- a/src/app/pricing/page.tsx
+++ b/src/app/pricing/page.tsx
@@ -1,10 +1,16 @@
-import { MarketingShell } from "@/features/landing/ui/MarketingShell";
-import { PricingPage } from "@/features/pricing/ui/PricingPage";
+import { UserSettingsSync } from "@/app/_components/UserSettingsSync";
+import { AuthBootstrap } from "@/features/auth";
+import { MarketingShell } from "@/features/landing";
+import { PricingPage } from "@/features/pricing";
 
 export default function Pricing() {
   return (
-    <MarketingShell activeTab="pricing">
-      <PricingPage />
-    </MarketingShell>
+    <>
+      <AuthBootstrap />
+      <UserSettingsSync />
+      <MarketingShell activeTab="pricing">
+        <PricingPage />
+      </MarketingShell>
+    </>
   );
 }

--- a/src/features/auth/index.ts
+++ b/src/features/auth/index.ts
@@ -1,0 +1,5 @@
+export { logout } from "@/features/auth/api/authApi";
+export { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+export { clearAuthSession } from "@/features/auth/service/authSession";
+export { AuthBootstrap } from "@/features/auth/ui/AuthBootstrap";
+export { LoginPage } from "@/features/auth/ui/LoginPage";

--- a/src/features/auth/ui/AuthBootstrap.tsx
+++ b/src/features/auth/ui/AuthBootstrap.tsx
@@ -4,8 +4,6 @@ import { useEffect, useRef } from "react";
 import { usePathname, useRouter } from "next/navigation";
 import { useQueryClient } from "@tanstack/react-query";
 import { logout } from "@/features/auth/api/authApi";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import { syncUserSettings } from "@/features/settings/service/settingsService";
 import { ApiError, subscribeToAuthExpired } from "@/shared/lib/apiClient";
 import {
   clearSessionOnUnauthorized,
@@ -15,7 +13,6 @@ import { notifyError } from "@/shared/feedback/toast";
 
 // 앱 전역의 인증 세션을 복구하고 만료 상태를 라우팅 및 캐시와 동기화합니다.
 export function AuthBootstrap() {
-  const session = useAuthSession();
   const router = useRouter();
   const pathname = usePathname();
   const queryClient = useQueryClient();
@@ -61,18 +58,6 @@ export function AuthBootstrap() {
       }
     });
   }, [queryClient, router]);
-
-  useEffect(() => {
-    if (!session?.user) {
-      return;
-    }
-
-    void syncUserSettings().catch((error: unknown) => {
-      if (error instanceof ApiError && error.status === 401) {
-        clearSessionOnUnauthorized();
-      }
-    });
-  }, [session]);
 
   return null;
 }

--- a/src/features/clip/hooks/useClipDeletion.ts
+++ b/src/features/clip/hooks/useClipDeletion.ts
@@ -13,13 +13,13 @@ import {
   invalidateClipQueries,
   removeClipsFromCache,
 } from "@/features/clip/service/clipQueryCache";
-import { invalidateTrashQueries } from "@/features/trash/service/trashQueryCache";
 import { notifyError } from "@/shared/feedback/toast";
 
 interface UseClipDeletionOptions {
   clips: Clip[];
   folderId: string;
   isAuthenticated: boolean;
+  onDeleted?: () => void | Promise<void>;
 }
 
 // 클립 삭제 모드, 선택 상태, 확인 모달과 단건·선택·전체 삭제 흐름을 관리합니다.
@@ -27,6 +27,7 @@ export const useClipDeletion = ({
   clips,
   folderId,
   isAuthenticated,
+  onDeleted,
 }: UseClipDeletionOptions) => {
   const queryClient = useQueryClient();
   const [isDeleteAllOpen, setIsDeleteAllOpen] = useState(false);
@@ -115,11 +116,11 @@ export const useClipDeletion = ({
         setIsDeleting(false);
         void invalidateClipQueries(queryClient);
         if (isDeleted) {
-          void invalidateTrashQueries(queryClient);
+          void onDeleted?.();
         }
       }
     },
-    [isAuthenticated, isDeleting, queryClient],
+    [isAuthenticated, isDeleting, onDeleted, queryClient],
   );
 
   const deleteClipsByIds = useCallback(
@@ -153,11 +154,11 @@ export const useClipDeletion = ({
         setIsDeleting(false);
         void invalidateClipQueries(queryClient);
         if (isDeleted) {
-          void invalidateTrashQueries(queryClient);
+          void onDeleted?.();
         }
       }
     },
-    [isAuthenticated, isDeleting, queryClient],
+    [isAuthenticated, isDeleting, onDeleted, queryClient],
   );
 
   const deleteSelected = useCallback(async () => {
@@ -239,7 +240,7 @@ export const useClipDeletion = ({
       setIsDeleting(false);
       void invalidateClipQueries(queryClient);
       if (isDeleted) {
-        void invalidateTrashQueries(queryClient);
+        void onDeleted?.();
       }
     }
   }, [
@@ -247,6 +248,7 @@ export const useClipDeletion = ({
     folderId,
     isAuthenticated,
     isDeleting,
+    onDeleted,
     queryClient,
   ]);
 

--- a/src/features/clip/hooks/useFolderClipsPage.ts
+++ b/src/features/clip/hooks/useFolderClipsPage.ts
@@ -11,8 +11,14 @@ import { useFolderClipCapture } from "@/features/clip/hooks/useFolderClipCapture
 import { useInfiniteClips } from "@/features/clip/hooks/useInfiniteClips";
 import type { Clip } from "@/features/clip/model/clip";
 
+interface UseFolderClipsPageOptions {
+  onClipsDeleted?: () => void | Promise<void>;
+}
+
 // 폴더 클립의 조회, 수집, 메뉴와 삭제 하위 훅을 페이지 영역별 계약으로 조합합니다.
-export const useFolderClipsPage = () => {
+export const useFolderClipsPage = ({
+  onClipsDeleted,
+}: UseFolderClipsPageOptions = {}) => {
   const params = useParams<{ id?: string }>();
   const folderId = params?.id ?? "";
   const filter = useClipCollectionFilter();
@@ -26,6 +32,7 @@ export const useFolderClipsPage = () => {
     clips: query.clips,
     folderId,
     isAuthenticated: query.isAuthenticated,
+    onDeleted: onClipsDeleted,
   });
   const isInteractionDisabled = deletion.isDeleteMode || deletion.isDeleting;
   const capture = useFolderClipCapture({

--- a/src/features/clip/hooks/useInfiniteClips.ts
+++ b/src/features/clip/hooks/useInfiniteClips.ts
@@ -2,7 +2,7 @@
 
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useMemo } from "react";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { fetchClips } from "@/features/clip/api/clipApi";
 import type { Clip, ClipFilter } from "@/features/clip/model/clip";
 import type { FetchClipsQueryDto } from "@/features/clip/model/clip.dto";

--- a/src/features/clip/index.ts
+++ b/src/features/clip/index.ts
@@ -1,0 +1,6 @@
+export { invalidateClipQueries } from "@/features/clip/service/clipQueryCache";
+export { FavoriteClipsPage } from "@/features/clip/ui/FavoriteClipsPage";
+export { FavoritesEntryPage } from "@/features/clip/ui/FavoritesEntryPage";
+export { FolderClipsPage } from "@/features/clip/ui/FolderClipsPage";
+export { RecentClipsPage } from "@/features/clip/ui/RecentClipsPage";
+export { RecentEntryPage } from "@/features/clip/ui/RecentEntryPage";

--- a/src/features/clip/ui/ClipEntryPage.tsx
+++ b/src/features/clip/ui/ClipEntryPage.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from "react";
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ClipListSkeleton } from "@/features/clip/ui/ClipListSkeleton";
-import { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
+import { useFoldersQuery } from "@/features/folder";
 
 // 기본 컬렉션 경로를 첫 폴더 경로로 연결하고 폴더가 없으면 대체 화면을 표시합니다.
 interface ClipEntryPageProps {

--- a/src/features/clip/ui/FolderClipsPage.tsx
+++ b/src/features/clip/ui/FolderClipsPage.tsx
@@ -7,15 +7,19 @@ import { ClipContextMenu } from "@/features/clip/ui/ClipContextMenu";
 import { ClipCopyToast } from "@/features/clip/ui/ClipCopyToast";
 import { ClipResultsSection } from "@/features/clip/ui/ClipResultsSection";
 import { ClipDeleteModeButton } from "@/features/clip/ui/ClipDeleteModeButton";
-import { DeleteAllClipsModal } from "@/features/clip/ui/DeleteAllClipsModal";
 import { FilterBar } from "@/features/clip/ui/FilterBar";
 import { FolderClipCaptureHint } from "@/features/clip/ui/FolderClipCaptureHint";
+import { ConfirmActionModal } from "@/shared/ui/overlay/ConfirmActionModal";
 
 // 폴더 클립의 조회, 복사, 즐겨찾기, 컨텍스트 메뉴와 삭제 UI를 조합합니다.
-export function FolderClipsPage() {
+interface FolderClipsPageProps {
+  onClipsDeleted?: () => void | Promise<void>;
+}
+
+export function FolderClipsPage({ onClipsDeleted }: FolderClipsPageProps) {
   const t = useTranslations("clips");
   const { capture, collection, contextMenu, deletion, feedback } =
-    useFolderClipsPage();
+    useFolderClipsPage({ onClipsDeleted });
   const { actions, filter, results } = collection;
   const hasClipLoadError = results.isError && results.clips.length === 0;
 
@@ -86,7 +90,7 @@ export function FolderClipsPage() {
         />
       ) : null}
       <ClipCopyToast label={t("copyToast")} position={feedback.copyToast} />
-      <DeleteAllClipsModal
+      <ConfirmActionModal
         isOpen={deletion.isDeleteAllOpen}
         title={t("deleteModal.title")}
         description={t("deleteModal.description")}

--- a/src/features/folder/hooks/useFolderActions.ts
+++ b/src/features/folder/hooks/useFolderActions.ts
@@ -2,7 +2,7 @@
 
 import { useCallback, useMemo } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import {
   createFolder as createFolderRequest,
   deleteFolder as deleteFolderRequest,
@@ -19,7 +19,6 @@ import {
   sortFolders,
 } from "@/features/folder/service/folderCollection";
 import { getFolderQueryKey } from "@/features/folder/service/folderQueryCache";
-import { invalidateTrashQueries } from "@/features/trash/service/trashQueryCache";
 
 const createAuthRequiredError = () => new Error("AUTH_REQUIRED");
 
@@ -94,7 +93,6 @@ export const useFolderActions = () => {
       setFolders((folders) =>
         folders.filter((folder) => folder.id !== folderId),
       );
-      void invalidateTrashQueries(queryClient);
     },
   });
 

--- a/src/features/folder/hooks/useFoldersQuery.ts
+++ b/src/features/folder/hooks/useFoldersQuery.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { fetchFolders } from "@/features/folder/api/folderApi";
 import {
   mapFolder,

--- a/src/features/folder/index.ts
+++ b/src/features/folder/index.ts
@@ -1,0 +1,4 @@
+export { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
+export type { FolderItem } from "@/features/folder/model/folder";
+export { invalidateFolderQueries } from "@/features/folder/service/folderQueryCache";
+export { FolderSidebarContent } from "@/features/folder/ui/FolderSidebarContent";

--- a/src/features/folder/service/folderQueryCache.ts
+++ b/src/features/folder/service/folderQueryCache.ts
@@ -1,4 +1,9 @@
+import type { QueryClient } from "@tanstack/react-query";
+
 export const FOLDER_QUERY_KEY = "folders";
 
 export const getFolderQueryKey = (userId: string | null) =>
   [FOLDER_QUERY_KEY, userId] as const;
+
+export const invalidateFolderQueries = (queryClient: QueryClient) =>
+  queryClient.invalidateQueries({ queryKey: [FOLDER_QUERY_KEY] });

--- a/src/features/landing/index.ts
+++ b/src/features/landing/index.ts
@@ -1,0 +1,2 @@
+export { LandingPage } from "@/features/landing/ui/LandingPage";
+export { MarketingShell } from "@/features/landing/ui/MarketingShell";

--- a/src/features/pricing/index.ts
+++ b/src/features/pricing/index.ts
@@ -1,0 +1,1 @@
+export { PricingPage } from "@/features/pricing/ui/PricingPage";

--- a/src/features/pricing/ui/PricingPage.tsx
+++ b/src/features/pricing/ui/PricingPage.tsx
@@ -1,13 +1,11 @@
-import { AuthBootstrap } from "@/features/auth/ui/AuthBootstrap";
 import { PricingComparisonSection } from "@/features/pricing/ui/PricingComparisonSection";
 import { PricingHeroSection } from "@/features/pricing/ui/PricingHeroSection";
 import { PricingPlansSection } from "@/features/pricing/ui/PricingPlansSection";
 
-// 인증 상태를 준비하고 요금제 소개, 플랜 선택, 비교 섹션을 조합합니다.
+// 요금제 소개, 플랜 선택과 비교 섹션을 조합합니다.
 export function PricingPage() {
   return (
     <section className="relative overflow-hidden">
-      <AuthBootstrap />
       <div
         className="absolute inset-x-0 top-0 -z-10 h-[28rem]"
         style={{

--- a/src/features/pricing/ui/PricingPlansSection.tsx
+++ b/src/features/pricing/ui/PricingPlansSection.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useQueryClient } from "@tanstack/react-query";
 import { useState } from "react";
 import {
   PRICING_PLANS,
@@ -11,14 +10,11 @@ import {
 import { PricingCancelModal } from "@/features/pricing/ui/PricingCancelModal";
 import { PricingPlanCard } from "@/features/pricing/ui/PricingPlanCard";
 import {
-  fetchMySubscription,
-  updateMySubscription,
-} from "@/features/subscription/api/subscriptionApi";
-import { useMySubscription } from "@/features/subscription/hooks/useMySubscription";
-import {
   hasRemainingCanceledProPeriod,
   isActiveProSubscription,
-} from "@/features/subscription/model/subscription";
+  useMySubscription,
+  useSubscriptionActions,
+} from "@/features/subscription";
 import { notifyError, notifySuccess } from "@/shared/feedback/toast";
 import { ApiError } from "@/shared/lib/apiClient";
 import { Button } from "@/shared/ui/button/Button";
@@ -37,12 +33,9 @@ const formatSubscriptionDate = (value: string | null) => {
 // 구독 상태에 맞는 요금제 카드 액션과 취소 흐름을 조합합니다.
 export function PricingPlansSection() {
   const router = useRouter();
-  const queryClient = useQueryClient();
-  const {
-    isAuthenticated,
-    queryKey: subscriptionQueryKey,
-    subscription,
-  } = useMySubscription();
+  const { isAuthenticated, subscription } = useMySubscription();
+  const { cancelSubscription, resumeSubscription, syncSubscription } =
+    useSubscriptionActions();
   const [isCancelModalOpen, setIsCancelModalOpen] = useState(false);
   const [isCancelingSubscription, setIsCancelingSubscription] = useState(false);
   const [isResumingSubscription, setIsResumingSubscription] = useState(false);
@@ -57,8 +50,7 @@ export function PricingPlansSection() {
     setIsCancelingSubscription(true);
 
     try {
-      const nextSubscription = await updateMySubscription({ type: "CANCEL" });
-      queryClient.setQueryData(subscriptionQueryKey, nextSubscription);
+      await cancelSubscription();
       notifySuccess("Pro 구독이 취소되었습니다.");
       setIsCancelModalOpen(false);
       router.push("/favorites");
@@ -69,12 +61,6 @@ export function PricingPlansSection() {
     }
   };
 
-  const syncSubscription = async () => {
-    const nextSubscription = await fetchMySubscription();
-    queryClient.setQueryData(subscriptionQueryKey, nextSubscription);
-    return nextSubscription;
-  };
-
   const handleResumeSubscription = async () => {
     if (isResumingSubscription) {
       return;
@@ -83,8 +69,7 @@ export function PricingPlansSection() {
     setIsResumingSubscription(true);
 
     try {
-      const nextSubscription = await updateMySubscription({ type: "RESUME" });
-      queryClient.setQueryData(subscriptionQueryKey, nextSubscription);
+      await resumeSubscription();
       notifySuccess("Pro 구독 자동갱신이 재개되었습니다.");
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {

--- a/src/features/settings/index.ts
+++ b/src/features/settings/index.ts
@@ -1,0 +1,5 @@
+export {
+  persistUserSettings,
+  syncUserSettings,
+} from "@/features/settings/service/settingsService";
+export { SettingsModal } from "@/features/settings/ui/SettingsModal";

--- a/src/features/settings/server/index.ts
+++ b/src/features/settings/server/index.ts
@@ -1,0 +1,4 @@
+export {
+  getInitialUserSettings,
+  type InitialUserSettings,
+} from "@/features/settings/server/getInitialUserSettings";

--- a/src/features/settings/ui/SettingsAboutSection.tsx
+++ b/src/features/settings/ui/SettingsAboutSection.tsx
@@ -2,7 +2,7 @@
 
 import { useTranslations } from "next-intl";
 import { HiOutlineCreditCard } from "react-icons/hi";
-import type { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+import type { MySubscriptionResponseDto } from "@/features/subscription";
 import type { AppLocale } from "@/shared/config/locale";
 import { Text } from "@/shared/ui/typography/Text";
 

--- a/src/features/settings/ui/SettingsModal.tsx
+++ b/src/features/settings/ui/SettingsModal.tsx
@@ -3,11 +3,11 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { HiOutlineCog, HiOutlineX } from "react-icons/hi";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { persistUserSettings } from "@/features/settings/service/settingsService";
 import { SettingsAboutSection } from "@/features/settings/ui/SettingsAboutSection";
 import { SettingsPreferencesSection } from "@/features/settings/ui/SettingsPreferencesSection";
-import { useMySubscription } from "@/features/subscription/hooks/useMySubscription";
+import { useMySubscription } from "@/features/subscription";
 import type { AppLocale } from "@/shared/config/locale";
 import { useSettingsStore } from "@/shared/store/settingsStore";
 import { Button } from "@/shared/ui/button/Button";

--- a/src/features/subscription/hooks/useMySubscription.ts
+++ b/src/features/subscription/hooks/useMySubscription.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { fetchMySubscription } from "@/features/subscription/api/subscriptionApi";
 import { getMySubscriptionQueryKey } from "@/features/subscription/service/subscriptionQueryCache";
 
@@ -22,7 +22,6 @@ export const useMySubscription = () => {
     isAuthenticated,
     isError: isAuthenticated && query.isError,
     isPending: isAuthenticated && query.isPending,
-    queryKey,
     subscription: isAuthenticated ? (query.data ?? null) : null,
   };
 };

--- a/src/features/subscription/hooks/useSubscriptionActions.ts
+++ b/src/features/subscription/hooks/useSubscriptionActions.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthSession } from "@/features/auth";
+import {
+  fetchMySubscription,
+  updateMySubscription,
+} from "@/features/subscription/api/subscriptionApi";
+import { syncMySubscriptionQueryData } from "@/features/subscription/service/subscriptionQueryCache";
+
+// 구독 변경 요청과 현재 사용자 구독 캐시 동기화를 하나의 공개 액션으로 제공합니다.
+export const useSubscriptionActions = () => {
+  const queryClient = useQueryClient();
+  const session = useAuthSession();
+  const userId = session?.user?.id ?? null;
+
+  const syncSubscription = useCallback(async () => {
+    const subscription = await fetchMySubscription();
+    syncMySubscriptionQueryData(queryClient, subscription, userId);
+    return subscription;
+  }, [queryClient, userId]);
+
+  const cancelSubscription = useCallback(async () => {
+    const subscription = await updateMySubscription({ type: "CANCEL" });
+    syncMySubscriptionQueryData(queryClient, subscription, userId);
+    return subscription;
+  }, [queryClient, userId]);
+
+  const resumeSubscription = useCallback(async () => {
+    const subscription = await updateMySubscription({ type: "RESUME" });
+    syncMySubscriptionQueryData(queryClient, subscription, userId);
+    return subscription;
+  }, [queryClient, userId]);
+
+  return {
+    cancelSubscription,
+    resumeSubscription,
+    syncSubscription,
+  };
+};

--- a/src/features/subscription/index.ts
+++ b/src/features/subscription/index.ts
@@ -1,0 +1,9 @@
+export { useMySubscription } from "@/features/subscription/hooks/useMySubscription";
+export { useSubscriptionActions } from "@/features/subscription/hooks/useSubscriptionActions";
+export {
+  hasRemainingCanceledProPeriod,
+  isActiveProSubscription,
+} from "@/features/subscription/model/subscription";
+export type { MySubscriptionResponseDto } from "@/features/subscription/model/subscription.dto";
+export { BillingPage } from "@/features/subscription/ui/BillingPage";
+export { BillingResultPage } from "@/features/subscription/ui/BillingResultPage";

--- a/src/features/subscription/ui/BillingPage.tsx
+++ b/src/features/subscription/ui/BillingPage.tsx
@@ -8,7 +8,7 @@ import {
   fetchMySubscription,
   updateMySubscription,
 } from "@/features/subscription/api/subscriptionApi";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { hasRemainingCanceledProPeriod } from "@/features/subscription/model/subscription";
 import type { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
 import {

--- a/src/features/trash/hooks/useTrashActions.ts
+++ b/src/features/trash/hooks/useTrashActions.ts
@@ -2,9 +2,7 @@
 
 import { useCallback, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
-import { CLIP_QUERY_KEY } from "@/features/clip/service/clipQueryCache";
-import { FOLDER_QUERY_KEY } from "@/features/folder/service/folderQueryCache";
+import { useAuthSession } from "@/features/auth";
 import {
   deleteAllTrashItems,
   deleteTrashClip,
@@ -20,8 +18,14 @@ import { ApiError } from "@/shared/lib/apiClient";
 
 export type TrashActionError = "action" | "restoreConflict";
 
+interface UseTrashActionsOptions {
+  onItemsChanged?: () => void | Promise<void>;
+}
+
 // 휴지통 복원과 영구 삭제 액션의 중복 실행 방지, 오류 판정, 관련 캐시 갱신을 관리합니다.
-export const useTrashActions = () => {
+export const useTrashActions = ({
+  onItemsChanged,
+}: UseTrashActionsOptions = {}) => {
   const session = useAuthSession();
   const isAuthenticated = Boolean(session?.user);
   const queryClient = useQueryClient();
@@ -30,12 +34,9 @@ export const useTrashActions = () => {
   const pendingActionKeyRef = useRef<string | null>(null);
 
   const refreshRelatedData = useCallback(async () => {
-    await Promise.all([
-      invalidateTrashQueries(queryClient),
-      queryClient.invalidateQueries({ queryKey: [FOLDER_QUERY_KEY] }),
-      queryClient.invalidateQueries({ queryKey: [CLIP_QUERY_KEY] }),
-    ]);
-  }, [queryClient]);
+    await invalidateTrashQueries(queryClient);
+    await onItemsChanged?.();
+  }, [onItemsChanged, queryClient]);
 
   const runAction = useCallback(
     async (actionKey: string, action: () => Promise<unknown>) => {

--- a/src/features/trash/hooks/useTrashItemsQuery.ts
+++ b/src/features/trash/hooks/useTrashItemsQuery.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useInfiniteQuery } from "@tanstack/react-query";
-import { useAuthSession } from "@/features/auth/hooks/useAuthSession";
+import { useAuthSession } from "@/features/auth";
 import { fetchTrashItems } from "@/features/trash/api/trashApi";
 import { TRASH_QUERY_KEYS } from "@/features/trash/service/trashQueryCache";
 import { waitForMinimumLoading } from "@/shared/lib/loading";

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -1,15 +1,21 @@
 "use client";
 
 import { useCallback } from "react";
-import { useFoldersQuery } from "@/features/folder/hooks/useFoldersQuery";
 import { useTrashActions } from "@/features/trash/hooks/useTrashActions";
 import { useTrashItemsQuery } from "@/features/trash/hooks/useTrashItemsQuery";
 
+interface UseTrashPageOptions {
+  activeFolders: Array<{ id: string; name: string }>;
+  onItemsChanged?: () => void | Promise<void>;
+}
+
 // 휴지통 조회, 관련 폴더와 복원·삭제 액션을 페이지 영역별 계약으로 조합합니다.
-export const useTrashPage = () => {
-  const { folders } = useFoldersQuery();
+export const useTrashPage = ({
+  activeFolders,
+  onItemsChanged,
+}: UseTrashPageOptions) => {
   const query = useTrashItemsQuery();
-  const trashActions = useTrashActions();
+  const trashActions = useTrashActions({ onItemsChanged });
   const { refetch } = query;
   const { clearError, error: actionError, ...actions } = trashActions;
 
@@ -24,7 +30,7 @@ export const useTrashPage = () => {
       reload,
     },
     context: {
-      activeFolders: folders,
+      activeFolders,
     },
     results: {
       error: actionError ?? (query.isError ? "load" : null),

--- a/src/features/trash/index.ts
+++ b/src/features/trash/index.ts
@@ -1,0 +1,2 @@
+export { invalidateTrashQueries } from "@/features/trash/service/trashQueryCache";
+export { TrashPage } from "@/features/trash/ui/TrashPage";

--- a/src/features/trash/model/trash.dto.ts
+++ b/src/features/trash/model/trash.dto.ts
@@ -1,12 +1,10 @@
-import { ClipApiType } from "@/features/clip/model/clip.dto";
-
 export type TrashItemResponseDto =
   | {
       itemType: "CLIP";
       id: string;
       deletedAt: string | null;
       title: string;
-      type: ClipApiType;
+      type: "TEXT" | "COLOR" | "IMAGE";
       folderId: string;
     }
   | {

--- a/src/features/trash/ui/TrashPage.tsx
+++ b/src/features/trash/ui/TrashPage.tsx
@@ -2,12 +2,12 @@
 
 import { useState } from "react";
 import { useTranslations } from "next-intl";
-import { DeleteAllClipsModal } from "@/features/clip/ui/DeleteAllClipsModal";
 import { useTrashPage } from "@/features/trash/hooks/useTrashPage";
 import { TrashListSection } from "@/features/trash/ui/TrashListSection";
 import { TrashPageEmptyState } from "@/features/trash/ui/TrashPageEmptyState";
 import { TrashPageHeader } from "@/features/trash/ui/TrashPageHeader";
 import type { TrashItemRow } from "@/features/trash/ui/trashRow";
+import { ConfirmActionModal } from "@/shared/ui/overlay/ConfirmActionModal";
 
 const getClipTypeLabel = (
   clipType: "TEXT" | "COLOR" | "IMAGE",
@@ -25,7 +25,12 @@ const getClipTypeLabel = (
 };
 
 // 휴지통 페이지의 상태에 따라 안내, 빈 상태, 리스트 섹션을 조합하는 루트 컴포넌트입니다.
-export function TrashPage() {
+interface TrashPageProps {
+  activeFolders: Array<{ id: string; name: string }>;
+  onItemsChanged?: () => void | Promise<void>;
+}
+
+export function TrashPage({ activeFolders, onItemsChanged }: TrashPageProps) {
   const t = useTranslations("trash");
   const [deleteModal, setDeleteModal] = useState<
     "clearAll" | "selected" | null
@@ -33,7 +38,10 @@ export function TrashPage() {
   const [selectedRowKeys, setSelectedRowKeys] = useState<Set<string>>(
     () => new Set(),
   );
-  const { actions, context, results } = useTrashPage();
+  const { actions, context, results } = useTrashPage({
+    activeFolders,
+    onItemsChanged,
+  });
   const { items } = results;
   const deletedFolderIds = new Set(
     items
@@ -213,7 +221,7 @@ export function TrashPage() {
         />
       ) : null}
 
-      <DeleteAllClipsModal
+      <ConfirmActionModal
         isOpen={deleteModal !== null}
         title={
           deleteModal === "selected"

--- a/src/shared/ui/overlay/ConfirmActionModal.stories.tsx
+++ b/src/shared/ui/overlay/ConfirmActionModal.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { ConfirmActionModal } from "@/shared/ui/overlay/ConfirmActionModal";
+
+const meta = {
+  title: "Shared UI/ConfirmActionModal",
+  component: ConfirmActionModal,
+  parameters: {
+    layout: "fullscreen",
+  },
+  args: {
+    isOpen: true,
+    title: "항목을 삭제할까요?",
+    description: "삭제한 항목은 복구할 수 없습니다.",
+    cancelLabel: "취소",
+    confirmLabel: "삭제",
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+  },
+} satisfies Meta<typeof ConfirmActionModal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Confirming: Story = {
+  args: {
+    confirmLabel: "삭제 중",
+    isConfirming: true,
+  },
+};

--- a/src/shared/ui/overlay/ConfirmActionModal.tsx
+++ b/src/shared/ui/overlay/ConfirmActionModal.tsx
@@ -3,8 +3,7 @@
 import { Button } from "@/shared/ui/button/Button";
 import { Modal } from "@/shared/ui/overlay/Modal";
 
-// 현재 폴더의 모든 클립 삭제를 확인하고 요청 진행 중 액션을 잠급니다.
-interface DeleteAllClipsModalProps {
+interface ConfirmActionModalProps {
   isOpen: boolean;
   title: string;
   description: string;
@@ -15,7 +14,8 @@ interface DeleteAllClipsModalProps {
   onConfirm: () => void;
 }
 
-export function DeleteAllClipsModal({
+// 파괴적 작업의 설명과 진행 상태를 표시하는 공통 확인 모달입니다.
+export function ConfirmActionModal({
   isOpen,
   title,
   description,
@@ -24,7 +24,7 @@ export function DeleteAllClipsModal({
   isConfirming = false,
   onCancel,
   onConfirm,
-}: DeleteAllClipsModalProps) {
+}: ConfirmActionModalProps) {
   return (
     <Modal isOpen={isOpen} contentClassName="w-full max-w-sm">
       <div className="rounded-xl bg-(--surface-elevated) shadow-xl">


### PR DESCRIPTION
## PR 요약

- 기능 도메인별 최소 공개 API를 정의하고 app 조정 계층을 통해 feature 간 순환 의존을 제거했습니다.

## 변경 내용 상세

### 변경 사항

- Auth, Clip, Folder, Landing, Pricing, Settings, Subscription, Trash에 공개 `index.ts`를 추가했습니다.
- App Router와 다른 feature가 내부 `api`, `hooks`, `model`, `service`, `ui` 경로 대신 공개 API를 사용하도록 변경했습니다.
- 클립 삭제, 폴더 삭제, 휴지통 복원·삭제 후 여러 feature 캐시를 갱신하는 책임을 app 조정 컴포넌트로 이동했습니다.
- 인증 후 사용자 설정 동기화를 `UserSettingsSync`로 분리해 Auth와 Settings의 순환 의존을 제거했습니다.
- Pricing이 Subscription 내부 API와 query cache를 직접 사용하지 않고 공개 `useSubscriptionActions` hook을 사용하도록 변경했습니다.
- Clip 전용 삭제 확인 모달을 도메인 비종속 `ConfirmActionModal`로 이동하고 Storybook 상태를 추가했습니다.

### 변경 이유

- feature 구현 세부 사항이 다른 도메인으로 노출되는 것을 막고 `app -> features -> shared` 의존성 방향을 유지하기 위함입니다.
- mutation 이후 여러 도메인의 캐시를 조정하는 책임을 개별 feature가 아닌 app 레이어에서 관리하기 위함입니다.

## 관련 이슈

- Closes #108

## 검증 결과

- `npm run lint` 통과
- `npm run build` 통과
- `npm run build-storybook` 통과
- `git diff --check` 통과
- feature 간 import graph에서 양방향·순환 의존 및 외부 내부 경로 import가 없음을 확인
- `/`, `/login`, `/pricing` 200 응답 확인
- 미인증 상태에서 `/favorites`, `/recent`, `/trash`, `/billing`이 `/login`으로 307 이동하는 것 확인

## 기타 참고사항

- 렌더링 결과를 변경하지 않는 구조 리팩터링이므로 Before/After 스크린샷은 첨부하지 않았습니다.
- 구조 경계 자동화는 이번 PR에 포함하지 않았으며, 필요하면 별도 이슈에서 검증 도구와 CI 연동을 도입합니다.
- 작업 트리의 `FEATURES_ARCHITECTURE_REVIEW.md`는 이번 PR에 포함하지 않았습니다.