### PR TITLE
#109 / fix(subscription) : Toss SDK 재시도와 결제 오류 피드백 수정

### DIFF
--- a/src/features/subscription/ui/BillingCheckoutCard.tsx
+++ b/src/features/subscription/ui/BillingCheckoutCard.tsx
@@ -1,24 +1,19 @@
 import { HiOutlineRefresh } from "react-icons/hi";
-import type { BillingAuthRequestResponseDto } from "@/features/subscription/model/subscription.dto";
 import { BillingUnlockedFeatureList } from "@/features/subscription/ui/BillingUnlockedFeatureList";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 
 export type BillingStep = "idle" | "loading" | "redirecting" | "error";
 
-// Pro 요금과 제공 기능, 인증 정보, 결제 시작 상태를 하나의 카드로 표시합니다.
+// Pro 요금, 제공 기능과 결제 시작 상태를 하나의 카드로 표시합니다.
 interface BillingCheckoutCardProps {
   actionLabel: string;
-  billingAuth: BillingAuthRequestResponseDto | null;
-  message: string | null;
   onStartBilling: () => void;
   step: BillingStep;
 }
 
 export function BillingCheckoutCard({
   actionLabel,
-  billingAuth,
-  message,
   onStartBilling,
   step,
 }: BillingCheckoutCardProps) {
@@ -40,24 +35,6 @@ export function BillingCheckoutCard({
       </div>
 
       <BillingUnlockedFeatureList />
-
-      {billingAuth ? (
-        <div className="mt-4 rounded-xl border border-(--border) px-4 py-3 text-sm text-(--muted)">
-          <p className="font-medium text-(--foreground)">결제 인증 정보</p>
-          <p className="mt-1 break-all">
-            customerKey: {billingAuth.customerKey}
-          </p>
-        </div>
-      ) : null}
-
-      {message ? (
-        <p
-          className="mt-4 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300"
-          role="alert"
-        >
-          {message}
-        </p>
-      ) : null}
 
       <Button
         onClick={onStartBilling}

--- a/src/features/subscription/ui/BillingPage.tsx
+++ b/src/features/subscription/ui/BillingPage.tsx
@@ -19,6 +19,7 @@ import {
   type BillingStep,
 } from "@/features/subscription/ui/BillingCheckoutCard";
 import { BillingHeroSection } from "@/features/subscription/ui/BillingHeroSection";
+import { notifyError, notifySuccess } from "@/shared/feedback/toast";
 import { ApiError } from "@/shared/lib/apiClient";
 import { useSession } from "@/shared/session/useSession";
 
@@ -42,40 +43,56 @@ declare global {
 const TOSS_PAYMENTS_SCRIPT_ID = "toss-payments-sdk";
 const TOSS_PAYMENTS_SCRIPT_SRC = "https://js.tosspayments.com/v1/payment";
 
-const loadTossPaymentsScript = () =>
-  new Promise<void>((resolve, reject) => {
-    if (typeof window === "undefined") {
-      reject(new Error("결제 환경을 확인할 수 없습니다."));
-      return;
-    }
+let tossPaymentsScriptPromise: Promise<void> | null = null;
 
-    // Toss SDK는 결제 시작 시점에만 필요하므로 초기 번들에 포함하지 않는다.
-    if (window.TossPayments) {
-      resolve();
-      return;
-    }
+const loadTossPaymentsScript = () => {
+  if (typeof window === "undefined") {
+    return Promise.reject(new Error("결제 환경을 확인할 수 없습니다."));
+  }
 
-    // 기존 script가 로딩 중인 경우 중복 삽입하지 않고 완료 이벤트만 구독한다.
-    const existingScript = document.getElementById(TOSS_PAYMENTS_SCRIPT_ID);
-    if (existingScript) {
-      existingScript.addEventListener("load", () => resolve(), { once: true });
-      existingScript.addEventListener(
-        "error",
-        () => reject(new Error("결제 모듈을 불러오지 못했습니다.")),
-        { once: true },
-      );
-      return;
-    }
+  // Toss SDK는 결제 시작 시점에만 필요하므로 초기 번들에 포함하지 않는다.
+  if (window.TossPayments) {
+    return Promise.resolve();
+  }
+
+  if (tossPaymentsScriptPromise) {
+    return tossPaymentsScriptPromise;
+  }
+
+  tossPaymentsScriptPromise = new Promise<void>((resolve, reject) => {
+    document.getElementById(TOSS_PAYMENTS_SCRIPT_ID)?.remove();
+
+    const resetScriptPromise = () => {
+      tossPaymentsScriptPromise = null;
+    };
 
     const script = document.createElement("script");
     script.id = TOSS_PAYMENTS_SCRIPT_ID;
     script.src = TOSS_PAYMENTS_SCRIPT_SRC;
     script.async = true;
-    script.onload = () => resolve();
-    script.onerror = () =>
+
+    script.onload = () => {
+      resetScriptPromise();
+      if (window.TossPayments) {
+        resolve();
+        return;
+      }
+
+      script.remove();
+      reject(new Error("결제 모듈을 시작하지 못했습니다."));
+    };
+
+    script.onerror = () => {
+      resetScriptPromise();
+      script.remove();
       reject(new Error("결제 모듈을 불러오지 못했습니다."));
+    };
+
     document.head.appendChild(script);
   });
+
+  return tossPaymentsScriptPromise;
+};
 
 const mapBillingAuthMethod = (
   method: BillingAuthRequestResponseDto["method"],
@@ -87,10 +104,7 @@ export function BillingPage() {
   const queryClient = useQueryClient();
   const { user } = useSession();
   const userId = user?.id ?? null;
-  const [billingAuth, setBillingAuth] =
-    useState<BillingAuthRequestResponseDto | null>(null);
   const [step, setStep] = useState<BillingStep>("idle");
-  const [message, setMessage] = useState<string | null>(null);
 
   const handleStartBilling = async () => {
     if (step === "loading" || step === "redirecting") {
@@ -98,7 +112,6 @@ export function BillingPage() {
     }
 
     setStep("loading");
-    setMessage(null);
 
     try {
       const currentSubscription = await fetchMySubscription();
@@ -107,7 +120,7 @@ export function BillingPage() {
         const nextSubscription = await updateMySubscription({ type: "RESUME" });
         syncMySubscriptionQueryData(queryClient, nextSubscription, userId);
         setStep("idle");
-        setMessage("Pro 구독 자동갱신이 재개되었습니다.");
+        notifySuccess("Pro 구독 자동갱신이 재개되었습니다.");
         router.push("/pricing");
         return;
       }
@@ -115,7 +128,6 @@ export function BillingPage() {
       // 백엔드가 customerKey/successUrl/failUrl을 생성하고,
       // 프론트는 해당 값으로 Toss 빌링 인증 화면만 호출한다.
       const request = await createBillingAuthRequest();
-      setBillingAuth(request);
       setStep("redirecting");
 
       await loadTossPaymentsScript();
@@ -152,7 +164,7 @@ export function BillingPage() {
       }
 
       setStep("error");
-      setMessage(
+      notifyError(
         error instanceof Error
           ? error.message
           : "결제 인증을 시작하지 못했습니다.",
@@ -172,8 +184,6 @@ export function BillingPage() {
                 ? "결제 인증 이동 중"
                 : "카드 인증하고 Pro 시작"
           }
-          billingAuth={billingAuth}
-          message={message}
           onStartBilling={() => {
             void handleStartBilling();
           }}


### PR DESCRIPTION
## PR 요약

- Toss Payments SDK 로딩 실패 후 재시도 시 결제 버튼이 무한 로딩에 머무는 문제를 수정합니다.

## 변경 내용 상세

### 변경 사항

- Toss SDK 로딩을 module-level Promise로 관리해 동시 호출은 같은 로딩 작업을 공유하도록 변경했습니다.
- SDK script 로딩 실패 또는 Toss 전역 객체 초기화 실패 시 script 요소와 Promise 상태를 정리해 다음 시도에서 새 script를 삽입하도록 수정했습니다.
- 결제 인증 정보(customerKey) 표시 영역을 제거했습니다.
- 결제 오류 메시지를 인라인 alert 대신 앱 공통 toast 알림으로 표시하도록 변경했습니다.

### 변경 이유

- 실패한 `toss-payments-sdk` script 요소가 DOM에 남으면 다음 결제 시도에서 이미 종료된 script 이벤트를 기다리며 `loading` 또는 `redirecting` 상태에 머무를 수 있습니다.
- 결제 인증 정보는 사용자에게 노출할 필요가 낮고, 오류 피드백은 앱 전역 toast 패턴과 맞추는 편이 일관적입니다.

## 관련 이슈

- Closes #109

## 기타 참고사항

- 검증: `npm run lint` 통과
- 검증: `npm run build` 통과