### PR TITLE
#106 / fix(pricing) : 요금제 페이지 다국어와 CTA 디자인 개선

### DIFF
--- a/e2e/pricing.spec.ts
+++ b/e2e/pricing.spec.ts
@@ -1,0 +1,62 @@
+import { expect, test } from "@playwright/test";
+
+const pricingLocales = [
+  {
+    locale: "ko",
+    heading: /작업 방식에 맞는\s*EasyClip 플랜을 선택하세요\./,
+    proCta: "Pro로 업그레이드",
+    comparisonTitle: "핵심 비교",
+  },
+  {
+    locale: "en",
+    heading: /Choose the EasyClip plan\s*that fits how you work\./,
+    proCta: "Upgrade to Pro",
+    comparisonTitle: "Compare the essentials",
+  },
+  {
+    locale: "ja",
+    heading: /あなたの働き方に合う\s*EasyClipプランを選びましょう。/,
+    proCta: "Proにアップグレード",
+    comparisonTitle: "主な違いを比較",
+  },
+  {
+    locale: "zh",
+    heading: /选择适合你的\s*EasyClip 套餐。/,
+    proCta: "升级到 Pro",
+    comparisonTitle: "核心功能比较",
+  },
+] as const;
+
+for (const pricingLocale of pricingLocales) {
+  test(`요금제 페이지를 ${pricingLocale.locale} 언어로 가로 넘침 없이 렌더링한다`, async ({
+    context,
+    page,
+  }) => {
+    await context.addCookies([
+      {
+        name: "easy_clip_language",
+        value: pricingLocale.locale,
+        domain: "127.0.0.1",
+        path: "/",
+      },
+    ]);
+
+    await page.goto("/pricing");
+
+    await expect(
+      page.getByRole("heading", { name: pricingLocale.heading }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: pricingLocale.proCta }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: pricingLocale.comparisonTitle }),
+    ).toBeVisible();
+
+    const hasHorizontalOverflow = await page
+      .locator("html")
+      .evaluate((element) => element.scrollWidth > element.clientWidth);
+
+    expect(hasHorizontalOverflow).toBe(false);
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -101,8 +101,8 @@
   --pricing-button-bg: #111827;
   --pricing-button-bg-hover: #1f2937;
   --pricing-button-fg: #ffffff;
-  --pricing-button-featured-bg: #ffffff;
-  --pricing-button-featured-bg-hover: #e2e8f0;
+  --pricing-button-featured-bg: #b7bec9;
+  --pricing-button-featured-bg-hover: #d5dae2;
   --pricing-button-featured-fg: #0f172a;
 }
 
@@ -195,9 +195,9 @@
   --pricing-button-bg: #6366f1;
   --pricing-button-bg-hover: #818cf8;
   --pricing-button-fg: #f8fafc;
-  --pricing-button-featured-bg: #f8fafc;
-  --pricing-button-featured-bg-hover: #e2e8f0;
-  --pricing-button-featured-fg: #111827;
+  --pricing-button-featured-bg: #c5ccd6;
+  --pricing-button-featured-bg-hover: #e1e5eb;
+  --pricing-button-featured-fg: #0f172a;
 }
 
 /* -----------------------------------------------------------------------------

--- a/src/features/pricing/const/pricingContent.ts
+++ b/src/features/pricing/const/pricingContent.ts
@@ -1,84 +1,43 @@
+export type PricingPlanId = "free" | "pro";
+
+export type PricingPlanFeatureId =
+  | "projects"
+  | "clips"
+  | "devices"
+  | "organization"
+  | "ai";
+
 export interface PricingPlan {
-  name: string;
-  badge: string;
-  description: string;
-  price: string;
-  priceSuffix?: string;
-  billingNote: string;
-  ctaLabel: string;
+  id: PricingPlanId;
+  featureIds: readonly PricingPlanFeatureId[];
+  price: number;
   ctaHref: string;
   highlight: boolean;
-  features: readonly string[];
 }
 
-export interface PricingComparisonPoint {
-  label: string;
-  freeValue: string;
-  proValue: string;
-}
+export type PricingComparisonPointId =
+  | "projects"
+  | "clips"
+  | "devices"
+  | "organization"
+  | "ai";
 
 export const PRICING_PLANS: readonly PricingPlan[] = [
   {
-    name: "Free",
-    badge: "개인 시작용",
-    description: "가볍게 시작하고 검색 중심으로 클립을 정리하는 기본 플랜",
-    price: "₩0",
-    priceSuffix: "/ month",
-    billingNote: "월간 요금 없이 바로 사용",
-    ctaLabel: "무료로 시작하기",
+    id: "free",
+    price: 0,
     ctaHref: "/login",
     highlight: false,
-    features: [
-      "하나의 프로젝트 사용 가능",
-      "최대 50개의 클립 생성 가능",
-      "데스크톱 1개, 모바일 1개 연동 가능",
-      "검색 기능 사용 가능",
-    ],
+    featureIds: ["projects", "clips", "devices", "organization"],
   },
   {
-    name: "Pro",
-    badge: "집중 작업용",
-    description: "프로젝트를 여러 개 운영하고 태그 기반 정리가 필요한 플랜",
-    price: "₩3,900",
-    priceSuffix: "/ month",
-    billingNote: "월 3,900원으로 Pro 기능 사용",
-    ctaLabel: "Pro로 업그레이드",
+    id: "pro",
+    price: 3_900,
     ctaHref: "/billing",
     highlight: true,
-    features: [
-      "무제한 프로젝트 생성 가능",
-      "각 프로젝트당 최대 500개의 클립 생성 가능",
-      "무제한 기기 연동",
-      "태그 기능 사용 가능",
-      "AI 기능 추가 예정",
-    ],
+    featureIds: ["projects", "clips", "devices", "organization", "ai"],
   },
 ] as const;
 
-export const PRICING_COMPARISON_POINTS: readonly PricingComparisonPoint[] = [
-  {
-    label: "프로젝트 수",
-    freeValue: "1개",
-    proValue: "무제한",
-  },
-  {
-    label: "클립 수",
-    freeValue: "최대 50개",
-    proValue: "프로젝트당 최대 500개",
-  },
-  {
-    label: "기기 연동",
-    freeValue: "데스크톱 1개 + 모바일 1개",
-    proValue: "무제한 기기 연동",
-  },
-  {
-    label: "정리 방식",
-    freeValue: "검색",
-    proValue: "검색 + 태그",
-  },
-  {
-    label: "AI 기능",
-    freeValue: "미지원",
-    proValue: "추가 예정",
-  },
-] as const;
+export const PRICING_COMPARISON_POINT_IDS: readonly PricingComparisonPointId[] =
+  ["projects", "clips", "devices", "organization", "ai"] as const;

--- a/src/features/pricing/service/pricingFormatters.test.ts
+++ b/src/features/pricing/service/pricingFormatters.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import {
+  formatPricingAmount,
+  formatSubscriptionDate,
+} from "@/features/pricing/service/pricingFormatters";
+import type { AppLocale } from "@/shared/config/locale";
+
+const pricingLocales: readonly AppLocale[] = ["ko", "en", "ja", "zh"];
+const subscriptionDate = "2026-08-14T03:04:00.000Z";
+
+describe("pricingFormatters", () => {
+  it.each(pricingLocales)("%s 로케일의 통화 형식을 사용한다", (locale) => {
+    const expected = new Intl.NumberFormat(locale, {
+      style: "currency",
+      currency: "KRW",
+      maximumFractionDigits: 0,
+    }).format(3_900);
+
+    expect(formatPricingAmount(3_900, locale)).toBe(expected);
+  });
+
+  it.each(pricingLocales)("%s 로케일의 날짜 형식을 사용한다", (locale) => {
+    const expected = new Intl.DateTimeFormat(locale, {
+      dateStyle: "medium",
+      timeStyle: "short",
+    }).format(new Date(subscriptionDate));
+
+    expect(formatSubscriptionDate(subscriptionDate, locale, "-")).toBe(
+      expected,
+    );
+  });
+
+  it("없거나 올바르지 않은 날짜에는 대체 문구를 반환한다", () => {
+    expect(formatSubscriptionDate(null, "ko", "-")).toBe("-");
+    expect(formatSubscriptionDate("not-a-date", "ko", "-")).toBe("-");
+  });
+});

--- a/src/features/pricing/service/pricingFormatters.ts
+++ b/src/features/pricing/service/pricingFormatters.ts
@@ -1,0 +1,30 @@
+import type { AppLocale } from "@/shared/config/locale";
+
+// 선택 언어에 맞춰 금액과 구독 일시를 일관되게 표시합니다.
+export const formatPricingAmount = (amount: number, locale: AppLocale) =>
+  new Intl.NumberFormat(locale, {
+    style: "currency",
+    currency: "KRW",
+    maximumFractionDigits: 0,
+  }).format(amount);
+
+export const formatSubscriptionDate = (
+  value: string | null,
+  locale: AppLocale,
+  emptyValue: string,
+) => {
+  if (!value) {
+    return emptyValue;
+  }
+
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return emptyValue;
+  }
+
+  return new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+};

--- a/src/features/pricing/ui/PricingCancelModal.tsx
+++ b/src/features/pricing/ui/PricingCancelModal.tsx
@@ -3,24 +3,31 @@ import { Modal } from "@/shared/ui/overlay/Modal";
 
 // Pro 구독 취소 의사를 확인하고 진행 상태에 따라 액션을 제어합니다.
 interface PricingCancelModalProps {
+  cancelLabel: string;
+  confirmLabel: string;
+  confirmingLabel: string;
+  description: string;
   isCanceling: boolean;
   onCancel: () => void;
   onConfirm: () => void;
+  title: string;
 }
 
 export function PricingCancelModal({
+  cancelLabel,
+  confirmLabel,
+  confirmingLabel,
+  description,
   isCanceling,
   onCancel,
   onConfirm,
+  title,
 }: PricingCancelModalProps) {
   return (
     <Modal overlay="strong" contentClassName="w-full max-w-sm">
       <div className="rounded-2xl border border-(--border) bg-(--surface-elevated) p-5 shadow-xl">
-        <h2 className="text-lg font-semibold">Pro 구독을 취소할까요?</h2>
-        <p className="mt-3 text-sm leading-6 text-(--muted)">
-          확인을 누르면 Pro 구독의 자동 갱신이 중지되고 Free 플랜으로
-          전환됩니다.
-        </p>
+        <h2 className="text-lg font-semibold">{title}</h2>
+        <p className="mt-3 text-sm leading-6 text-(--muted)">{description}</p>
         <div className="mt-6 flex gap-2">
           <Button
             onClick={onCancel}
@@ -29,7 +36,7 @@ export function PricingCancelModal({
             size="lg"
             className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
           >
-            아니오
+            {cancelLabel}
           </Button>
           <Button
             onClick={onConfirm}
@@ -38,7 +45,7 @@ export function PricingCancelModal({
             size="lg"
             className="min-h-0 flex-1 py-2.5 font-semibold disabled:cursor-not-allowed disabled:opacity-60"
           >
-            {isCanceling ? "변경 중" : "예"}
+            {isCanceling ? confirmingLabel : confirmLabel}
           </Button>
         </div>
       </div>

--- a/src/features/pricing/ui/PricingComparisonSection.tsx
+++ b/src/features/pricing/ui/PricingComparisonSection.tsx
@@ -1,18 +1,22 @@
-import { PRICING_COMPARISON_POINTS } from "@/features/pricing/const/pricingContent";
+"use client";
+
+import { useTranslations } from "next-intl";
+import { PRICING_COMPARISON_POINT_IDS } from "@/features/pricing/const/pricingContent";
 
 // Free와 Pro 플랜의 핵심 차이를 접근 가능한 표로 비교합니다.
 export function PricingComparisonSection() {
+  const t = useTranslations("pricing.comparison");
+
   return (
     <section
       className="mt-8 rounded-[2rem] border border-(--border) bg-(--surface) p-6"
       style={{ boxShadow: "var(--pricing-compare-shadow)" }}
     >
       <div className="flex flex-col gap-3">
-        <p className="text-sm font-medium text-(--muted)">Quick comparison</p>
-        <h2 className="text-2xl font-semibold tracking-tight">핵심 비교</h2>
+        <p className="text-sm font-medium text-(--muted)">{t("eyebrow")}</p>
+        <h2 className="text-2xl font-semibold tracking-tight">{t("title")}</h2>
         <p className="max-w-2xl text-sm leading-6 text-(--muted)">
-          주요 차이를 표로 정리했습니다. 다른 요금제 페이지처럼 항목별로 바로
-          비교할 수 있도록 구성했습니다.
+          {t("description")}
         </p>
       </div>
 
@@ -22,20 +26,22 @@ export function PricingComparisonSection() {
             <thead>
               <tr className="bg-[var(--landing-demo-surface)] text-left">
                 <th className="px-5 py-4 text-sm font-semibold text-(--foreground)">
-                  항목
+                  {t("columns.feature")}
                 </th>
                 <th className="border-l border-(--border) px-5 py-4 text-sm font-semibold text-(--foreground)">
-                  Free
+                  {t("columns.free")}
                 </th>
                 <th className="border-l border-(--border) px-5 py-4 text-sm font-semibold">
-                  <span style={{ color: "var(--pricing-accent)" }}>Pro</span>
+                  <span style={{ color: "var(--pricing-accent)" }}>
+                    {t("columns.pro")}
+                  </span>
                 </th>
               </tr>
             </thead>
             <tbody>
-              {PRICING_COMPARISON_POINTS.map((point, index) => (
+              {PRICING_COMPARISON_POINT_IDS.map((point, index) => (
                 <tr
-                  key={point.label}
+                  key={point}
                   className={
                     index % 2 === 0
                       ? "bg-(--surface)"
@@ -43,14 +49,14 @@ export function PricingComparisonSection() {
                   }
                 >
                   <th className="border-t border-(--border) px-5 py-4 text-left text-sm font-medium text-(--foreground)">
-                    {point.label}
+                    {t(`points.${point}.label`)}
                   </th>
                   <td className="border-t border-l border-(--border) px-5 py-4 text-sm text-(--muted)">
-                    {point.freeValue}
+                    {t(`points.${point}.freeValue`)}
                   </td>
                   <td className="border-t border-l border-(--border) px-5 py-4 text-sm font-medium">
                     <span style={{ color: "var(--pricing-accent)" }}>
-                      {point.proValue}
+                      {t(`points.${point}.proValue`)}
                     </span>
                   </td>
                 </tr>

--- a/src/features/pricing/ui/PricingHeroSection.tsx
+++ b/src/features/pricing/ui/PricingHeroSection.tsx
@@ -1,7 +1,12 @@
+"use client";
+
+import { useTranslations } from "next-intl";
 import { HiOutlineSparkles } from "react-icons/hi";
 
 // 요금제 페이지의 목적과 선택 안내를 첫 영역에 표시합니다.
 export function PricingHeroSection() {
+  const t = useTranslations("pricing.hero");
+
   return (
     <div className="mx-auto max-w-3xl text-center">
       <div
@@ -12,13 +17,13 @@ export function PricingHeroSection() {
         }}
       >
         <HiOutlineSparkles className="h-4 w-4" aria-hidden />
-        <span>Simple plans for focused users</span>
+        <span>{t("eyebrow")}</span>
       </div>
 
       <h1 className="mt-6 text-4xl leading-tight font-semibold tracking-tight md:text-6xl">
-        작업 방식에 맞는
+        {t("titleLine1")}
         <br />
-        EasyClip 플랜을 선택하세요.
+        {t("titleLine2")}
       </h1>
     </div>
   );

--- a/src/features/pricing/ui/PricingPlanAction.tsx
+++ b/src/features/pricing/ui/PricingPlanAction.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import type { ComponentProps, MouseEventHandler, ReactNode } from "react";
+import { Button } from "@/shared/ui/button/Button";
+
+type PricingPlanActionProps =
+  | {
+      children: ReactNode;
+      href: ComponentProps<typeof Link>["href"];
+      kind: "link";
+    }
+  | {
+      children: ReactNode;
+      disabled?: boolean;
+      kind: "button";
+      onClick?: MouseEventHandler<HTMLButtonElement>;
+    };
+
+const actionClassName =
+  "mt-8 rounded-2xl font-semibold transition-[background-color,opacity,transform] duration-200 hover:opacity-90";
+
+const linkActionClassName =
+  "inline-flex w-full cursor-pointer items-center justify-center bg-(--pricing-button-bg) px-5 py-3 text-sm text-(--pricing-button-fg) hover:bg-(--pricing-button-bg-hover)";
+
+// 요금제 카드 CTA의 링크·버튼 시맨틱을 유지하면서 Free 카드 디자인을 일관되게 적용합니다.
+export function PricingPlanAction(props: PricingPlanActionProps) {
+  if (props.kind === "link") {
+    return (
+      <Link
+        href={props.href}
+        className={`${actionClassName} ${linkActionClassName}`}
+      >
+        {props.children}
+      </Link>
+    );
+  }
+
+  return (
+    <Button
+      type="button"
+      onClick={props.onClick}
+      disabled={props.disabled}
+      variant="pricing"
+      size="lg"
+      fullWidth
+      className={actionClassName}
+    >
+      {props.children}
+    </Button>
+  );
+}

--- a/src/features/pricing/ui/PricingPlanCard.tsx
+++ b/src/features/pricing/ui/PricingPlanCard.tsx
@@ -3,16 +3,30 @@ import { HiCheck } from "react-icons/hi";
 import type { PricingPlan } from "@/features/pricing/const/pricingContent";
 import { Badge } from "@/shared/ui/badge/Badge";
 
+export interface PricingPlanContent {
+  badge: string;
+  billingNote: string;
+  description: string;
+  features: readonly string[];
+  name: string;
+  price: string;
+  priceSuffix: string;
+}
+
 // 요금제의 가격, 기능 목록, 현재 상태와 액션을 하나의 비교 카드로 표시합니다.
 interface PricingPlanCardProps {
   action: ReactNode;
+  content: PricingPlanContent;
   plan: PricingPlan;
+  recommendedLabel: string;
   status?: ReactNode;
 }
 
 export function PricingPlanCard({
   action,
+  content,
   plan,
+  recommendedLabel,
   status,
 }: PricingPlanCardProps) {
   return (
@@ -40,10 +54,10 @@ export function PricingPlanCard({
                 : "text-(--muted)"
             }`}
           >
-            {plan.badge}
+            {content.badge}
           </p>
           <h2 className="mt-3 text-2xl font-semibold sm:text-3xl">
-            {plan.name}
+            {content.name}
           </h2>
         </div>
         {plan.highlight ? (
@@ -52,7 +66,7 @@ export function PricingPlanCard({
             size="sm"
             style={{ backgroundColor: "var(--pricing-featured-badge)" }}
           >
-            Recommended
+            {recommendedLabel}
           </Badge>
         ) : null}
       </div>
@@ -64,14 +78,14 @@ export function PricingPlanCard({
             : "text-(--muted)"
         }`}
       >
-        {plan.description}
+        {content.description}
       </p>
 
       <div className="mt-8 flex items-end gap-2">
         <span className="text-4xl font-semibold tracking-tight sm:text-5xl">
-          {plan.price}
+          {content.price}
         </span>
-        {plan.priceSuffix ? (
+        {content.priceSuffix ? (
           <span
             className={`pb-1 text-sm ${
               plan.highlight
@@ -79,7 +93,7 @@ export function PricingPlanCard({
                 : "text-(--muted)"
             }`}
           >
-            {plan.priceSuffix}
+            {content.priceSuffix}
           </span>
         ) : null}
       </div>
@@ -91,14 +105,14 @@ export function PricingPlanCard({
             : "text-(--muted)"
         }`}
       >
-        {plan.billingNote}
+        {content.billingNote}
       </p>
 
       {action}
       {status}
 
       <ul className="mt-8 space-y-4">
-        {plan.features.map((feature) => (
+        {content.features.map((feature) => (
           <li key={feature} className="flex items-start gap-3">
             <span
               className={`mt-0.5 inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full ${

--- a/src/features/pricing/ui/PricingPlansSection.tsx
+++ b/src/features/pricing/ui/PricingPlansSection.tsx
@@ -1,14 +1,22 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
+import { useLocale, useTranslations } from "next-intl";
 import {
   PRICING_PLANS,
   type PricingPlan,
 } from "@/features/pricing/const/pricingContent";
 import { PricingCancelModal } from "@/features/pricing/ui/PricingCancelModal";
-import { PricingPlanCard } from "@/features/pricing/ui/PricingPlanCard";
+import {
+  PricingPlanCard,
+  type PricingPlanContent,
+} from "@/features/pricing/ui/PricingPlanCard";
+import { PricingPlanAction } from "@/features/pricing/ui/PricingPlanAction";
+import {
+  formatPricingAmount,
+  formatSubscriptionDate,
+} from "@/features/pricing/service/pricingFormatters";
 import {
   hasRemainingCanceledProPeriod,
   isActiveProSubscription,
@@ -17,23 +25,15 @@ import {
 } from "@/features/subscription";
 import { notifyError, notifySuccess } from "@/shared/feedback/toast";
 import { ApiError } from "@/shared/lib/apiClient";
+import { DEFAULT_LOCALE, isAppLocale } from "@/shared/config/locale";
 import { useSession } from "@/shared/session/useSession";
-import { Button } from "@/shared/ui/button/Button";
-
-const formatSubscriptionDate = (value: string | null) => {
-  if (!value) {
-    return "-";
-  }
-
-  return new Intl.DateTimeFormat("ko-KR", {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(new Date(value));
-};
 
 // 구독 상태에 맞는 요금제 카드 액션과 취소 흐름을 조합합니다.
 export function PricingPlansSection() {
   const router = useRouter();
+  const t = useTranslations("pricing");
+  const currentLocale = useLocale();
+  const locale = isAppLocale(currentLocale) ? currentLocale : DEFAULT_LOCALE;
   const { status } = useSession();
   const { isAuthenticated, subscription } = useMySubscription();
   const { cancelSubscription, resumeSubscription, syncSubscription } =
@@ -53,11 +53,11 @@ export function PricingPlansSection() {
 
     try {
       await cancelSubscription();
-      notifySuccess("Pro 구독이 취소되었습니다.");
+      notifySuccess(t("toasts.cancelSuccess"));
       setIsCancelModalOpen(false);
       router.push("/favorites");
     } catch {
-      notifyError("구독 변경에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      notifyError(t("toasts.updateError"));
     } finally {
       setIsCancelingSubscription(false);
     }
@@ -72,18 +72,18 @@ export function PricingPlansSection() {
 
     try {
       await resumeSubscription();
-      notifySuccess("Pro 구독 자동갱신이 재개되었습니다.");
+      notifySuccess(t("toasts.resumeSuccess"));
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
         const latestSubscription = await syncSubscription().catch(() => null);
 
         if (isActiveProSubscription(latestSubscription)) {
-          notifySuccess("Pro 구독 자동갱신이 재개되었습니다.");
+          notifySuccess(t("toasts.resumeSuccess"));
           return;
         }
       }
 
-      notifyError("구독 변경에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      notifyError(t("toasts.updateError"));
     } finally {
       setIsResumingSubscription(false);
     }
@@ -100,46 +100,36 @@ export function PricingPlansSection() {
 
     if (isCurrentFreePlan || isCurrentProPlanCard) {
       return (
-        <Button
-          disabled
-          variant="secondaryMuted"
-          size="lg"
-          fullWidth
-          className="mt-8 cursor-not-allowed rounded-2xl font-semibold text-(--muted) disabled:cursor-not-allowed disabled:opacity-100"
-        >
-          현재 플랜
-        </Button>
+        <PricingPlanAction disabled kind="button">
+          {t("plans.currentPlan")}
+        </PricingPlanAction>
       );
     }
 
     if (isResumeTargetPlan) {
       return (
-        <Button
+        <PricingPlanAction
           onClick={() => {
             void handleResumeSubscription();
           }}
           disabled={isResumingSubscription}
-          variant="pricingFeatured"
-          size="lg"
-          fullWidth
-          className="mt-8 rounded-2xl font-semibold transition-[opacity,transform] duration-200 hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60"
+          kind="button"
         >
-          {isResumingSubscription ? "재개 중" : "구독 재개"}
-        </Button>
+          {isResumingSubscription
+            ? t("subscription.resuming")
+            : t("subscription.resume")}
+        </PricingPlanAction>
       );
     }
 
     if (isAuthenticated && isFreePlan && isCurrentProPlan) {
       return (
-        <Button
+        <PricingPlanAction
           onClick={() => setIsCancelModalOpen(true)}
-          variant="secondaryMuted"
-          size="lg"
-          fullWidth
-          className="mt-8 rounded-2xl font-semibold"
+          kind="button"
         >
-          Free로 전환하기
-        </Button>
+          {t("subscription.downgrade")}
+        </PricingPlanAction>
       );
     }
 
@@ -149,16 +139,9 @@ export function PricingPlansSection() {
         : plan.ctaHref;
 
     return (
-      <Link
-        href={planHref}
-        className={`mt-8 inline-flex w-full cursor-pointer items-center justify-center rounded-2xl px-5 py-3 text-sm font-semibold transition-[background-color,opacity,transform] duration-200 hover:opacity-90 ${
-          plan.highlight
-            ? "bg-(--pricing-button-featured-bg) text-(--pricing-button-featured-fg) hover:bg-(--pricing-button-featured-bg-hover)"
-            : "bg-(--pricing-button-bg) text-(--pricing-button-fg) hover:bg-(--pricing-button-bg-hover)"
-        }`}
-      >
-        <span>{plan.ctaLabel}</span>
-      </Link>
+      <PricingPlanAction href={planHref} kind="link">
+        {t(`plans.${plan.id}.cta`)}
+      </PricingPlanAction>
     );
   };
 
@@ -169,34 +152,57 @@ export function PricingPlansSection() {
 
     const renewalLabel = isCurrentProPlan
       ? subscription?.autoRenew
-        ? "자동갱신 활성화됨"
-        : "자동갱신 비활성화됨"
-      : "자동갱신 중지됨";
-    const billingDateLabel = isCurrentProPlan ? "다음 결제일" : "이용 종료일";
+        ? t("subscription.renewalEnabled")
+        : t("subscription.renewalDisabled")
+      : t("subscription.renewalStopped");
+    const billingDateLabel = isCurrentProPlan
+      ? t("subscription.nextBillingAt")
+      : t("subscription.currentPeriodEnd");
     const billingDateValue = isCurrentProPlan
       ? subscription?.nextBillingAt
       : subscription?.currentPeriodEnd;
 
     return (
       <div className="mt-4 rounded-2xl border border-white/15 bg-white/10 px-4 py-3 text-sm text-white">
-        <p className="font-semibold">현재 PRO 이용 중</p>
+        <p className="font-semibold">{t("subscription.currentPro")}</p>
         <p className="mt-1 text-[var(--pricing-featured-text)]">
           {renewalLabel}
         </p>
         <p className="mt-1 text-[var(--pricing-featured-text)]">
-          {billingDateLabel}: {formatSubscriptionDate(billingDateValue ?? null)}
+          {t("subscription.date", {
+            label: billingDateLabel,
+            value: formatSubscriptionDate(
+              billingDateValue ?? null,
+              locale,
+              t("subscription.emptyValue"),
+            ),
+          })}
         </p>
       </div>
     );
   };
+
+  const getPlanContent = (plan: PricingPlan): PricingPlanContent => ({
+    badge: t(`plans.${plan.id}.badge`),
+    billingNote: t(`plans.${plan.id}.billingNote`),
+    description: t(`plans.${plan.id}.description`),
+    features: plan.featureIds.map((featureId) =>
+      t(`plans.${plan.id}.features.${featureId}`),
+    ),
+    name: t(`plans.${plan.id}.name`),
+    price: formatPricingAmount(plan.price, locale),
+    priceSuffix: t(`plans.${plan.id}.priceSuffix`),
+  });
 
   return (
     <>
       <div className="mt-10 grid gap-4 sm:mt-12 sm:gap-6 lg:mt-16 lg:grid-cols-[0.95fr_1.05fr]">
         {PRICING_PLANS.map((plan) => (
           <PricingPlanCard
-            key={plan.name}
+            key={plan.id}
+            content={getPlanContent(plan)}
             plan={plan}
+            recommendedLabel={t("plans.recommended")}
             action={renderPlanAction(plan)}
             status={renderPlanStatus(plan)}
           />
@@ -210,6 +216,11 @@ export function PricingPlansSection() {
           onConfirm={() => {
             void handleCancelSubscription();
           }}
+          cancelLabel={t("subscription.cancelModal.dismiss")}
+          confirmLabel={t("subscription.cancelModal.confirm")}
+          confirmingLabel={t("subscription.cancelModal.confirming")}
+          description={t("subscription.cancelModal.description")}
+          title={t("subscription.cancelModal.title")}
         />
       ) : null}
     </>

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -35,6 +35,109 @@
       }
     }
   },
+  "pricing": {
+    "hero": {
+      "eyebrow": "Simple plans for focused work",
+      "titleLine1": "Choose the EasyClip plan",
+      "titleLine2": "that fits how you work."
+    },
+    "plans": {
+      "recommended": "Recommended",
+      "currentPlan": "Current plan",
+      "free": {
+        "name": "Free",
+        "badge": "For getting started",
+        "description": "A simple plan for organizing clips with the essentials and fast search.",
+        "priceSuffix": "/ month",
+        "billingNote": "Start right away with no monthly fee",
+        "cta": "Start for free",
+        "features": {
+          "projects": "Use 1 project",
+          "clips": "Create up to 50 clips",
+          "devices": "Connect 1 desktop and 1 mobile device",
+          "organization": "Use search",
+          "ai": ""
+        }
+      },
+      "pro": {
+        "name": "Pro",
+        "badge": "For focused work",
+        "description": "For managing multiple projects with tag-based organization.",
+        "priceSuffix": "/ month",
+        "billingNote": "Unlock Pro features for ₩3,900 per month",
+        "cta": "Upgrade to Pro",
+        "features": {
+          "projects": "Create unlimited projects",
+          "clips": "Create up to 500 clips per project",
+          "devices": "Connect unlimited devices",
+          "organization": "Use tags",
+          "ai": "AI features coming soon"
+        }
+      }
+    },
+    "subscription": {
+      "currentPro": "You are currently on Pro",
+      "renewalEnabled": "Auto-renewal is on.",
+      "renewalDisabled": "Auto-renewal is off.",
+      "renewalStopped": "Auto-renewal has stopped. You can keep using Pro until your access ends.",
+      "nextBillingAt": "Next billing date",
+      "currentPeriodEnd": "Access ends",
+      "date": "{label}: {value}",
+      "emptyValue": "-",
+      "downgrade": "Switch to Free",
+      "resume": "Resume subscription",
+      "resuming": "Resuming",
+      "cancelModal": {
+        "title": "Cancel your Pro subscription?",
+        "description": "This stops auto-renewal. Your plan will switch to Free after the current billing period ends.",
+        "dismiss": "No",
+        "confirm": "Yes",
+        "confirming": "Updating"
+      }
+    },
+    "comparison": {
+      "eyebrow": "Quick comparison",
+      "title": "Compare the essentials",
+      "description": "Compare the main differences side by side.",
+      "columns": {
+        "feature": "Feature",
+        "free": "Free",
+        "pro": "Pro"
+      },
+      "points": {
+        "projects": {
+          "label": "Projects",
+          "freeValue": "1",
+          "proValue": "Unlimited"
+        },
+        "clips": {
+          "label": "Clips",
+          "freeValue": "Up to 50",
+          "proValue": "Up to 500 per project"
+        },
+        "devices": {
+          "label": "Devices",
+          "freeValue": "1 desktop + 1 mobile",
+          "proValue": "Unlimited devices"
+        },
+        "organization": {
+          "label": "Organization",
+          "freeValue": "Search",
+          "proValue": "Search + tags"
+        },
+        "ai": {
+          "label": "AI features",
+          "freeValue": "Not available",
+          "proValue": "Coming soon"
+        }
+      }
+    },
+    "toasts": {
+      "cancelSuccess": "Your Pro subscription has been canceled.",
+      "resumeSuccess": "Pro auto-renewal has resumed.",
+      "updateError": "We could not update your subscription. Please try again shortly."
+    }
+  },
   "login": {
     "title": "Sign in to EasyClip",
     "subtitle": "Copy anywhere, paste everywhere",

--- a/src/messages/ja.json
+++ b/src/messages/ja.json
@@ -35,6 +35,109 @@
       }
     }
   },
+  "pricing": {
+    "hero": {
+      "eyebrow": "集中して作業する人のためのシンプルなプラン",
+      "titleLine1": "あなたの働き方に合う",
+      "titleLine2": "EasyClipプランを選びましょう。"
+    },
+    "plans": {
+      "recommended": "おすすめ",
+      "currentPlan": "現在のプラン",
+      "free": {
+        "name": "Free",
+        "badge": "個人のスタート向け",
+        "description": "基本機能と検索でクリップを整理できるシンプルなプランです。",
+        "priceSuffix": "/月",
+        "billingNote": "月額料金なしですぐに利用できます",
+        "cta": "無料で始める",
+        "features": {
+          "projects": "1つのプロジェクトを利用可能",
+          "clips": "最大50件のクリップを作成可能",
+          "devices": "デスクトップ1台、モバイル1台を連携可能",
+          "organization": "検索機能を利用可能",
+          "ai": ""
+        }
+      },
+      "pro": {
+        "name": "Pro",
+        "badge": "集中作業向け",
+        "description": "複数のプロジェクトを運用し、タグで整理したい人のためのプランです。",
+        "priceSuffix": "/月",
+        "billingNote": "月額₩3,900でPro機能を利用できます",
+        "cta": "Proにアップグレード",
+        "features": {
+          "projects": "プロジェクトを無制限に作成可能",
+          "clips": "プロジェクトごとに最大500件のクリップを作成可能",
+          "devices": "デバイスを無制限に連携可能",
+          "organization": "タグ機能を利用可能",
+          "ai": "AI機能は近日追加予定"
+        }
+      }
+    },
+    "subscription": {
+      "currentPro": "現在Proを利用中",
+      "renewalEnabled": "自動更新が有効です。",
+      "renewalDisabled": "自動更新が無効です。",
+      "renewalStopped": "自動更新を停止しました。利用終了日までPro機能を引き続き利用できます。",
+      "nextBillingAt": "次回請求日",
+      "currentPeriodEnd": "利用終了日",
+      "date": "{label}: {value}",
+      "emptyValue": "-",
+      "downgrade": "Freeに切り替える",
+      "resume": "サブスクリプションを再開",
+      "resuming": "再開中",
+      "cancelModal": {
+        "title": "Proサブスクリプションを解約しますか？",
+        "description": "確認すると自動更新が停止され、現在の請求期間が終わった後にFreeプランへ切り替わります。",
+        "dismiss": "いいえ",
+        "confirm": "はい",
+        "confirming": "変更中"
+      }
+    },
+    "comparison": {
+      "eyebrow": "クイック比較",
+      "title": "主な違いを比較",
+      "description": "主な違いを項目ごとにすぐ比較できます。",
+      "columns": {
+        "feature": "項目",
+        "free": "Free",
+        "pro": "Pro"
+      },
+      "points": {
+        "projects": {
+          "label": "プロジェクト数",
+          "freeValue": "1件",
+          "proValue": "無制限"
+        },
+        "clips": {
+          "label": "クリップ数",
+          "freeValue": "最大50件",
+          "proValue": "プロジェクトごとに最大500件"
+        },
+        "devices": {
+          "label": "デバイス連携",
+          "freeValue": "デスクトップ1台 + モバイル1台",
+          "proValue": "無制限のデバイス連携"
+        },
+        "organization": {
+          "label": "整理方法",
+          "freeValue": "検索",
+          "proValue": "検索 + タグ"
+        },
+        "ai": {
+          "label": "AI機能",
+          "freeValue": "未対応",
+          "proValue": "近日追加予定"
+        }
+      }
+    },
+    "toasts": {
+      "cancelSuccess": "Proサブスクリプションを解約しました。",
+      "resumeSuccess": "Proの自動更新を再開しました。",
+      "updateError": "サブスクリプションを変更できませんでした。しばらくしてから再試行してください。"
+    }
+  },
   "login": {
     "title": "EasyClip にログイン",
     "subtitle": "どこでもコピーして、どこでも貼り付け",

--- a/src/messages/ko.json
+++ b/src/messages/ko.json
@@ -35,6 +35,109 @@
       }
     }
   },
+  "pricing": {
+    "hero": {
+      "eyebrow": "집중해서 일하는 사용자를 위한 간단한 요금제",
+      "titleLine1": "작업 방식에 맞는",
+      "titleLine2": "EasyClip 플랜을 선택하세요."
+    },
+    "plans": {
+      "recommended": "추천",
+      "currentPlan": "현재 플랜",
+      "free": {
+        "name": "Free",
+        "badge": "개인 시작용",
+        "description": "가볍게 시작하고 검색 중심으로 클립을 정리하는 기본 플랜",
+        "priceSuffix": "/월",
+        "billingNote": "월간 요금 없이 바로 사용",
+        "cta": "무료로 시작하기",
+        "features": {
+          "projects": "프로젝트 1개 사용 가능",
+          "clips": "최대 50개의 클립 생성 가능",
+          "devices": "데스크톱 1개, 모바일 1개 연동 가능",
+          "organization": "검색 기능 사용 가능",
+          "ai": ""
+        }
+      },
+      "pro": {
+        "name": "Pro",
+        "badge": "집중 작업용",
+        "description": "프로젝트를 여러 개 운영하고 태그 기반 정리가 필요한 플랜",
+        "priceSuffix": "/월",
+        "billingNote": "월 3,900원으로 Pro 기능 사용",
+        "cta": "Pro로 업그레이드",
+        "features": {
+          "projects": "무제한 프로젝트 생성 가능",
+          "clips": "프로젝트당 최대 500개의 클립 생성 가능",
+          "devices": "무제한 기기 연동",
+          "organization": "태그 기능 사용 가능",
+          "ai": "AI 기능 추가 예정"
+        }
+      }
+    },
+    "subscription": {
+      "currentPro": "현재 Pro 이용 중",
+      "renewalEnabled": "자동 갱신이 활성화되어 있습니다.",
+      "renewalDisabled": "자동 갱신이 비활성화되어 있습니다.",
+      "renewalStopped": "자동 갱신이 중지되었습니다. 이용 종료일까지 Pro 기능을 계속 이용할 수 있습니다.",
+      "nextBillingAt": "다음 결제일",
+      "currentPeriodEnd": "이용 종료일",
+      "date": "{label}: {value}",
+      "emptyValue": "-",
+      "downgrade": "Free로 전환하기",
+      "resume": "구독 재개",
+      "resuming": "재개 중",
+      "cancelModal": {
+        "title": "Pro 구독을 취소할까요?",
+        "description": "확인하면 자동 갱신이 중지되며, 현재 결제 기간이 끝난 뒤 Free 플랜으로 전환됩니다.",
+        "dismiss": "아니오",
+        "confirm": "예",
+        "confirming": "변경 중"
+      }
+    },
+    "comparison": {
+      "eyebrow": "빠른 비교",
+      "title": "핵심 비교",
+      "description": "주요 차이를 항목별로 바로 비교할 수 있도록 정리했습니다.",
+      "columns": {
+        "feature": "항목",
+        "free": "Free",
+        "pro": "Pro"
+      },
+      "points": {
+        "projects": {
+          "label": "프로젝트 수",
+          "freeValue": "1개",
+          "proValue": "무제한"
+        },
+        "clips": {
+          "label": "클립 수",
+          "freeValue": "최대 50개",
+          "proValue": "프로젝트당 최대 500개"
+        },
+        "devices": {
+          "label": "기기 연동",
+          "freeValue": "데스크톱 1개 + 모바일 1개",
+          "proValue": "무제한 기기 연동"
+        },
+        "organization": {
+          "label": "정리 방식",
+          "freeValue": "검색",
+          "proValue": "검색 + 태그"
+        },
+        "ai": {
+          "label": "AI 기능",
+          "freeValue": "미지원",
+          "proValue": "추가 예정"
+        }
+      }
+    },
+    "toasts": {
+      "cancelSuccess": "Pro 구독이 취소되었습니다.",
+      "resumeSuccess": "Pro 구독 자동 갱신이 재개되었습니다.",
+      "updateError": "구독 변경에 실패했습니다. 잠시 후 다시 시도해주세요."
+    }
+  },
   "login": {
     "title": "EasyClip에 로그인",
     "subtitle": "어디서든 복사하고, 어디서나 붙여넣기",

--- a/src/messages/zh.json
+++ b/src/messages/zh.json
@@ -35,6 +35,109 @@
       }
     }
   },
+  "pricing": {
+    "hero": {
+      "eyebrow": "为专注工作打造的简洁套餐",
+      "titleLine1": "选择适合你的",
+      "titleLine2": "EasyClip 套餐。"
+    },
+    "plans": {
+      "recommended": "推荐",
+      "currentPlan": "当前套餐",
+      "free": {
+        "name": "Free",
+        "badge": "适合个人起步",
+        "description": "使用基础功能和搜索整理剪贴内容的入门套餐。",
+        "priceSuffix": "/月",
+        "billingNote": "无需月费，立即开始使用",
+        "cta": "免费开始",
+        "features": {
+          "projects": "可使用 1 个项目",
+          "clips": "最多创建 50 条剪贴内容",
+          "devices": "可连接 1 台桌面设备和 1 台移动设备",
+          "organization": "可使用搜索功能",
+          "ai": ""
+        }
+      },
+      "pro": {
+        "name": "Pro",
+        "badge": "适合专注工作",
+        "description": "适合管理多个项目并使用标签整理内容的用户。",
+        "priceSuffix": "/月",
+        "billingNote": "每月 ₩3,900，解锁 Pro 功能",
+        "cta": "升级到 Pro",
+        "features": {
+          "projects": "可创建无限项目",
+          "clips": "每个项目最多创建 500 条剪贴内容",
+          "devices": "可连接无限设备",
+          "organization": "可使用标签功能",
+          "ai": "AI 功能即将推出"
+        }
+      }
+    },
+    "subscription": {
+      "currentPro": "当前正在使用 Pro",
+      "renewalEnabled": "已开启自动续订。",
+      "renewalDisabled": "已关闭自动续订。",
+      "renewalStopped": "自动续订已停止。在使用结束日期前，你仍可继续使用 Pro 功能。",
+      "nextBillingAt": "下次扣费日期",
+      "currentPeriodEnd": "使用结束日期",
+      "date": "{label}：{value}",
+      "emptyValue": "-",
+      "downgrade": "切换到 Free",
+      "resume": "恢复订阅",
+      "resuming": "正在恢复",
+      "cancelModal": {
+        "title": "要取消 Pro 订阅吗？",
+        "description": "确认后将停止自动续订，并会在当前计费周期结束后切换到 Free 套餐。",
+        "dismiss": "否",
+        "confirm": "是",
+        "confirming": "正在更新"
+      }
+    },
+    "comparison": {
+      "eyebrow": "快速比较",
+      "title": "核心功能比较",
+      "description": "按项目快速比较主要差异。",
+      "columns": {
+        "feature": "项目",
+        "free": "Free",
+        "pro": "Pro"
+      },
+      "points": {
+        "projects": {
+          "label": "项目数量",
+          "freeValue": "1 个",
+          "proValue": "无限"
+        },
+        "clips": {
+          "label": "剪贴内容数量",
+          "freeValue": "最多 50 条",
+          "proValue": "每个项目最多 500 条"
+        },
+        "devices": {
+          "label": "设备连接",
+          "freeValue": "1 台桌面设备 + 1 台移动设备",
+          "proValue": "无限设备连接"
+        },
+        "organization": {
+          "label": "整理方式",
+          "freeValue": "搜索",
+          "proValue": "搜索 + 标签"
+        },
+        "ai": {
+          "label": "AI 功能",
+          "freeValue": "暂不支持",
+          "proValue": "即将推出"
+        }
+      }
+    },
+    "toasts": {
+      "cancelSuccess": "已取消 Pro 订阅。",
+      "resumeSuccess": "已恢复 Pro 自动续订。",
+      "updateError": "无法更新订阅，请稍后重试。"
+    }
+  },
   "login": {
     "title": "登录 EasyClip",
     "subtitle": "随处复制，随处粘贴",


### PR DESCRIPTION
## PR 요약

- 요금제 페이지의 다국어 표시와 카드 CTA 디자인을 개선합니다.

## 변경 내용 상세

### 변경 사항

- `ko`, `en`, `ja`, `zh` 로케일에 요금제 페이지 문구를 추가하고, 제목·플랜 정보·비교표·구독 상태·취소 안내·토스트를 번역 키로 전환했습니다.
- 선택한 로케일에 맞춰 요금제 금액과 구독 일시를 표시하는 포매터 및 단위 테스트를 추가했습니다.
- Free/Pro 카드의 CTA를 `PricingPlanAction`으로 통합하고, 모두 Free 카드 버튼 디자인을 사용하도록 정리했습니다.
- light·dark 테마에서 Pro CTA가 명확히 표시되도록 요금제 CTA 토큰을 조정했습니다.
- 4개 로케일의 요금제 화면 렌더링과 가로 넘침을 확인하는 Playwright 시나리오를 추가했습니다.

### 변경 이유

- 기존 요금제 화면에는 하드코딩된 문구가 남아 있어 선택한 언어와 화면 표시가 일치하지 않았습니다.
- Pro 카드 CTA의 강조 색상과 카드별 액션 구현이 분산돼 있어 시각적 일관성과 유지보수성을 개선할 필요가 있었습니다.

## 관련 이슈

- Closes #106

## 검증 결과

- `npm run lint` 통과
- `npm test` 통과 (4개 파일, 16개 테스트)
- `npm run build` 통과
- `/pricing` 로컬 스모크 테스트 통과 (HTTP 200)
- `npm run test:e2e`는 실행 환경에 `libnspr4.so`가 없어 Chromium을 시작하지 못해 미통과했습니다. 애플리케이션 시나리오 자체는 실행되지 않았습니다.

## 기타 참고사항

- 로컬 Chromium 의존성이 없어 UI 스크린샷은 첨부하지 못했습니다.