### PR TITLE
#104 / fix(clips) : 조회 기록 실패를 복사 흐름에서 분리

### DIFF
--- a/src/features/clip/hooks/useClipCopyAction.ts
+++ b/src/features/clip/hooks/useClipCopyAction.ts
@@ -48,9 +48,13 @@ export const useClipCopyAction = ({
       }
 
       if (isAuthenticated) {
-        await recordClipView(clip.id);
-        moveClipToRecentCache(queryClient, clip.id);
-        void invalidateClipQueries(queryClient);
+        try {
+          await recordClipView(clip.id);
+          moveClipToRecentCache(queryClient, clip.id);
+          void invalidateClipQueries(queryClient);
+        } catch {
+          // 복사는 이미 성공했으므로 조회 기록 실패는 사용자에게 노출하지 않습니다.
+        }
       }
     },
     [isAuthenticated, isDisabled, queryClient, showCopyToast],


### PR DESCRIPTION
## PR 요약

- 클립 복사 후 조회 기록 요청 실패가 복사 성공 흐름을 깨지 않도록 격리합니다.

## 변경 내용 상세

### 변경 사항

- `recordClipView`와 최근 항목 cache 갱신 흐름을 별도 `try/catch`로 감쌌습니다.
- 클립보드 복사가 성공한 뒤 조회 기록 요청이 실패해도 `copyClip` Promise가 reject되지 않도록 했습니다.
- 조회 기록 실패는 복사 실패 토스트로 노출하지 않고 조용히 처리합니다.

### 변경 이유

- `POST /clips/{clipId}/views` 실패는 복사 자체의 실패가 아니라 부가 기록 실패입니다.
- 일반 목록의 `void actions.copyClip(...)` 경로에서 unhandled Promise rejection이 발생하지 않도록 합니다.
- 컨텍스트 메뉴 복사처럼 `await copyClipAction(clip)` 뒤 후속 UI 처리가 있는 경로가 중단되지 않도록 합니다.

## 관련 이슈

- Closes #104

## 기타 참고사항

- 검증 결과: `npm run lint` 통과
- 검증 결과: `npm run build` 통과
- 검증 결과: `git diff --check` 통과
- `FEATURES_ARCHITECTURE_REVIEW.md`는 기존 untracked 파일이라 PR 범위에서 제외했습니다.