### PR TITLE
#110 / fix(settings) : 테마 초기화 기준을 쿠키로 정리

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,7 +32,7 @@ export default async function RootLayout({
     >
       <body className="bg-background text-foreground antialiased">
         <QueryProvider>
-          {/* 서버 설정 또는 theme cookie 초기값을 런타임 설정 store와 next-intl provider에 연결합니다. */}
+          {/* 서버 설정 또는 settings cookie 초기값을 런타임 설정 store와 next-intl provider에 연결합니다. */}
           <AppSettingsProvider
             initialLocale={initialSettings.language}
             initialTheme={initialSettings.theme}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,7 +4,7 @@ import { SessionProvider } from "@/app/providers/session/SessionProvider";
 import { hasAuthSessionCookie } from "@/features/auth/server";
 import { getInitialUserSettings } from "@/features/settings/server";
 import { AppToaster } from "@/shared/feedback/AppToaster";
-import { IntlProvider } from "@/shared/providers/IntlProvider";
+import { AppSettingsProvider } from "@/shared/providers/AppSettingsProvider";
 import { QueryProvider } from "@/shared/providers/QueryProvider";
 import "./globals.css";
 
@@ -19,10 +19,10 @@ export default async function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const [initialSettings, shouldRestoreSession] = await Promise.all([
-    getInitialUserSettings(),
-    hasAuthSessionCookie(),
-  ]);
+  const shouldRestoreSession = await hasAuthSessionCookie();
+  const initialSettings = await getInitialUserSettings({
+    shouldFetchServerSettings: shouldRestoreSession,
+  });
 
   return (
     <html
@@ -32,10 +32,10 @@ export default async function RootLayout({
     >
       <body className="bg-background text-foreground antialiased">
         <QueryProvider>
-          <IntlProvider
+          {/* 서버 설정 또는 theme cookie 초기값을 런타임 설정 store와 next-intl provider에 연결합니다. */}
+          <AppSettingsProvider
             initialLocale={initialSettings.language}
             initialTheme={initialSettings.theme}
-            preferServerSettings={initialSettings.source === "server"}
           >
             <SessionProvider shouldRestoreSession={shouldRestoreSession}>
               <UserSettingsSync
@@ -44,7 +44,7 @@ export default async function RootLayout({
               {children}
               <AppToaster />
             </SessionProvider>
-          </IntlProvider>
+          </AppSettingsProvider>
         </QueryProvider>
       </body>
     </html>

--- a/src/features/settings/model/settings.dto.ts
+++ b/src/features/settings/model/settings.dto.ts
@@ -2,9 +2,14 @@ import { APP_LOCALES, type AppLocale } from "@/shared/config/locale";
 
 export const SERVER_SUPPORTED_LANGUAGES = APP_LOCALES;
 
+// 서버가 사용자 설정에서 허용하는 언어 코드입니다.
 export type ServerSupportedLanguage = AppLocale;
 
-export type UserSettingsThemeDto = "LIGHT" | "DARK" | "SYSTEM";
+// 서버 사용자 설정 테마 값입니다. 프론트 정책상 시스템 테마는 사용하지 않습니다.
+export type UserSettingsThemeDto = "LIGHT" | "DARK";
+
+// 사용자 설정 수정 요청에서 보낼 수 있는 테마 값입니다.
+export type UpdateUserSettingsThemeDto = UserSettingsThemeDto;
 
 export interface UserSettingsResponseDto {
   id: string;
@@ -14,6 +19,6 @@ export interface UserSettingsResponseDto {
 }
 
 export interface UpdateUserSettingsDto {
-  theme?: UserSettingsThemeDto;
+  theme?: UpdateUserSettingsThemeDto;
   language?: ServerSupportedLanguage;
 }

--- a/src/features/settings/server/getInitialUserSettings.ts
+++ b/src/features/settings/server/getInitialUserSettings.ts
@@ -10,6 +10,7 @@ import {
 } from "@/shared/config/locale";
 import {
   DEFAULT_THEME,
+  LANGUAGE_COOKIE_NAME,
   THEME_COOKIE_NAME,
   isThemeMode,
   type ThemeMode,
@@ -23,8 +24,11 @@ export interface InitialUserSettings {
   theme: ThemeMode;
 }
 
-const buildFallbackSettings = (theme: ThemeMode): InitialUserSettings => ({
-  language: DEFAULT_LOCALE,
+const buildFallbackSettings = (
+  theme: ThemeMode,
+  language: AppLocale,
+): InitialUserSettings => ({
+  language,
   source: "fallback",
   theme,
 });
@@ -60,8 +64,12 @@ export async function getInitialUserSettings({
 }: GetInitialUserSettingsOptions = {}): Promise<InitialUserSettings> {
   const cookieStore = await cookies();
   const storedTheme = cookieStore.get(THEME_COOKIE_NAME)?.value;
+  const storedLanguage = cookieStore.get(LANGUAGE_COOKIE_NAME)?.value;
   const fallbackSettings = buildFallbackSettings(
     isThemeMode(storedTheme) ? storedTheme : DEFAULT_THEME,
+    storedLanguage && isAppLocale(storedLanguage)
+      ? storedLanguage
+      : DEFAULT_LOCALE,
   );
 
   if (!shouldFetchServerSettings) {

--- a/src/features/settings/server/getInitialUserSettings.ts
+++ b/src/features/settings/server/getInitialUserSettings.ts
@@ -8,7 +8,12 @@ import {
   isAppLocale,
   type AppLocale,
 } from "@/shared/config/locale";
-import { DEFAULT_THEME, type ThemeMode } from "@/shared/config/settings";
+import {
+  DEFAULT_THEME,
+  THEME_COOKIE_NAME,
+  isThemeMode,
+  type ThemeMode,
+} from "@/shared/config/settings";
 
 type InitialUserSettingsSource = "server" | "fallback";
 
@@ -18,11 +23,11 @@ export interface InitialUserSettings {
   theme: ThemeMode;
 }
 
-const FALLBACK_SETTINGS: InitialUserSettings = {
+const buildFallbackSettings = (theme: ThemeMode): InitialUserSettings => ({
   language: DEFAULT_LOCALE,
   source: "fallback",
-  theme: DEFAULT_THEME,
-};
+  theme,
+});
 
 const mapThemeFromServer = (
   theme: UserSettingsResponseDto["theme"],
@@ -34,10 +39,9 @@ const mapThemeFromServer = (
   return "dark";
 };
 
-const buildCookieHeader = async () => {
-  const cookieStore = await cookies();
-  const requestCookies = cookieStore.getAll();
-
+const buildCookieHeader = (
+  requestCookies: Array<{ name: string; value: string }>,
+) => {
   if (requestCookies.length === 0) {
     return null;
   }
@@ -47,11 +51,27 @@ const buildCookieHeader = async () => {
     .join("; ");
 };
 
-export async function getInitialUserSettings(): Promise<InitialUserSettings> {
-  const cookieHeader = await buildCookieHeader();
+interface GetInitialUserSettingsOptions {
+  shouldFetchServerSettings?: boolean;
+}
+
+export async function getInitialUserSettings({
+  shouldFetchServerSettings = true,
+}: GetInitialUserSettingsOptions = {}): Promise<InitialUserSettings> {
+  const cookieStore = await cookies();
+  const storedTheme = cookieStore.get(THEME_COOKIE_NAME)?.value;
+  const fallbackSettings = buildFallbackSettings(
+    isThemeMode(storedTheme) ? storedTheme : DEFAULT_THEME,
+  );
+
+  if (!shouldFetchServerSettings) {
+    return fallbackSettings;
+  }
+
+  const cookieHeader = buildCookieHeader(cookieStore.getAll());
 
   if (!cookieHeader) {
-    return FALLBACK_SETTINGS;
+    return fallbackSettings;
   }
 
   try {
@@ -63,7 +83,7 @@ export async function getInitialUserSettings(): Promise<InitialUserSettings> {
     });
 
     if (!response.ok) {
-      return FALLBACK_SETTINGS;
+      return fallbackSettings;
     }
 
     const settings = (await response.json()) as UserSettingsResponseDto;
@@ -71,11 +91,11 @@ export async function getInitialUserSettings(): Promise<InitialUserSettings> {
     return {
       language: isAppLocale(settings.language)
         ? settings.language
-        : FALLBACK_SETTINGS.language,
+        : fallbackSettings.language,
       source: "server",
       theme: mapThemeFromServer(settings.theme),
     };
   } catch {
-    return FALLBACK_SETTINGS;
+    return fallbackSettings;
   }
 }

--- a/src/features/settings/service/settingsService.ts
+++ b/src/features/settings/service/settingsService.ts
@@ -6,6 +6,7 @@ import {
   SERVER_SUPPORTED_LANGUAGES,
   ServerSupportedLanguage,
   UpdateUserSettingsDto,
+  UpdateUserSettingsThemeDto,
   UserSettingsThemeDto,
 } from "@/features/settings/model/settings.dto";
 import {
@@ -14,30 +15,17 @@ import {
   useSettingsStore,
 } from "@/shared/store/settingsStore";
 
-const getSystemTheme = (): ThemeMode => {
-  if (
-    typeof window !== "undefined" &&
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-  ) {
-    return "dark";
-  }
-
-  return "light";
-};
-
+// 서버 DTO의 대문자 테마 값을 클라이언트 전역 설정 값으로 변환합니다.
 const mapThemeFromServer = (theme: UserSettingsThemeDto): ThemeMode => {
   if (theme === "LIGHT") {
     return "light";
   }
 
-  if (theme === "DARK") {
-    return "dark";
-  }
-
-  return getSystemTheme();
+  return "dark";
 };
 
-const mapThemeToServer = (theme: ThemeMode): UserSettingsThemeDto =>
+// 프론트 정책은 light/dark만 허용하므로 수정 요청에도 SYSTEM을 보내지 않습니다.
+const mapThemeToServer = (theme: ThemeMode): UpdateUserSettingsThemeDto =>
   theme === "light" ? "LIGHT" : "DARK";
 
 export const isServerSupportedLanguage = (

--- a/src/shared/config/settings.ts
+++ b/src/shared/config/settings.ts
@@ -5,8 +5,9 @@ export type LanguageCode = AppLocale;
 
 export const DEFAULT_THEME: ThemeMode = "dark";
 
-// 서버 렌더링에서도 읽을 수 있도록 사용자 theme는 cookie에 저장합니다.
+// 서버 렌더링에서도 읽을 수 있도록 사용자 theme/language는 cookie에 저장합니다.
 export const THEME_COOKIE_NAME = "easy_clip_theme";
+export const LANGUAGE_COOKIE_NAME = "easy_clip_language";
 export const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
 
 export const isThemeMode = (value: string | undefined): value is ThemeMode =>

--- a/src/shared/config/settings.ts
+++ b/src/shared/config/settings.ts
@@ -4,3 +4,10 @@ export type ThemeMode = "light" | "dark";
 export type LanguageCode = AppLocale;
 
 export const DEFAULT_THEME: ThemeMode = "dark";
+
+// 서버 렌더링에서도 읽을 수 있도록 사용자 theme는 cookie에 저장합니다.
+export const THEME_COOKIE_NAME = "easy_clip_theme";
+export const THEME_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export const isThemeMode = (value: string | undefined): value is ThemeMode =>
+  value === "light" || value === "dark";

--- a/src/shared/providers/AppSettingsProvider.tsx
+++ b/src/shared/providers/AppSettingsProvider.tsx
@@ -42,7 +42,7 @@ export function AppSettingsProvider({
   const language = isSettingsReady ? storeLanguage : initialLocale;
 
   useIsomorphicLayoutEffect(() => {
-    // 서버가 결정한 초기 설정을 현재 런타임 store와 theme cookie에 반영합니다.
+    // 서버가 결정한 초기 설정을 현재 런타임 store와 settings cookie에 반영합니다.
     useSettingsStore.getState().hydrateFromServer({
       language: initialLocale,
       theme: initialTheme,

--- a/src/shared/providers/AppSettingsProvider.tsx
+++ b/src/shared/providers/AppSettingsProvider.tsx
@@ -14,11 +14,10 @@ import {
   useSettingsStore,
 } from "@/shared/store/settingsStore";
 
-interface IntlProviderProps {
+interface AppSettingsProviderProps {
   children: React.ReactNode;
   initialLocale: AppLocale;
   initialTheme: ThemeMode;
-  preferServerSettings: boolean;
 }
 
 const messagesByLocale = {
@@ -31,12 +30,11 @@ const messagesByLocale = {
 const useIsomorphicLayoutEffect =
   typeof window === "undefined" ? useEffect : useLayoutEffect;
 
-export function IntlProvider({
+export function AppSettingsProvider({
   children,
   initialLocale,
   initialTheme,
-  preferServerSettings,
-}: IntlProviderProps) {
+}: AppSettingsProviderProps) {
   const [isSettingsReady, setIsSettingsReady] = useState(false);
   const storeTheme = useSettingsStore((state) => state.theme);
   const storeLanguage = useSettingsStore((state) => state.language);
@@ -44,30 +42,13 @@ export function IntlProvider({
   const language = isSettingsReady ? storeLanguage : initialLocale;
 
   useIsomorphicLayoutEffect(() => {
-    let isMounted = true;
-
-    useSettingsStore.setState({
+    // 서버가 결정한 초기 설정을 현재 런타임 store와 theme cookie에 반영합니다.
+    useSettingsStore.getState().hydrateFromServer({
       language: initialLocale,
       theme: initialTheme,
     });
-
-    if (preferServerSettings) {
-      setIsSettingsReady(true);
-      return () => {
-        isMounted = false;
-      };
-    }
-
-    void Promise.resolve(useSettingsStore.persist.rehydrate()).finally(() => {
-      if (isMounted) {
-        setIsSettingsReady(true);
-      }
-    });
-
-    return () => {
-      isMounted = false;
-    };
-  }, [initialLocale, initialTheme, preferServerSettings]);
+    setIsSettingsReady(true);
+  }, [initialLocale, initialTheme]);
 
   useEffect(() => {
     applySettings(theme, language);

--- a/src/shared/providers/AppSettingsProvider.tsx
+++ b/src/shared/providers/AppSettingsProvider.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // 초기 사용자 설정을 반영해 다국어 메시지와 테마 상태를 제공합니다.
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef } from "react";
 import { NextIntlClientProvider } from "next-intl";
 import enMessages from "@/messages/en.json";
 import jaMessages from "@/messages/ja.json";
@@ -35,29 +35,39 @@ export function AppSettingsProvider({
   initialLocale,
   initialTheme,
 }: AppSettingsProviderProps) {
-  const [isSettingsReady, setIsSettingsReady] = useState(false);
+  const initialSettingsRef = useRef<{
+    language: AppLocale;
+    theme: ThemeMode;
+  } | null>(null);
+
+  // 자식이 첫 렌더에서 DEFAULT 설정을 읽지 않도록 SSR 초기값을 한 번만 먼저 주입합니다.
+  if (initialSettingsRef.current === null) {
+    initialSettingsRef.current = {
+      language: initialLocale,
+      theme: initialTheme,
+    };
+    useSettingsStore.getState().applyInitialSettings(initialSettingsRef.current);
+  }
+
   const storeTheme = useSettingsStore((state) => state.theme);
   const storeLanguage = useSettingsStore((state) => state.language);
-  const theme = isSettingsReady ? storeTheme : initialTheme;
-  const language = isSettingsReady ? storeLanguage : initialLocale;
 
   useIsomorphicLayoutEffect(() => {
-    // 서버가 결정한 초기 설정을 현재 런타임 store와 settings cookie에 반영합니다.
+    // 서버가 결정한 초기 설정을 settings cookie에도 반영합니다.
     useSettingsStore.getState().hydrateFromServer({
       language: initialLocale,
       theme: initialTheme,
     });
-    setIsSettingsReady(true);
   }, [initialLocale, initialTheme]);
 
   useEffect(() => {
-    applySettings(theme, language);
-  }, [language, theme]);
+    applySettings(storeTheme, storeLanguage);
+  }, [storeLanguage, storeTheme]);
 
   return (
     <NextIntlClientProvider
-      locale={language ?? initialLocale}
-      messages={messagesByLocale[language]}
+      locale={storeLanguage}
+      messages={messagesByLocale[storeLanguage]}
       timeZone={DEFAULT_TIME_ZONE}
     >
       {children}

--- a/src/shared/store/settingsStore.ts
+++ b/src/shared/store/settingsStore.ts
@@ -21,6 +21,10 @@ interface SettingsState {
   toggleTheme: () => void;
   setLanguage: (language: LanguageCode) => void;
   syncLanguage: (language: LanguageCode) => void;
+  applyInitialSettings: (settings: {
+    theme: ThemeMode;
+    language: LanguageCode;
+  }) => void;
   hydrateFromServer: (settings: {
     theme?: ThemeMode;
     language?: LanguageCode;
@@ -59,6 +63,7 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
     writeSettingsCookie(LANGUAGE_COOKIE_NAME, language);
     set({ language });
   },
+  applyInitialSettings: ({ theme, language }) => set({ theme, language }),
   hydrateFromServer: ({ theme, language }) => {
     if (theme) {
       writeSettingsCookie(THEME_COOKIE_NAME, theme);

--- a/src/shared/store/settingsStore.ts
+++ b/src/shared/store/settingsStore.ts
@@ -1,14 +1,11 @@
 "use client";
 
 import { create } from "zustand";
-import {
-  createJSONStorage,
-  persist,
-  type StateStorage,
-} from "zustand/middleware";
 import { DEFAULT_LOCALE } from "@/shared/config/locale";
 import {
   DEFAULT_THEME,
+  THEME_COOKIE_MAX_AGE_SECONDS,
+  THEME_COOKIE_NAME,
   type LanguageCode,
   type ThemeMode,
 } from "@/shared/config/settings";
@@ -29,36 +26,40 @@ interface SettingsState {
   }) => void;
 }
 
-const noopStorage: StateStorage = {
-  getItem: () => null,
-  setItem: () => undefined,
-  removeItem: () => undefined,
+const writeThemeCookie = (theme: ThemeMode) => {
+  document.cookie = [
+    `${THEME_COOKIE_NAME}=${theme}`,
+    `Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}`,
+    "Path=/",
+    "SameSite=Lax",
+  ].join("; ");
 };
-export const useSettingsStore = create<SettingsState>()(
-  persist(
-    (set, get) => ({
-      theme: DEFAULT_THEME,
-      language: DEFAULT_LOCALE,
-      setTheme: (theme) => set({ theme }),
-      toggleTheme: () =>
-        set({ theme: get().theme === "dark" ? "light" : "dark" }),
-      setLanguage: (language) => set({ language }),
-      syncLanguage: (language) => set({ language }),
-      hydrateFromServer: ({ theme, language }) =>
-        set((state) => ({
-          theme: theme ?? state.theme,
-          language: language ?? state.language,
-        })),
-    }),
-    {
-      name: "easy-clip-settings",
-      skipHydration: true,
-      storage: createJSONStorage(() =>
-        typeof window === "undefined" ? noopStorage : localStorage,
-      ),
-    },
-  ),
-);
+
+export const useSettingsStore = create<SettingsState>()((set, get) => ({
+  theme: DEFAULT_THEME,
+  language: DEFAULT_LOCALE,
+  setTheme: (theme) => {
+    writeThemeCookie(theme);
+    set({ theme });
+  },
+  toggleTheme: () => {
+    const theme = get().theme === "dark" ? "light" : "dark";
+    writeThemeCookie(theme);
+    set({ theme });
+  },
+  setLanguage: (language) => set({ language }),
+  syncLanguage: (language) => set({ language }),
+  hydrateFromServer: ({ theme, language }) => {
+    if (theme) {
+      writeThemeCookie(theme);
+    }
+
+    set((state) => ({
+      theme: theme ?? state.theme,
+      language: language ?? state.language,
+    }));
+  },
+}));
 
 export const applySettings = (theme: ThemeMode, language: LanguageCode) => {
   document.documentElement.dataset.theme = theme;

--- a/src/shared/store/settingsStore.ts
+++ b/src/shared/store/settingsStore.ts
@@ -4,6 +4,7 @@ import { create } from "zustand";
 import { DEFAULT_LOCALE } from "@/shared/config/locale";
 import {
   DEFAULT_THEME,
+  LANGUAGE_COOKIE_NAME,
   THEME_COOKIE_MAX_AGE_SECONDS,
   THEME_COOKIE_NAME,
   type LanguageCode,
@@ -26,9 +27,12 @@ interface SettingsState {
   }) => void;
 }
 
-const writeThemeCookie = (theme: ThemeMode) => {
+const writeSettingsCookie = (
+  name: typeof THEME_COOKIE_NAME | typeof LANGUAGE_COOKIE_NAME,
+  value: ThemeMode | LanguageCode,
+) => {
   document.cookie = [
-    `${THEME_COOKIE_NAME}=${theme}`,
+    `${name}=${value}`,
     `Max-Age=${THEME_COOKIE_MAX_AGE_SECONDS}`,
     "Path=/",
     "SameSite=Lax",
@@ -39,19 +43,29 @@ export const useSettingsStore = create<SettingsState>()((set, get) => ({
   theme: DEFAULT_THEME,
   language: DEFAULT_LOCALE,
   setTheme: (theme) => {
-    writeThemeCookie(theme);
+    writeSettingsCookie(THEME_COOKIE_NAME, theme);
     set({ theme });
   },
   toggleTheme: () => {
     const theme = get().theme === "dark" ? "light" : "dark";
-    writeThemeCookie(theme);
+    writeSettingsCookie(THEME_COOKIE_NAME, theme);
     set({ theme });
   },
-  setLanguage: (language) => set({ language }),
-  syncLanguage: (language) => set({ language }),
+  setLanguage: (language) => {
+    writeSettingsCookie(LANGUAGE_COOKIE_NAME, language);
+    set({ language });
+  },
+  syncLanguage: (language) => {
+    writeSettingsCookie(LANGUAGE_COOKIE_NAME, language);
+    set({ language });
+  },
   hydrateFromServer: ({ theme, language }) => {
     if (theme) {
-      writeThemeCookie(theme);
+      writeSettingsCookie(THEME_COOKIE_NAME, theme);
+    }
+
+    if (language) {
+      writeSettingsCookie(LANGUAGE_COOKIE_NAME, language);
     }
 
     set((state) => ({


### PR DESCRIPTION
## PR 요약

- 테마와 언어의 초기 렌더링 기준을 SSR에서 읽을 수 있는 cookie 기반으로 정리합니다.

## 변경 내용 상세

### 변경 사항

- `SYSTEM` 테마 타입과 브라우저 시스템 테마 해석 로직을 제거하고 light/dark 두 상태만 사용하도록 정리
- `easy_clip_theme`, `easy_clip_language` cookie를 추가해 SSR fallback 시에도 저장된 설정을 초기 `data-theme`와 `lang`에 반영
- 인증 쿠키가 있을 때만 서버 사용자 설정을 조회하고, 서버 설정 조회 실패 시 settings cookie를 fallback으로 사용
- `IntlProvider`를 `AppSettingsProvider`로 변경해 theme/language 초기화 책임을 명확화
- Zustand persist/localStorage 기반 설정 복원을 제거하고 theme/language 변경 시 cookie를 갱신하도록 변경

### 변경 이유

- `localStorage`는 SSR 단계에서 읽을 수 없어 첫 화면과 hydration 이후 설정이 달라질 수 있습니다.
- settings cookie는 서버 렌더링에서 읽을 수 있어 새로고침 첫 페인트의 theme/language 불일치를 줄일 수 있습니다.
- 테마 정책을 light/dark 두 상태로 단순화해 서버/클라이언트 매핑 불일치를 제거합니다.

## 관련 이슈

- Closes #110

## 기타 참고사항

- 검증 결과: `npm run lint` 통과
- 검증 결과: `npm run build` 통과
- 검증 결과: `git diff --check` 통과
- `FEATURES_ARCHITECTURE_REVIEW.md`는 기존 untracked 파일이라 PR 범위에서 제외했습니다.