### PR TITLE
#102 / refactor(trash) : 휴지통 행 매핑과 선택 상태 분리

### DIFF
--- a/src/features/trash/hooks/useTrashItemsQuery.ts
+++ b/src/features/trash/hooks/useTrashItemsQuery.ts
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMemo } from "react";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { fetchTrashItems } from "@/features/trash/api/trashApi";
 import { TRASH_QUERY_KEYS } from "@/features/trash/service/trashQueryCache";
@@ -27,6 +28,13 @@ export const useTrashItemsQuery = () => {
       lastPage.hasNextPage ? lastPage.nextCursor : undefined,
     placeholderData: (previousData) => previousData,
   });
+  const items = useMemo(
+    () =>
+      isAuthenticated
+        ? (trashItemsQuery.data?.pages.flatMap((page) => page.items) ?? [])
+        : [],
+    [isAuthenticated, trashItemsQuery.data],
+  );
 
   return {
     fetchNextPage: trashItemsQuery.fetchNextPage,
@@ -34,9 +42,7 @@ export const useTrashItemsQuery = () => {
     isError: trashItemsQuery.isError,
     isFetchingNextPage: trashItemsQuery.isFetchingNextPage,
     isLoading: isAuthenticated && trashItemsQuery.isPending,
-    items: isAuthenticated
-      ? (trashItemsQuery.data?.pages.flatMap((page) => page.items) ?? [])
-      : [],
+    items,
     refetch: trashItemsQuery.refetch,
   };
 };

--- a/src/features/trash/hooks/useTrashPage.ts
+++ b/src/features/trash/hooks/useTrashPage.ts
@@ -1,11 +1,17 @@
 "use client";
 
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
+import { useTranslations } from "next-intl";
 import { useTrashActions } from "@/features/trash/hooks/useTrashActions";
 import { useTrashItemsQuery } from "@/features/trash/hooks/useTrashItemsQuery";
+import type { TrashFolderReference } from "@/features/trash/service/trashRowMapper";
+import {
+  createTrashFolderNameById,
+  mapTrashItemsToRows,
+} from "@/features/trash/service/trashRowMapper";
 
 interface UseTrashPageOptions {
-  activeFolders: Array<{ id: string; name: string }>;
+  activeFolders: TrashFolderReference[];
   onItemsChanged?: () => void | Promise<void>;
 }
 
@@ -14,10 +20,36 @@ export const useTrashPage = ({
   activeFolders,
   onItemsChanged,
 }: UseTrashPageOptions) => {
+  const t = useTranslations("trash");
   const query = useTrashItemsQuery();
   const trashActions = useTrashActions({ onItemsChanged });
   const { refetch } = query;
   const { clearError, error: actionError, ...actions } = trashActions;
+  const labels = useMemo(
+    () => ({
+      folderType: t("folderType"),
+      fileType: t("fileType"),
+      unknownParentFolder: t("unknownParentFolder"),
+      clipTypes: {
+        TEXT: t("clipKinds.text"),
+        COLOR: t("clipKinds.color"),
+        IMAGE: t("clipKinds.image"),
+      },
+    }),
+    [t],
+  );
+  const folderNameById = useMemo(
+    () => createTrashFolderNameById(activeFolders, query.items),
+    [activeFolders, query.items],
+  );
+  const rows = useMemo(
+    () =>
+      mapTrashItemsToRows(query.items, {
+        folderNameById,
+        labels,
+      }),
+    [folderNameById, labels, query.items],
+  );
 
   const reload = useCallback(async () => {
     clearError();
@@ -29,16 +61,13 @@ export const useTrashPage = ({
       ...actions,
       reload,
     },
-    context: {
-      activeFolders,
-    },
     results: {
       error: actionError ?? (query.isError ? "load" : null),
       fetchNextPage: query.fetchNextPage,
       hasNextPage: query.hasNextPage,
       isFetchingNextPage: query.isFetchingNextPage,
       isLoading: query.isLoading,
-      items: query.items,
+      rows,
     },
   };
 };

--- a/src/features/trash/hooks/useTrashSelection.ts
+++ b/src/features/trash/hooks/useTrashSelection.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import {
+  getTrashRowKey,
+  type TrashItemRow,
+} from "@/features/trash/model/trashRow";
+import {
+  getSelectedTrashRows,
+  mapTrashRowsToMutationItems,
+  reconcileTrashRowSelection,
+  toggleAllTrashRowSelection,
+  toggleTrashRowSelection,
+} from "@/features/trash/service/trashSelection";
+
+// 휴지통 행 선택과 선택 항목의 bulk 요청 payload 생성을 관리합니다.
+export const useTrashSelection = (rows: readonly TrashItemRow[]) => {
+  const [storedSelectedRowKeys, setStoredSelectedRowKeys] = useState<
+    Set<string>
+  >(
+    () => new Set(),
+  );
+
+  const selectedRows = useMemo(
+    () => getSelectedTrashRows(rows, storedSelectedRowKeys),
+    [rows, storedSelectedRowKeys],
+  );
+  const selectedRowKeys = useMemo(
+    () => new Set(selectedRows.map(getTrashRowKey)),
+    [selectedRows],
+  );
+  const selectedItems = useMemo(
+    () => mapTrashRowsToMutationItems(selectedRows),
+    [selectedRows],
+  );
+  const toggleRow = useCallback((row: TrashItemRow) => {
+    setStoredSelectedRowKeys((currentKeys) =>
+      toggleTrashRowSelection(
+        reconcileTrashRowSelection(currentKeys, rows),
+        row,
+      ),
+    );
+  }, [rows]);
+  const toggleAllRows = useCallback(() => {
+    setStoredSelectedRowKeys((currentKeys) =>
+      toggleAllTrashRowSelection(
+        reconcileTrashRowSelection(currentKeys, rows),
+        rows,
+      ),
+    );
+  }, [rows]);
+  const clearSelection = useCallback(
+    () => setStoredSelectedRowKeys(new Set()),
+    [],
+  );
+
+  return {
+    clearSelection,
+    selectedItems,
+    selectedRowKeys,
+    selectedRows,
+    toggleAllRows,
+    toggleRow,
+  };
+};

--- a/src/features/trash/model/trashRow.ts
+++ b/src/features/trash/model/trashRow.ts
@@ -1,0 +1,27 @@
+import type { TrashItemResponseDto } from "@/features/trash/model/trash.dto";
+
+export type TrashClipType = Extract<
+  TrashItemResponseDto,
+  { itemType: "CLIP" }
+>["type"];
+
+export type TrashItemRow =
+  | {
+      kind: "folder";
+      id: string;
+      name: string;
+      deletedAt: string | null;
+      typeLabel: string;
+    }
+  | {
+      kind: "clip";
+      id: string;
+      name: string;
+      deletedAt: string | null;
+      typeLabel: string;
+      clipType: TrashClipType;
+      parentFolderName: string;
+    };
+
+export const getTrashRowKey = (row: TrashItemRow) =>
+  `${row.kind}-${row.id}`;

--- a/src/features/trash/service/trashRowMapper.test.ts
+++ b/src/features/trash/service/trashRowMapper.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { TrashItemResponseDto } from "@/features/trash/model/trash.dto";
+import {
+  createTrashFolderNameById,
+  mapTrashItemsToRows,
+} from "@/features/trash/service/trashRowMapper";
+
+const labels = {
+  folderType: "폴더",
+  fileType: "파일",
+  unknownParentFolder: "알 수 없는 상위 폴더",
+  clipTypes: {
+    TEXT: "텍스트",
+    COLOR: "색상",
+    IMAGE: "이미지",
+  },
+};
+
+const items: TrashItemResponseDto[] = [
+  {
+    itemType: "FOLDER",
+    id: "folder-deleted",
+    name: "삭제된 폴더",
+    deletedAt: "2026-08-18T00:00:00.000Z",
+  },
+  {
+    itemType: "CLIP",
+    id: "clip-in-deleted-folder",
+    title: "폴더에 포함된 클립",
+    type: "TEXT",
+    folderId: "folder-deleted",
+    deletedAt: "2026-08-18T00:00:00.000Z",
+  },
+  {
+    itemType: "CLIP",
+    id: "clip-in-active-folder",
+    title: "활성 폴더 클립",
+    type: "COLOR",
+    folderId: "folder-active",
+    deletedAt: "2026-08-18T00:00:00.000Z",
+  },
+  {
+    itemType: "CLIP",
+    id: "clip-without-parent",
+    title: "상위 폴더를 찾을 수 없는 클립",
+    type: "IMAGE",
+    folderId: "folder-missing",
+    deletedAt: null,
+  },
+];
+
+describe("trashRowMapper", () => {
+  it("활성 폴더와 휴지통 폴더의 이름을 명시적인 맵으로 결합한다", () => {
+    const folderNameById = createTrashFolderNameById(
+      [{ id: "folder-active", name: "활성 폴더" }],
+      items,
+    );
+
+    expect([...folderNameById]).toEqual([
+      ["folder-active", "활성 폴더"],
+      ["folder-deleted", "삭제된 폴더"],
+    ]);
+  });
+
+  it("삭제된 폴더에 포함된 클립은 제외하고 나머지 DTO를 화면 행으로 변환한다", () => {
+    const folderNameById = createTrashFolderNameById(
+      [{ id: "folder-active", name: "활성 폴더" }],
+      items,
+    );
+
+    expect(mapTrashItemsToRows(items, { folderNameById, labels })).toEqual([
+      {
+        kind: "folder",
+        id: "folder-deleted",
+        name: "삭제된 폴더",
+        deletedAt: "2026-08-18T00:00:00.000Z",
+        typeLabel: "폴더",
+      },
+      {
+        kind: "clip",
+        id: "clip-in-active-folder",
+        name: "활성 폴더 클립",
+        deletedAt: "2026-08-18T00:00:00.000Z",
+        typeLabel: "파일 · 색상",
+        clipType: "COLOR",
+        parentFolderName: "활성 폴더",
+      },
+      {
+        kind: "clip",
+        id: "clip-without-parent",
+        name: "상위 폴더를 찾을 수 없는 클립",
+        deletedAt: null,
+        typeLabel: "파일 · 이미지",
+        clipType: "IMAGE",
+        parentFolderName: "알 수 없는 상위 폴더",
+      },
+    ]);
+  });
+});

--- a/src/features/trash/service/trashRowMapper.ts
+++ b/src/features/trash/service/trashRowMapper.ts
@@ -1,0 +1,83 @@
+import type {
+  TrashClipType,
+  TrashItemRow,
+} from "@/features/trash/model/trashRow";
+import type { TrashItemResponseDto } from "@/features/trash/model/trash.dto";
+
+export interface TrashFolderReference {
+  id: string;
+  name: string;
+}
+
+export interface TrashRowLabels {
+  folderType: string;
+  fileType: string;
+  unknownParentFolder: string;
+  clipTypes: Record<TrashClipType, string>;
+}
+
+interface MapTrashItemsToRowsOptions {
+  folderNameById: ReadonlyMap<string, string>;
+  labels: TrashRowLabels;
+}
+
+// 활성 폴더와 현재 조회된 휴지통 폴더를 하나의 부모 폴더 이름 맵으로 결합합니다.
+export const createTrashFolderNameById = (
+  activeFolders: readonly TrashFolderReference[],
+  items: readonly TrashItemResponseDto[],
+) => {
+  const folderNameById = new Map(
+    activeFolders.map((folder) => [folder.id, folder.name] as const),
+  );
+
+  items.forEach((item) => {
+    if (item.itemType === "FOLDER") {
+      folderNameById.set(item.id, item.name);
+    }
+  });
+
+  return folderNameById;
+};
+
+// 휴지통 DTO를 화면 행으로 변환하고, 삭제된 부모 폴더에 포함된 클립의 중복 표시는 제외합니다.
+export const mapTrashItemsToRows = (
+  items: readonly TrashItemResponseDto[],
+  { folderNameById, labels }: MapTrashItemsToRowsOptions,
+): TrashItemRow[] => {
+  const deletedFolderIds = new Set(
+    items
+      .filter((item) => item.itemType === "FOLDER")
+      .map((folder) => folder.id),
+  );
+  const rows: TrashItemRow[] = [];
+
+  items.forEach((item) => {
+    if (item.itemType === "FOLDER") {
+      rows.push({
+        kind: "folder",
+        id: item.id,
+        name: item.name,
+        deletedAt: item.deletedAt,
+        typeLabel: labels.folderType,
+      });
+      return;
+    }
+
+    if (deletedFolderIds.has(item.folderId)) {
+      return;
+    }
+
+    rows.push({
+      kind: "clip",
+      id: item.id,
+      name: item.title,
+      deletedAt: item.deletedAt,
+      typeLabel: `${labels.fileType} · ${labels.clipTypes[item.type]}`,
+      clipType: item.type,
+      parentFolderName:
+        folderNameById.get(item.folderId) ?? labels.unknownParentFolder,
+    });
+  });
+
+  return rows;
+};

--- a/src/features/trash/service/trashSelection.test.ts
+++ b/src/features/trash/service/trashSelection.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { TrashItemRow } from "@/features/trash/model/trashRow";
+import {
+  getSelectedTrashRows,
+  mapTrashRowsToMutationItems,
+  reconcileTrashRowSelection,
+  toggleAllTrashRowSelection,
+  toggleTrashRowSelection,
+} from "@/features/trash/service/trashSelection";
+
+const rows: TrashItemRow[] = [
+  {
+    kind: "folder",
+    id: "folder-1",
+    name: "프로젝트",
+    deletedAt: null,
+    typeLabel: "폴더",
+  },
+  {
+    kind: "clip",
+    id: "clip-1",
+    name: "메모",
+    deletedAt: null,
+    typeLabel: "파일 · 텍스트",
+    clipType: "TEXT",
+    parentFolderName: "프로젝트",
+  },
+];
+
+describe("trashSelection", () => {
+  it("행을 토글할 때 기존 선택을 변경하지 않고 새 선택 집합을 반환한다", () => {
+    const selectedRowKeys = new Set(["folder-folder-1"]);
+
+    const nextKeys = toggleTrashRowSelection(selectedRowKeys, rows[1]);
+
+    expect([...selectedRowKeys]).toEqual(["folder-folder-1"]);
+    expect([...nextKeys]).toEqual(["folder-folder-1", "clip-clip-1"]);
+  });
+
+  it("전체 선택과 전체 선택 해제를 전환한다", () => {
+    const allSelected = toggleAllTrashRowSelection(new Set(), rows);
+
+    expect([...allSelected]).toEqual(["folder-folder-1", "clip-clip-1"]);
+    expect(toggleAllTrashRowSelection(allSelected, rows)).toEqual(new Set());
+  });
+
+  it("목록에서 사라진 선택 키만 정리한다", () => {
+    const selectedRowKeys = new Set(["folder-folder-1", "clip-removed"]);
+
+    expect(reconcileTrashRowSelection(selectedRowKeys, rows)).toEqual(
+      new Set(["folder-folder-1"]),
+    );
+    expect(reconcileTrashRowSelection(new Set(["clip-clip-1"]), rows)).toEqual(
+      new Set(["clip-clip-1"]),
+    );
+  });
+
+  it("선택 행을 목록 순서로 복원·영구 삭제 API payload로 변환한다", () => {
+    const selectedRows = getSelectedTrashRows(
+      rows,
+      new Set(["clip-clip-1", "folder-folder-1"]),
+    );
+
+    expect(mapTrashRowsToMutationItems(selectedRows)).toEqual([
+      { itemType: "FOLDER", id: "folder-1" },
+      { itemType: "CLIP", id: "clip-1" },
+    ]);
+  });
+});

--- a/src/features/trash/service/trashSelection.ts
+++ b/src/features/trash/service/trashSelection.ts
@@ -1,0 +1,59 @@
+import {
+  getTrashRowKey,
+  type TrashItemRow,
+} from "@/features/trash/model/trashRow";
+import type { TrashItemMutationDto } from "@/features/trash/model/trash.dto";
+
+export const getSelectedTrashRows = (
+  rows: readonly TrashItemRow[],
+  selectedRowKeys: ReadonlySet<string>,
+) => rows.filter((row) => selectedRowKeys.has(getTrashRowKey(row)));
+
+export const toggleTrashRowSelection = (
+  selectedRowKeys: ReadonlySet<string>,
+  row: TrashItemRow,
+) => {
+  const nextKeys = new Set(selectedRowKeys);
+  const key = getTrashRowKey(row);
+
+  if (nextKeys.has(key)) {
+    nextKeys.delete(key);
+  } else {
+    nextKeys.add(key);
+  }
+
+  return nextKeys;
+};
+
+export const toggleAllTrashRowSelection = (
+  selectedRowKeys: ReadonlySet<string>,
+  rows: readonly TrashItemRow[],
+) => {
+  const areAllRowsSelected =
+    rows.length > 0 &&
+    rows.every((row) => selectedRowKeys.has(getTrashRowKey(row)));
+
+  return areAllRowsSelected
+    ? new Set<string>()
+    : new Set(rows.map(getTrashRowKey));
+};
+
+export const reconcileTrashRowSelection = (
+  selectedRowKeys: Set<string>,
+  rows: readonly TrashItemRow[],
+) => {
+  const availableRowKeys = new Set(rows.map(getTrashRowKey));
+  const nextKeys = new Set(
+    [...selectedRowKeys].filter((key) => availableRowKeys.has(key)),
+  );
+
+  return nextKeys.size === selectedRowKeys.size ? selectedRowKeys : nextKeys;
+};
+
+export const mapTrashRowsToMutationItems = (
+  rows: readonly TrashItemRow[],
+): TrashItemMutationDto[] =>
+  rows.map((row) => ({
+    itemType: row.kind === "clip" ? "CLIP" : "FOLDER",
+    id: row.id,
+  }));

--- a/src/features/trash/ui/TrashListRow.tsx
+++ b/src/features/trash/ui/TrashListRow.tsx
@@ -9,8 +9,8 @@ import {
 } from "react-icons/hi";
 import {
   formatDeletedAt,
-  type TrashItemRow,
 } from "@/features/trash/ui/trashRow";
+import type { TrashItemRow } from "@/features/trash/model/trashRow";
 import { Badge } from "@/shared/ui/badge/Badge";
 import { Button } from "@/shared/ui/button/Button";
 import { Checkbox } from "@/shared/ui/input/Checkbox";

--- a/src/features/trash/ui/TrashListSection.tsx
+++ b/src/features/trash/ui/TrashListSection.tsx
@@ -3,8 +3,11 @@
 import { useEffect, useRef } from "react";
 import { useTranslations } from "next-intl";
 import { useInView } from "react-intersection-observer";
+import {
+  getTrashRowKey,
+  type TrashItemRow,
+} from "@/features/trash/model/trashRow";
 import { TrashListRow } from "@/features/trash/ui/TrashListRow";
-import type { TrashItemRow } from "@/features/trash/ui/trashRow";
 import { Checkbox } from "@/shared/ui/input/Checkbox";
 
 const SKELETON_ROWS = Array.from({ length: 6 }, (_, index) => index);
@@ -48,7 +51,7 @@ export function TrashListSection({
   });
   const allRowsSelected =
     rows.length > 0 &&
-    rows.every((row) => selectedRowKeys.has(`${row.kind}-${row.id}`));
+    rows.every((row) => selectedRowKeys.has(getTrashRowKey(row)));
 
   useEffect(() => {
     if (!inView) {
@@ -99,9 +102,9 @@ export function TrashListSection({
           ? SKELETON_ROWS.map((row) => <TrashListSkeletonRow key={row} />)
           : rows.map((row) => (
               <TrashListRow
-                key={`${row.kind}-${row.id}`}
+                key={getTrashRowKey(row)}
                 row={row}
-                isSelected={selectedRowKeys.has(`${row.kind}-${row.id}`)}
+                isSelected={selectedRowKeys.has(getTrashRowKey(row))}
                 pendingActionKey={pendingActionKey}
                 onToggleSelected={onToggleRow}
                 onRestoreFolder={onRestoreFolder}

--- a/src/features/trash/ui/TrashPage.tsx
+++ b/src/features/trash/ui/TrashPage.tsx
@@ -3,30 +3,16 @@
 import { useState } from "react";
 import { useTranslations } from "next-intl";
 import { useTrashPage } from "@/features/trash/hooks/useTrashPage";
+import { useTrashSelection } from "@/features/trash/hooks/useTrashSelection";
 import { TrashListSection } from "@/features/trash/ui/TrashListSection";
 import { TrashPageEmptyState } from "@/features/trash/ui/TrashPageEmptyState";
 import { TrashPageHeader } from "@/features/trash/ui/TrashPageHeader";
-import type { TrashItemRow } from "@/features/trash/ui/trashRow";
+import type { TrashFolderReference } from "@/features/trash/service/trashRowMapper";
 import { ConfirmActionModal } from "@/shared/ui/overlay/ConfirmActionModal";
-
-const getClipTypeLabel = (
-  clipType: "TEXT" | "COLOR" | "IMAGE",
-  t: ReturnType<typeof useTranslations<"trash">>,
-) => {
-  if (clipType === "TEXT") {
-    return t("clipKinds.text");
-  }
-
-  if (clipType === "COLOR") {
-    return t("clipKinds.color");
-  }
-
-  return t("clipKinds.image");
-};
 
 // 휴지통 페이지의 상태에 따라 안내, 빈 상태, 리스트 섹션을 조합하는 루트 컴포넌트입니다.
 interface TrashPageProps {
-  activeFolders: Array<{ id: string; name: string }>;
+  activeFolders: TrashFolderReference[];
   onItemsChanged?: () => void | Promise<void>;
 }
 
@@ -35,61 +21,25 @@ export function TrashPage({ activeFolders, onItemsChanged }: TrashPageProps) {
   const [deleteModal, setDeleteModal] = useState<
     "clearAll" | "selected" | null
   >(null);
-  const [selectedRowKeys, setSelectedRowKeys] = useState<Set<string>>(
-    () => new Set(),
-  );
-  const { actions, context, results } = useTrashPage({
+  const { actions, results } = useTrashPage({
     activeFolders,
     onItemsChanged,
   });
-  const { items } = results;
-  const deletedFolderIds = new Set(
-    items
-      .filter((item) => item.itemType === "FOLDER")
-      .map((folder) => folder.id),
-  );
-  const folderNameById = new Map([
-    ...context.activeFolders.map((folder) => [folder.id, folder.name] as const),
-    ...items
-      .filter((item) => item.itemType === "FOLDER")
-      .map((folder) => [folder.id, folder.name] as const),
-  ]);
-
-  const rows: TrashItemRow[] = items
-    .filter(
-      (item) =>
-        item.itemType === "FOLDER" || !deletedFolderIds.has(item.folderId),
-    )
-    .map((item) => {
-      if (item.itemType === "FOLDER") {
-        return {
-          kind: "folder",
-          id: item.id,
-          name: item.name,
-          deletedAt: item.deletedAt,
-          typeLabel: t("folderType"),
-        };
-      }
-
-      return {
-        kind: "clip",
-        id: item.id,
-        name: item.title,
-        deletedAt: item.deletedAt,
-        typeLabel: `${t("fileType")} · ${getClipTypeLabel(item.type, t)}`,
-        clipType: item.type,
-        parentFolderName:
-          folderNameById.get(item.folderId) ?? t("unknownParentFolder"),
-      };
-    });
+  const { rows } = results;
+  const {
+    clearSelection,
+    selectedItems,
+    selectedRowKeys,
+    selectedRows,
+    toggleAllRows,
+    toggleRow,
+  } = useTrashSelection(rows);
   const isClearingAll = actions.pendingActionKey === "trash-clear-all";
   const isRestoringSelected =
     actions.pendingActionKey === "trash-restore-selected";
   const isDeletingSelected =
     actions.pendingActionKey === "trash-delete-selected";
   const isActionPending = actions.pendingActionKey !== null;
-  const rowKey = (row: TrashItemRow) => `${row.kind}-${row.id}`;
-  const selectedRows = rows.filter((row) => selectedRowKeys.has(rowKey(row)));
   const hasRows = rows.length > 0;
   const errorMessage =
     results.error === "restoreConflict"
@@ -98,65 +48,27 @@ export function TrashPage({ activeFolders, onItemsChanged }: TrashPageProps) {
         ? t("actionError")
         : t("error");
 
-  const handleToggleRow = (row: TrashItemRow) => {
-    setSelectedRowKeys((currentKeys) => {
-      const nextKeys = new Set(currentKeys);
-      const key = rowKey(row);
-
-      if (nextKeys.has(key)) {
-        nextKeys.delete(key);
-      } else {
-        nextKeys.add(key);
-      }
-
-      return nextKeys;
-    });
-  };
-
-  const handleToggleAllRows = () => {
-    setSelectedRowKeys((currentKeys) => {
-      const areAllRowsSelected =
-        rows.length > 0 && rows.every((row) => currentKeys.has(rowKey(row)));
-
-      if (areAllRowsSelected) {
-        return new Set();
-      }
-
-      return new Set(rows.map(rowKey));
-    });
-  };
-
   const handleDeleteSelected = async () => {
-    if (selectedRows.length === 0) {
+    if (selectedItems.length === 0) {
       return;
     }
 
-    const isDeleted = await actions.deleteItems(
-      selectedRows.map((row) => ({
-        itemType: row.kind === "clip" ? "CLIP" : "FOLDER",
-        id: row.id,
-      })),
-    );
+    const isDeleted = await actions.deleteItems(selectedItems);
 
     if (isDeleted) {
-      setSelectedRowKeys(new Set());
+      clearSelection();
     }
   };
 
   const handleRestoreSelected = async () => {
-    if (selectedRows.length === 0) {
+    if (selectedItems.length === 0) {
       return;
     }
 
-    const isRestored = await actions.restoreItems(
-      selectedRows.map((row) => ({
-        itemType: row.kind === "clip" ? "CLIP" : "FOLDER",
-        id: row.id,
-      })),
-    );
+    const isRestored = await actions.restoreItems(selectedItems);
 
     if (isRestored) {
-      setSelectedRowKeys(new Set());
+      clearSelection();
     }
   };
 
@@ -204,8 +116,8 @@ export function TrashPage({ activeFolders, onItemsChanged }: TrashPageProps) {
           onFetchNextPage={() => {
             void results.fetchNextPage();
           }}
-          onToggleRow={handleToggleRow}
-          onToggleAllRows={handleToggleAllRows}
+          onToggleRow={toggleRow}
+          onToggleAllRows={toggleAllRows}
           onRestoreFolder={(folderId) => {
             void actions.restoreFolder(folderId);
           }}

--- a/src/features/trash/ui/trashRow.ts
+++ b/src/features/trash/ui/trashRow.ts
@@ -1,21 +1,3 @@
-export type TrashItemRow =
-  | {
-      kind: "folder";
-      id: string;
-      name: string;
-      deletedAt: string | null;
-      typeLabel: string;
-    }
-  | {
-      kind: "clip";
-      id: string;
-      name: string;
-      deletedAt: string | null;
-      typeLabel: string;
-      clipType: "TEXT" | "COLOR" | "IMAGE";
-      parentFolderName: string;
-    };
-
 export const formatDeletedAt = (deletedAt: string | null) => {
   if (!deletedAt) {
     return "-";


### PR DESCRIPTION
## PR 요약

- 휴지통 행 변환과 선택 상태를 화면 컴포넌트에서 분리해 책임과 테스트 가능성을 높였습니다.

## 변경 내용 상세

### 변경 사항

- 휴지통 DTO를 화면 행으로 변환하는 순수 mapper와 부모 폴더 이름 맵을 service로 분리했습니다.
- 선택 토글, 전체 선택, 유효하지 않은 선택 키 정리, bulk 요청 payload 변환을 선택 상태 hook과 service로 분리했습니다.
- 선택 복원·영구 삭제 성공 시 선택을 초기화하도록 연결했습니다.
- 행 변환과 선택 로직의 Vitest 단위 테스트를 추가했습니다.

### 변경 이유

- TrashPage에 섞여 있던 화면 행 변환과 선택 상태 책임을 분리해 유지보수성과 검증 가능성을 개선합니다.

## 관련 이슈

- Closes #102

## 검증 결과

- npm run test -- src/features/trash/service/trashRowMapper.test.ts src/features/trash/service/trashSelection.test.ts
- npm run lint
- npm run build

## 기타 참고사항

- 화면 외관 변경 없이 내부 책임을 분리한 리팩터링입니다.